### PR TITLE
add libcurl3 to ubuntu installation deps

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -149,7 +149,7 @@ Note that nothing prevents Swift from being ported to other Linux distributions 
 1. Install required dependencies:
 
 ```
-$ sudo apt-get install clang libicu-dev libpython-dev libncurses5-dev
+$ sudo apt-get install clang libcurl3 libicu-dev libpython-dev libncurses5-dev
 ```
 
 2. Download the latest binary release above.


### PR DESCRIPTION
As discovered in https://github.com/tensorflow/swift-tutorials/issues/2, Foundation requires libcurl3 at runtime.