### PR TITLE
Use bullet operator • for matrix multiplication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ import TensorFlow
 var x = Tensor<Float>([[1, 2], [3, 4]])
 
 for i in 1...5 {
-    x += matmul(x, x)
+    x += x • x
 }
 
 print(x)


### PR DESCRIPTION
To be merged when https://github.com/apple/swift/pull/17173 is in and a new toolchain is built.

*Note:* On macOS, this can be easily typed with ⌥8.