### PR TITLE
Updating installation instructions to point to latest builds.

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -10,7 +10,7 @@ To install Swift for TensorFlow, download one of the packages below and follow t
 
 Packages will be released nightly after automated building is set up.
 
-| Download | Date [(last commit)](https://github.com/apple/swift/commit/280486afdc0c940af345c614a80826fcc8326abc) |
+| Download | Date |
 |----------|------|
 | [Xcode 10](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2019-01-04-a-osx.pkg) | January 04, 2019 |
 | [ubuntu 18.04 (Cuda 10.0)](https://storage.googleapis.com/s4tf-kokoro-artifact-testing/latest/swift-tensorflow-DEVELOPMENT-cuda10.0-cudnn7-ubuntu18.04.tar.gz) | Nightly Build |

--- a/Installation.md
+++ b/Installation.md
@@ -163,13 +163,21 @@ Note that nothing prevents Swift from being ported to other Linux distributions 
 
 * Ubuntu 18.04 (64-bit)
 
+### Additional Requirements
+
+* For GPU toolchains:
+  * CUDA Toolkit 9.2 or 10.0 
+  * CuDNN 7.1
+  * An NVIDIA GPU with compute compatibility 3.5, 6.1 or 7.0
+
 ### Installation
 
 1. Install required dependencies:
 
 ```
-$ sudo apt-get install clang libcurl3 libicu-dev libpython-dev libncurses5-dev libxml2
+$ sudo apt-get install clang libpython-dev libblocksruntime-dev
 ```
+(**Note:** You _may_ also need to install other [dependencies](https://github.com/apple/swift#linux), if you are unable to run `swift` or other tools below.)
 
 2. Download the latest binary release above.
 

--- a/Installation.md
+++ b/Installation.md
@@ -13,8 +13,8 @@ Packages will be released nightly after automated building is set up.
 | Download | Date [(last commit)](https://github.com/apple/swift/commit/280486afdc0c940af345c614a80826fcc8326abc) |
 |----------|------|
 | [Xcode 10](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2019-01-04-a-osx.pkg) | January 04, 2019 |
-| [Ubuntu 16.04](https://storage.googleapis.com/swift-tensorflow/ubuntu16.04/swift-tensorflow-DEVELOPMENT-2019-01-04-a-ubuntu16.04.tar.gz) | January 04, 2019 |
-
+| [ubuntu 18.04 (Cuda 10.0)](https://storage.googleapis.com/s4tf-kokoro-artifact-testing/latest/swift-tensorflow-DEVELOPMENT-cuda10.0-cudnn7-ubuntu18.04.tar.gz) | Nightly Build |
+| [ubuntu 18.04 (Cuda 9.2)](https://storage.googleapis.com/s4tf-kokoro-artifact-testing/latest/swift-tensorflow-DEVELOPMENT-cuda9.2-cudnn7-ubuntu18.04.tar.gz) | Nightly Build |
 <details>
   <summary>Older Packages</summary>
 
@@ -64,6 +64,7 @@ Xcode 10 is required.
 
 | Download |
 |----------|
+| [January 04, 2019](https://storage.googleapis.com/swift-tensorflow/ubuntu16.04/swift-tensorflow-DEVELOPMENT-2019-01-04-a-ubuntu16.04.tar.gz) |
 | [December 04, 2018](https://storage.googleapis.com/swift-tensorflow/ubuntu16.04/swift-tensorflow-DEVELOPMENT-2018-12-04-a-ubuntu16.04.tar.gz) |
 | [November 21, 2018](https://storage.googleapis.com/swift-tensorflow/ubuntu16.04/swift-tensorflow-DEVELOPMENT-2018-11-21-a-ubuntu16.04.tar.gz) |
 | [October 17, 2018](https://storage.googleapis.com/swift-tensorflow/ubuntu16.04/swift-tensorflow-DEVELOPMENT-2018-10-17-a-ubuntu16.04.tar.gz) |
@@ -156,11 +157,11 @@ Note that nothing prevents Swift from being ported to other Linux distributions 
 
 ### Requirements
 
-* Ubuntu 14.04 or 16.04 (64-bit)
+* Ubuntu 18.04 (64-bit)
 
 ### Supported Target Platforms
 
-* Ubuntu 14.04 or 16.04 (64-bit)
+* Ubuntu 18.04 (64-bit)
 
 ### Installation
 


### PR DESCRIPTION
Don't have a way to update the date of the build yet. We should perhaps have our automated builds updated this fie directly.

This also removes references to Ubuntu 14.04 and 16.04 for now. Once we have an automated builds, we should put them back. 

Also, this does not update the installation instructions. I will do so in a subsequent PR.
