### PR TITLE
Update ⊗ to matmul to reflect an API change.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ import TensorFlow
 var x = Tensor<Float>([[1, 2], [3, 4]])
 
 for i in 1...5 {
-    x += x ⊗ x
+    x += matmul(x, x)
 }
 
 print(x)


### PR DESCRIPTION
Operator `⊗` and `Tensor.dot` are deprecated. `matmul` is the API for matrix multiplication from now on.