### PR TITLE
Start related projects section in README, remove jupyter subdirectory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ as part of being considered for being pulled into master.
 You can find example models in
 [tensorflow/swift-models](https://github.com/tensorflow/swift-models).
 
+## Related Projects
+
+### Jupyter Notebook support
+
+[Jupyter Notebook](http://jupyter.org/) support for Swift for TensorFlow is under development at
+[google/swift-jupyter](https://github.com/google/swift-jupyter).
+
 ## Community
 
 Discussion about Swift for TensorFlow happens on the

--- a/jupyter/README.md
+++ b/jupyter/README.md
@@ -1,1 +1,0 @@
-The Jupyter kernel has been moved to https://github.com/google/swift-jupyter.


### PR DESCRIPTION
The `jupyter` subdirectory is a bit misleading because it's essentially empty.
Instead, it may be better to start a related projects section in the README.

On the other hand, the README is getting quite bloated.
I'm not sure what the best decision is.