### PR TITLE
Add steps for building executables in Xcode

### DIFF
--- a/Usage.md
+++ b/Usage.md
@@ -141,3 +141,15 @@ print(x)
 </p>
 
 **Note:** Xcode Playgrounds are a great interactive environment for prototyping code, but they often hang or crash. If that happens, try restarting Xcode. There are some documented bugs regarding Swift for TensorFlow and Playgrounds. If you discover a new bug, please file an issue.
+
+To build an executable with Xcode 10, you must change some project settings from their default values:
+
+1. In the menu bar, select `File > Project Settings...`.
+
+2. Then, select `Legacy Build System` for Build Settings and click `Done`.
+
+3. In your target's Build Settings:
+  * Go to `Swift Compiler > Code Generation > Optimization Level` and select `Optimize for Speed [-O]`.
+  * Add `libtensorflow.so` and `libtensorflow_framework.so` to `Linked Frameworks and Libraries` and change `Runtime Search Paths`.
+    See [this comment](https://github.com/tensorflow/swift/issues/10#issuecomment-385167803) for specific instructions with screenshots.
+  * Go to `Linking > Other Linker Flags` and add `-lpython` to the list of flags.


### PR DESCRIPTION
Previous doc only contained instructions for running in an Xcode playground. This was not sufficient to get code to compile and link.