### PR TITLE
Create docs/site with walkthrough tutorial

### DIFF
--- a/docs/site/_book.yaml
+++ b/docs/site/_book.yaml
@@ -1,0 +1,28 @@
+upper_tabs:
+# Tabs left of dropdown menu
+- include: /_upper_tabs_left.yaml
+- include: /api_docs/_upper_tabs_api.yaml
+# Dropdown menu
+- name: Resources
+  path: /resources
+  is_default: true
+  menu:
+  - include: /resources/_menu_toc.yaml
+  lower_tabs:
+    # Subsite tabs
+    other:
+    - name: Tutorials
+      contents:
+      - title: "Swift for TensorFlow: walkthrough"
+        path: /swift/tutorials/walkthrough
+    - name: API
+      skip_translation: true
+      contents:
+      - title: Overview
+        path: /swift/api_docs/
+      - title: View on GitHub
+        path: https://github.com/tensorflow/swift
+        status: external
+      - include: /swift/api_docs/_toc.yaml
+
+- include: /_upper_tabs_right.yaml

--- a/docs/site/_project.yaml
+++ b/docs/site/_project.yaml
@@ -1,0 +1,11 @@
+name: Swift for TensorFlow
+breadcrumb_name: Swift for TensorFlow
+home_url: /swift/
+parent_project_metadata_path: /_project.yaml
+description: >
+  Swift for TensorFlow gives you the power of TensorFlow directly integrated into
+  the Swift programming language.
+use_site_branding: true
+hide_from_products_list: true
+content_license: cc3-apache2
+buganizer_id: 330264

--- a/docs/site/tutorials/.gitignore
+++ b/docs/site/tutorials/.gitignore
@@ -1,0 +1,3 @@
+iris_training.csv
+iris_test.csv
+.ipynb_checkpoints/

--- a/docs/site/tutorials/README.md
+++ b/docs/site/tutorials/README.md
@@ -1,0 +1,14 @@
+# Swift Tutorials
+
+This repository contains Jupyter notebooks demonstrating TensorFlow in Swift.
+
+# How to run
+
+## Docker
+
+Follow the [Using the Docker Container](https://github.com/google/swift-jupyter#using-the-docker-container) instructions to launch swift-jupyter using the docker container, with the following modifications:
+
+* In the `docker build` command, add the flag `--build-arg swift_tf_url=https://storage.googleapis.com/s4tf-kokoro-artifact-testing/release/swift_for_tensorflow_release_2019-01-30_06-00-00_RC00/swift-tensorflow-DEVELOPMENT-ubuntu18.04.tar.gz`, to use a build that is known to work with the tutorial.
+* In the `docker run` command, use `-v /path/to/tutorial/repo/:/notebooks` to so that the Jupyter in the container can see the tutorials.
+
+Open Jupyter and navigate to the tutorial that you want to use.

--- a/docs/site/tutorials/TutorialDatasetCSVAPI.swift
+++ b/docs/site/tutorials/TutorialDatasetCSVAPI.swift
@@ -1,0 +1,56 @@
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// https://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+/// This file contains some special-case APIs that make parts of the tutorial
+/// work even though we do not have general APIs. Soon, we will have general
+/// APIs replacing this.
+
+/// Initialize a TensorPair<Tensor<Float>, Tensor<Int32>> dataset from a CSV file.
+extension Dataset where Element == TensorPair<Tensor<Float>, Tensor<Int32>> {
+  public init(contentsOfCSVFile: String, hasHeader: Bool,
+              featureColumns: [Int],
+              labelColumns: [Int]) {
+    // We can't make `np` a private top-level variable in this file, because
+    // this function is @inlinable.
+    let np = Python.import("numpy")
+
+    let featuresNp = np.loadtxt(contentsOfCSVFile, delimiter: ",",
+                                skiprows: hasHeader ? 1 : 0,
+                                usecols: featureColumns,
+                                dtype: Float.numpyScalarTypes.first!)
+    guard let featuresTensor = Tensor<Float>(numpy: featuresNp) else {
+      // This should never happen, because we construct numpy in such a
+      // way that it should be convertible to tensor.
+      fatalError("np.loadtxt result can't be converted to Tensor")
+    }
+
+    let labelsNp = np.loadtxt(contentsOfCSVFile, delimiter: ",",
+                              skiprows: hasHeader ? 1 : 0,
+                              usecols: labelColumns,
+                              dtype: Int32.numpyScalarTypes.first!)
+    guard let labelsTensor = Tensor<Int32>(numpy: labelsNp) else {
+      // This should never happen, because we construct numpy in such a
+      // way that it should be convertible to tensor.
+      fatalError("np.loadtxt result can't be converted to Tensor")
+    }
+
+    self.init(elements: TensorPair(featuresTensor, labelsTensor))
+  }
+}
+
+/// Sequence doesn't have a non-predicated `first` property, so we define one.
+/// TODO: Add this to Swift's stdlib.
+extension Sequence where Element == TensorPair<Tensor<Float>, Tensor<Int32>> {
+  var first: TensorPair<Tensor<Float>, Tensor<Int32>>? {
+      return first(where: {_ in true})
+  }
+}

--- a/docs/site/tutorials/TutorialModelHelpers.swift
+++ b/docs/site/tutorials/TutorialModelHelpers.swift
@@ -1,0 +1,34 @@
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// https://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+/// This file contains some APIs that are important for the tutorial that are
+/// missing from the standard library. Eventually, we will eliminate this file
+/// by extending the standard library.
+
+// TODO: Add this to the standard library? It's a pretty useful op for
+// classification problems.
+@inlinable
+@differentiable(wrt: logits, vjp: _vjpSoftmaxCrossEntropy)
+func softmaxCrossEntropy(logits: Tensor<Float>, categoricalLabels: Tensor<Int32>) -> Tensor<Float> {
+  return Raw.sparseSoftmaxCrossEntropyWithLogits(features: logits,
+                                                 labels: categoricalLabels).loss.mean()
+}
+
+@usableFromInline
+func _vjpSoftmaxCrossEntropy(logits: Tensor<Float>, categoricalLabels: Tensor<Int32>) -> (Tensor<Float>, (Tensor<Float>) -> Tensor<Float>) {
+  let (loss, grad) = Raw.sparseSoftmaxCrossEntropyWithLogits(features: logits,
+                                                             labels: categoricalLabels)
+  func pullback(seed: Tensor<Float>) -> Tensor<Float> {
+    return seed * grad
+  }
+  return (loss.mean(), pullback)
+}

--- a/docs/site/tutorials/walkthrough.ipynb
+++ b/docs/site/tutorials/walkthrough.ipynb
@@ -28,10 +28,10 @@
         "    <a target=\"_blank\" href=\"https://www.tensorflow.org/swift/tutorials/walkthrough\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
         "  </td>\n",
         "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/swift/tutorials/walkthrough.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/swift/blob/master/docs/site/tutorials/walkthrough.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
         "  </td>\n",
         "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/swift/tutorials/walkthrough.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/swift/blob/master/docs/site/tutorials/walkthrough.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
         "  </td>\n",
         "</table>"
       ]

--- a/docs/site/tutorials/walkthrough.ipynb
+++ b/docs/site/tutorials/walkthrough.ipynb
@@ -1,0 +1,1245 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "rwxGnsA92emp"
+   },
+   "source": [
+    "##### Copyright 2018 The TensorFlow Authors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "colab": {},
+    "colab_type": "code",
+    "id": "CPII1rGR2rF9",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "// Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "// you may not use this file except in compliance with the License.\n",
+    "// You may obtain a copy of the License at\n",
+    "//\n",
+    "// https://www.apache.org/licenses/LICENSE-2.0\n",
+    "//\n",
+    "// Unless required by applicable law or agreed to in writing, software\n",
+    "// distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "// See the License for the specific language governing permissions and\n",
+    "// limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "LrO3-gmDO0mH"
+   },
+   "source": [
+    "## Swift for TensorFlow is a work-in-progress\n",
+    "\n",
+    "Swift for TensorFlow is still a work-in-progress. If you modify the code in this tutorial, you will frequently get unexpected error messages and kernel crashes. Restarting the kernel might occasionally help (Kernel > Restart in the Jupyter toolbar).\n",
+    "\n",
+    "We are working on stabilizing the compiler. You can help us by filing bugs on https://bugs.swift.org (set the \"Component\" field to \"Swift for TensorFlow\") or by emailing the swift@tensorflow.org mailing list when you encounter unexpected error messages and kernel crashes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "JtEZ1pCPn--z"
+   },
+   "source": [
+    "# Swift for TensorFlow: walkthrough"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "LDrzLFXE8T1l"
+   },
+   "source": [
+    "This guide introduces Swift for TensorFlow by using Swift for TensorFlow to build a machine learning model that categorizes iris flowers by species. It uses Swift for TensorFlow to:\n",
+    "1. Build a model,\n",
+    "2. Train this model on example data, and\n",
+    "3. Use the model to make predictions about unknown data.\n",
+    "\n",
+    "This guide is a Swift port of the [TensorFlow custom training walkthrough](https://www.tensorflow.org/tutorials/eager/custom_training_walkthrough).\n",
+    "\n",
+    "## TensorFlow programming\n",
+    "\n",
+    "This guide uses these high-level Swift for TensorFlow concepts:\n",
+    "\n",
+    "* Import data with the Datasets API.\n",
+    "* Build models and layers using Swift abstractions.\n",
+    "* Use Python libraries using Swift's Python interoperability when pure Swift libraries are not available.\n",
+    "\n",
+    "This tutorial is structured like many TensorFlow programs:\n",
+    "\n",
+    "1. Import and parse the data sets.\n",
+    "2. Select the type of model.\n",
+    "3. Train the model.\n",
+    "4. Evaluate the model's effectiveness.\n",
+    "5. Use the trained model to make predictions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "yNr7H-AIoLOR"
+   },
+   "source": [
+    "## Setup program"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "1J3AuPBT9gyR"
+   },
+   "source": [
+    "### Configure imports\n",
+    "\n",
+    "Import TensorFlow and some useful Python modules."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 53
+    },
+    "colab_type": "code",
+    "id": "g4Wzg69bnwK2",
+    "outputId": "fa0c0a7c-7905-4aad-a9c1-996432c9e7e0",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import TensorFlow\n",
+    "\n",
+    "import Python\n",
+    "%include \"EnableIPythonDisplay.swift\"\n",
+    "IPythonDisplay.shell.enable_matplotlib(\"inline\")\n",
+    "let plt = Python.import(\"matplotlib.pyplot\")\n",
+    "\n",
+    "// Download some helper files that we will include later.\n",
+    "let path = Python.import(\"os.path\")\n",
+    "let urllib = Python.import(\"urllib.request\")\n",
+    "let helperFiles = [\"TutorialDatasetCSVAPI.swift\", \"TutorialModelHelpers.swift\"]\n",
+    "for helperFile in helperFiles {\n",
+    "  if !Bool(path.isfile(helperFile))! {\n",
+    "    print(\"Downloading \\(helperFile)\")\n",
+    "    urllib.urlretrieve(\n",
+    "        \"https://raw.githubusercontent.com/tensorflow/swift-tutorials/master/iris/\" + helperFile,\n",
+    "        filename: helperFile)\n",
+    "  } else {\n",
+    "    print(\"Not downloading \\(helperFile): already exists\")\n",
+    "  }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Zx7wc0LuuxaJ"
+   },
+   "source": [
+    "## The iris classification problem\n",
+    "\n",
+    "Imagine you are a botanist seeking an automated way to categorize each iris flower you find. Machine learning provides many algorithms to classify flowers statistically. For instance, a sophisticated machine learning program could classify flowers based on photographs. Our ambitions are more modest—we're going to classify iris flowers based on the length and width measurements of their [sepals](https://en.wikipedia.org/wiki/Sepal) and [petals](https://en.wikipedia.org/wiki/Petal).\n",
+    "\n",
+    "The Iris genus entails about 300 species, but our program will only classify the following three:\n",
+    "\n",
+    "* Iris setosa\n",
+    "* Iris virginica\n",
+    "* Iris versicolor\n",
+    "\n",
+    "<table>\n",
+    "  <tr><td>\n",
+    "    <img src=\"https://www.tensorflow.org/images/iris_three_species.jpg\"\n",
+    "         alt=\"Petal geometry compared for three iris species: Iris setosa, Iris virginica, and Iris versicolor\">\n",
+    "  </td></tr>\n",
+    "  <tr><td align=\"center\">\n",
+    "    <b>Figure 1.</b> <a href=\"https://commons.wikimedia.org/w/index.php?curid=170298\">Iris setosa</a> (by <a href=\"https://commons.wikimedia.org/wiki/User:Radomil\">Radomil</a>, CC BY-SA 3.0), <a href=\"https://commons.wikimedia.org/w/index.php?curid=248095\">Iris versicolor</a>, (by <a href=\"https://commons.wikimedia.org/wiki/User:Dlanglois\">Dlanglois</a>, CC BY-SA 3.0), and <a href=\"https://www.flickr.com/photos/33397993@N05/3352169862\">Iris virginica</a> (by <a href=\"https://www.flickr.com/photos/33397993@N05\">Frank Mayfield</a>, CC BY-SA 2.0).<br/>&nbsp;\n",
+    "  </td></tr>\n",
+    "</table>\n",
+    "\n",
+    "Fortunately, someone has already created a [data set of 120 iris flowers](https://en.wikipedia.org/wiki/Iris_flower_data_set) with the sepal and petal measurements. This is a classic dataset that is popular for beginner machine learning classification problems."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "3Px6KAg0Jowz"
+   },
+   "source": [
+    "## Import and parse the training dataset\n",
+    "\n",
+    "Download the dataset file and convert it into a structure that can be used by this Swift program.\n",
+    "\n",
+    "### Download the dataset\n",
+    "\n",
+    "Download the training dataset file from http://download.tensorflow.org/data/iris_training.csv. We use a Python library to demonstrate Swift's Python interoperability. Swift's Python interoperability makes it easy and natural to import and use Python libraries from Swift code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 35
+    },
+    "colab_type": "code",
+    "id": "DKkgac4WO0mP",
+    "outputId": "7066e07c-f142-4a79-92ca-2eedded056e1",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "let urllib = Python.import(\"urllib.request\")\n",
+    "let downloadResult = urllib.urlretrieve(\"http://download.tensorflow.org/data/iris_training.csv\",\n",
+    "                                        \"iris_training.csv\")\n",
+    "let trainDataFilename = String(downloadResult[0])!\n",
+    "trainDataFilename"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "qnX1-aLors4S"
+   },
+   "source": [
+    "### Inspect the data\n",
+    "\n",
+    "This dataset, `iris_training.csv`, is a plain text file that stores tabular data formatted as comma-separated values (CSV). Let's look a the first 5 entries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 125
+    },
+    "colab_type": "code",
+    "id": "FQvb_JYdrpPm",
+    "outputId": "d8ee7217-3baf-4c74-950c-cac858d0227e",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "let f = Python.open(trainDataFilename)\n",
+    "for _ in 0..<5 {\n",
+    "    print(Python.next(f).strip())\n",
+    "}\n",
+    "f.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "kQhzD6P-uBoq"
+   },
+   "source": [
+    "From this view of the dataset, notice the following:\n",
+    "\n",
+    "1. The first line is a header containing information about the dataset:\n",
+    "  * There are 120 total examples. Each example has four features and one of three possible label names. \n",
+    "2. Subsequent rows are data records, one *[example](https://developers.google.com/machine-learning/glossary/#example)* per line, where:\n",
+    "  * The first four fields are *[features](https://developers.google.com/machine-learning/glossary/#feature)*: these are characteristics of an example. Here, the fields hold float numbers representing flower measurements.\n",
+    "  * The last column is the *[label](https://developers.google.com/machine-learning/glossary/#label)*: this is the value we want to predict. For this dataset, it's an integer value of 0, 1, or 2 that corresponds to a flower name.\n",
+    "\n",
+    "Let's write that out in code:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 53
+    },
+    "colab_type": "code",
+    "id": "9Edhevw7exl6",
+    "outputId": "aba9b8b2-d9e7-4fca-b086-42d4732a7093",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "let featureNames = [\"sepal_length\", \"sepal_width\", \"petal_length\", \"petal_width\"]\n",
+    "let labelName = \"species\"\n",
+    "let columnNames = featureNames + [labelName]\n",
+    "\n",
+    "print(\"Features: \\(featureNames)\")\n",
+    "print(\"Label: \\(labelName)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "CCtwLoJhhDNc"
+   },
+   "source": [
+    "Each label is associated with string name (for example, \"setosa\"), but machine learning typically relies on numeric values. The label numbers are mapped to a named representation, such as:\n",
+    "\n",
+    "* `0`: Iris setosa\n",
+    "* `1`: Iris versicolor\n",
+    "* `2`: Iris virginica\n",
+    "\n",
+    "For more information about features and labels, see the [ML Terminology section of the Machine Learning Crash Course](https://developers.google.com/machine-learning/crash-course/framing/ml-terminology)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "sVNlJlUOhkoX",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "let classNames = [\"Iris setosa\", \"Iris versicolor\", \"Iris virginica\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "dqPkQExM2Pwt"
+   },
+   "source": [
+    "### Create a Dataset\n",
+    "\n",
+    "Swift for TensorFlow's Dataset API handles loading data into a model. This is a high-level API for reading data and transforming it into a form used for training. Currently, Swift's Dataset API supports loading data only from CSV files, but we intend to extend it to handle many more types of data, like [TensorFlow's Dataset API](https://www.tensorflow.org/guide/datasets).\n",
+    "\n",
+    "Use the `Dataset(contentsOfCSVFile:hasHeader:featureColumns:labelColumns:)` initializer to initialize a `Dataset` with training data. Also batch the data into batches using the `.batched()` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "bBx_C6UWO0mc",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "public let batchSize = Int64(32)\n",
+    "\n",
+    "%include \"TutorialDatasetCSVAPI.swift\"\n",
+    "\n",
+    "let trainDataset: Dataset<TensorPair<Tensor<Float>, Tensor<Int32>>> = Dataset(\n",
+    "    contentsOfCSVFile: trainDataFilename, hasHeader: true,\n",
+    "    featureColumns: [0, 1, 2, 3], labelColumns: [4]\n",
+    ").batched(batchSize)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "gB_RSn62c-3G"
+   },
+   "source": [
+    "This returns a `Dataset` of `(features, labels)` pairs, where `feature` is a `Tensor<Float>` with shape `(batchSize, featureColumns.count)` and where `labels` is a `Tensor<Int32>` with shape `(batchSize, labelColumns.count)`\n",
+    "\n",
+    "These `Dataset` values are iterable. Let's look at the first element of the dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 55
+    },
+    "colab_type": "code",
+    "id": "iDuG94H-C122",
+    "outputId": "4f3f7c9b-8d1c-4181-f2cb-b1674f19d905",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "let firstTrainExamples = trainDataset.first!\n",
+    "let firstTrainFeatures = firstTrainExamples.first\n",
+    "let firstTrainLabels = firstTrainExamples.second\n",
+    "firstTrainFeatures"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "E63mArnQaAGz"
+   },
+   "source": [
+    "Notice that like-features are grouped together, or *batched*. Each example row's fields are appended to the corresponding feature array. Change the `batchSize` to set the number of examples stored in these feature arrays.\n",
+    "\n",
+    "You can start to see some clusters by plotting a few features from the batch, using Python's matplotlib:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 301
+    },
+    "colab_type": "code",
+    "id": "me5Wn-9FcyyO",
+    "outputId": "508fe06a-8cfe-48e5-8b2b-7ac2d57e5c23",
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "let firstTrainFeaturesTransposed = firstTrainFeatures.transposed()\n",
+    "let petalLengths = firstTrainFeaturesTransposed[3].scalars\n",
+    "let sepalLengths = firstTrainFeaturesTransposed[0].scalars\n",
+    "\n",
+    "plt.scatter(petalLengths, sepalLengths, c: firstTrainLabels.array.scalars)\n",
+    "plt.xlabel(\"Petal length\")\n",
+    "plt.ylabel(\"Sepal length\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "LsaVrtNM3Tx5"
+   },
+   "source": [
+    "## Select the type of model\n",
+    "\n",
+    "### Why model?\n",
+    "\n",
+    "A *[model](https://developers.google.com/machine-learning/crash-course/glossary#model)* is a relationship between features and the label.  For the iris classification problem, the model defines the relationship between the sepal and petal measurements and the predicted iris species. Some simple models can be described with a few lines of algebra, but complex machine learning models have a large number of parameters that are difficult to summarize.\n",
+    "\n",
+    "Could you determine the relationship between the four features and the iris species *without* using machine learning?  That is, could you use traditional programming techniques (for example, a lot of conditional statements) to create a model?  Perhaps—if you analyzed the dataset long enough to determine the relationships between petal and sepal measurements to a particular species. And this becomes difficult—maybe impossible—on more complicated datasets. A good machine learning approach *determines the model for you*. If you feed enough representative examples into the right machine learning model type, the program will figure out the relationships for you.\n",
+    "\n",
+    "### Select the model\n",
+    "\n",
+    "We need to select the kind of model to train. There are many types of models and picking a good one takes experience. This tutorial uses a neural network to solve the iris classification problem. *[Neural networks](https://developers.google.com/machine-learning/glossary/#neural_network)* can find complex relationships between features and the label. It is a highly-structured graph, organized into one or more *[hidden layers](https://developers.google.com/machine-learning/glossary/#hidden_layer)*. Each hidden layer consists of one or more *[neurons](https://developers.google.com/machine-learning/glossary/#neuron)*. There are several categories of neural networks and this program uses a dense, or *[fully-connected neural network](https://developers.google.com/machine-learning/glossary/#fully_connected_layer)*: the neurons in one layer receive input connections from *every* neuron in the previous layer. For example, Figure 2 illustrates a dense neural network consisting of an input layer, two hidden layers, and an output layer:\n",
+    "\n",
+    "<table>\n",
+    "  <tr><td>\n",
+    "    <img src=\"https://www.tensorflow.org/images/custom_estimators/full_network.png\"\n",
+    "         alt=\"A diagram of the network architecture: Inputs, 2 hidden layers, and outputs\">\n",
+    "  </td></tr>\n",
+    "  <tr><td align=\"center\">\n",
+    "    <b>Figure 2.</b> A neural network with features, hidden layers, and predictions.<br/>&nbsp;\n",
+    "  </td></tr>\n",
+    "</table>\n",
+    "\n",
+    "When the model from Figure 2 is trained and fed an unlabeled example, it yields three predictions: the likelihood that this flower is the given iris species. This prediction is called *[inference](https://developers.google.com/machine-learning/crash-course/glossary#inference)*. For this example, the sum of the output predictions is 1.0. In Figure 2, this prediction breaks down as: `0.02` for *Iris setosa*, `0.95` for *Iris versicolor*, and `0.03` for *Iris virginica*. This means that the model predicts—with 95% probability—that an unlabeled example flower is an *Iris versicolor*."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "W23DIMVPQEBt"
+   },
+   "source": [
+    "### Create a model using Swift abstractions\n",
+    "\n",
+    "We will build the model from scratch, starting with low-level TensorFlow APIs.\n",
+    "\n",
+    "Let's start by defining a dense neural network layer as a Swift `struct`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "wr5A5WvthvZ0",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import TensorFlow\n",
+    "\n",
+    "// `Layer` is a protocol that makes it possible for an optimizer to update the\n",
+    "// struct during training.\n",
+    "struct DenseLayer : Layer {\n",
+    "    // Trainable parameters.\n",
+    "    var w: Tensor<Float>\n",
+    "    var b: Tensor<Float>\n",
+    "    \n",
+    "    init(inputSize: Int32, outputSize: Int32) {\n",
+    "        w = Tensor(glorotUniform: [inputSize, outputSize])\n",
+    "        b = Tensor(zeros: [outputSize])\n",
+    "    }\n",
+    "    \n",
+    "    // A requirement of the `Layer` protocol that specifies how this layer\n",
+    "    // transforms input to output.\n",
+    "    @differentiable(wrt: (self, input))\n",
+    "    func applied(to input: Tensor<Float>, in context: Context) -> Tensor<Float> {\n",
+    "        return input • w + b\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "br5wwj0Z6C1z"
+   },
+   "source": [
+    "Next, let's use `DenseLayer` to define a neural network model for the iris classification problem."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "bZd1Ck4Y5xWN",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "let hiddenSize: Int32 = 10\n",
+    "struct IrisParameters : Layer {\n",
+    "    var layer1 = DenseLayer(inputSize: 4, outputSize: hiddenSize)\n",
+    "    var layer2 = DenseLayer(inputSize: hiddenSize, outputSize: hiddenSize)\n",
+    "    var layer3 = DenseLayer(inputSize: hiddenSize, outputSize: 3)\n",
+    "    \n",
+    "    @differentiable(wrt: (self, input))\n",
+    "    func applied(to input: Tensor<Float>, in context: Context) -> Tensor<Float> {\n",
+    "        let l1 = relu(layer1.applied(to: input, in: context))\n",
+    "        let l2 = relu(layer2.applied(to: l1, in: context))\n",
+    "        return layer3.applied(to: l2, in: context)\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "fK0vrIRv_tcc"
+   },
+   "source": [
+    "Now, let's initialize the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "mIEZ5VlI_5WM",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "var model = IrisParameters()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "2wFKnhWCpDSS"
+   },
+   "source": [
+    "### Using the model\n",
+    "\n",
+    "Let's have a quick look at what this model does to a batch of features:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 35
+    },
+    "colab_type": "code",
+    "id": "sKjJGIYzO0mr",
+    "outputId": "65ed9dce-b6f0-454c-c6c7-fad79695b4c4",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "let inferenceContext = Context(learningPhase: .inference)\n",
+    "let firstTrainPredictions = model.applied(to: firstTrainFeatures, in: inferenceContext)\n",
+    "firstTrainPredictions[0..<5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "wxyXOhwVr5S3"
+   },
+   "source": [
+    "Here, each example returns a [logit](https://developers.google.com/machine-learning/crash-course/glossary#logits) for each class. \n",
+    "\n",
+    "To convert these logits to a probability for each class, use the [softmax](https://developers.google.com/machine-learning/crash-course/glossary#softmax) function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 35
+    },
+    "colab_type": "code",
+    "id": "_tRwHZmTNTX2",
+    "outputId": "b71a8139-cbd6-41f2-e8c8-4f5122130af0",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "softmax(firstTrainPredictions[0..<5])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "uRZmchElo481"
+   },
+   "source": [
+    "Taking the `argmax` across classes gives us the predicted class index. But, the model hasn't been trained yet, so these aren't good predictions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 53
+    },
+    "colab_type": "code",
+    "id": "-Jzm_GoErz8B",
+    "outputId": "6e84e436-48e9-488b-d955-5b0463f0be33",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Prediction: \\(firstTrainPredictions.argmax(squeezingAxis: 1))\")\n",
+    "print(\"    Labels: \\(firstTrainLabels)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Vzq2E5J2QMtw"
+   },
+   "source": [
+    "## Train the model\n",
+    "\n",
+    "*[Training](https://developers.google.com/machine-learning/crash-course/glossary#training)* is the stage of machine learning when the model is gradually optimized, or the model *learns* the dataset. The goal is to learn enough about the structure of the training dataset to make predictions about unseen data. If you learn *too much* about the training dataset, then the predictions only work for the data it has seen and will not be generalizable. This problem is called *[overfitting](https://developers.google.com/machine-learning/crash-course/glossary#overfitting)*—it's like memorizing the answers instead of understanding how to solve a problem.\n",
+    "\n",
+    "The iris classification problem is an example of *[supervised machine learning](https://developers.google.com/machine-learning/glossary/#supervised_machine_learning)*: the model is trained from examples that contain labels. In *[unsupervised machine learning](https://developers.google.com/machine-learning/glossary/#unsupervised_machine_learning)*, the examples don't contain labels. Instead, the model typically finds patterns among the features."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "RaKp8aEjKX6B"
+   },
+   "source": [
+    "### Define the loss and gradient function\n",
+    "\n",
+    "Both training and evaluation stages need to calculate the model's *[loss](https://developers.google.com/machine-learning/crash-course/glossary#loss)*. This measures how off a model's predictions are from the desired label, in other words, how bad the model is performing. We want to minimize, or optimize, this value.\n",
+    "\n",
+    "Our model will calculate its loss using the `softmaxCrossEntropy` function which takes the model's class probability predictions and the desired label, and returns the average loss across the examples."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "rHgwjCKqAWNz",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "%include \"TutorialModelHelpers.swift\"\n",
+    "extension IrisParameters {\n",
+    "  // We declare the loss as \"differentiable\" so that we can differentiate it\n",
+    "  // later while optimizing the model.\n",
+    "  @differentiable(wrt: (self))\n",
+    "  func loss(for input: Tensor<Float>, labels: Tensor<Int32>, in context: Context) -> Tensor<Float> {\n",
+    "      let logits = applied(to: input, in: context)\n",
+    "      return softmaxCrossEntropy(logits: logits, categoricalLabels: labels)\n",
+    "  }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "9SIHZjYQATyz"
+   },
+   "source": [
+    "Let's calculate the loss for the current untrained model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 35
+    },
+    "colab_type": "code",
+    "id": "tMAT4DcMPwI-",
+    "outputId": "1a99433c-2560-427b-ad32-9f79265dd8fd",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Loss test: \\(model.loss(for: firstTrainFeatures, labels: firstTrainLabels, in: inferenceContext))\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "lOxFimtlKruu"
+   },
+   "source": [
+    "### Create an optimizer\n",
+    "\n",
+    "An *[optimizer](https://developers.google.com/machine-learning/crash-course/glossary#optimizer)* applies the computed gradients to the model's variables to minimize the `loss` function. You can think of the loss function as a curved surface (see Figure 3) and we want to find its lowest point by walking around. The gradients point in the direction of steepest ascent—so we'll travel the opposite way and move down the hill. By iteratively calculating the loss and gradient for each batch, we'll adjust the model during training. Gradually, the model will find the best combination of weights and bias to minimize loss. And the lower the loss, the better the model's predictions.\n",
+    "\n",
+    "<table>\n",
+    "  <tr><td>\n",
+    "    <img src=\"https://cs231n.github.io/assets/nn3/opt1.gif\" width=\"70%\"\n",
+    "         alt=\"Optimization algorithms visualized over time in 3D space.\">\n",
+    "  </td></tr>\n",
+    "  <tr><td align=\"center\">\n",
+    "    <b>Figure 3.</b> Optimization algorithms visualized over time in 3D space.<br/>(Source: <a href=\"http://cs231n.github.io/neural-networks-3/\">Stanford class CS231n</a>, MIT License, Image credit: <a href=\"https://twitter.com/alecrad\">Alec Radford</a>)\n",
+    "  </td></tr>\n",
+    "</table>\n",
+    "\n",
+    "Swift for TensorFlow has many [optimization algorithms](https://github.com/rxwei/DeepLearning/blob/master/Sources/DeepLearning/Optimizer.swift) available for training. This model uses the SGD optimizer that implements the *[stochastic gradient descent](https://developers.google.com/machine-learning/crash-course/glossary#gradient_descent)* (SGD) algorithm. The `learning_rate` sets the step size to take for each iteration down the hill. This is a *hyperparameter* that you'll commonly adjust to achieve better results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "8xxi2NNGKwG_",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "let optimizer: SGD<IrisParameters, Float> = SGD(learningRate: 0.001)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "pJVRZ0hP52ZB"
+   },
+   "source": [
+    "We'll use this to calculate a single gradient descent step:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 35
+    },
+    "colab_type": "code",
+    "id": "rxRNTFVe56RG",
+    "outputId": "f25ee2d8-1cd6-4cb2-e37b-c95f387136d6",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "let trainingContext = Context(learningPhase: .training)\n",
+    "let (loss, grads) = valueWithGradient(at: model) { model in\n",
+    "  model.loss(for: firstTrainFeatures,labels: firstTrainLabels, in: trainingContext)\n",
+    "}\n",
+    "print(\"Initial Loss: \\(loss)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "5B27cIT0O0nE"
+   },
+   "source": [
+    "We call the `model.update(withGradients:)` method to iterate over all the model parameters and apply gradient descent to them, where `param` is the parameter and where `grad` is the gradient along that parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 35
+    },
+    "colab_type": "code",
+    "id": "icyvh-o6O0nF",
+    "outputId": "356105be-0d10-486d-b7f3-e33963b87ffb",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "optimizer.update(&model.allDifferentiableVariables, along: grads)\n",
+    "print(\"Next Loss: \\(model.loss(for: firstTrainFeatures, labels: firstTrainLabels, in: trainingContext))\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "nhpgM7UpO0nG"
+   },
+   "source": [
+    "If you run the above two steps repeatedly, you should expect the loss to go down gradually."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "7Y2VSELvwAvW"
+   },
+   "source": [
+    "### Training loop\n",
+    "\n",
+    "With all the pieces in place, the model is ready for training! A training loop feeds the dataset examples into the model to help it make better predictions. The following code block sets up these training steps:\n",
+    "\n",
+    "1. Iterate each *epoch*. An epoch is one pass through the dataset.\n",
+    "2. Within an epoch, iterate over each example in the training `Dataset` grabbing its *features* (`x`) and *label* (`y`).\n",
+    "3. Using the example's features, make a prediction and compare it with the label. Measure the inaccuracy of the prediction and use that to calculate the model's loss and gradients.\n",
+    "4. Use gradient descent to update the model's variables.\n",
+    "5. Keep track of some stats for visualization.\n",
+    "6. Repeat for each epoch.\n",
+    "\n",
+    "The `numEpochs` variable is the number of times to loop over the dataset collection. Counter-intuitively, training a model longer does not guarantee a better model. `numEpochs` is a *[hyperparameter](https://developers.google.com/machine-learning/glossary/#hyperparameter)* that you can tune. Choosing the right number usually requires both experience and experimentation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "AIgulGRUhpto",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "let numEpochs = 501\n",
+    "var trainAccuracyResults: [Float] = []\n",
+    "var trainLossResults: [Float] = []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 215
+    },
+    "colab_type": "code",
+    "id": "066kVZQFO0nL",
+    "outputId": "bd7a5c12-7872-400e-e10d-56596ace23d1",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "func accuracy(predictions: Tensor<Int32>, truths: Tensor<Int32>) -> Float {\n",
+    "    return Tensor<Float>(predictions .== truths).mean().scalar!\n",
+    "}\n",
+    "\n",
+    "for epoch in 0..<numEpochs {\n",
+    "    var epochLoss: Float = 0\n",
+    "    var epochAccuracy: Float = 0\n",
+    "    var batchCount: Int = 0\n",
+    "    for examples in trainDataset {\n",
+    "        let x = examples.first\n",
+    "        let y = examples.second\n",
+    "        let (loss, grad) = valueWithGradient(at: model) { model in\n",
+    "            model.loss(for: firstTrainFeatures, labels: firstTrainLabels, in: trainingContext)\n",
+    "        }\n",
+    "        optimizer.update(&model.allDifferentiableVariables, along: grad)\n",
+    "        \n",
+    "        let logits = model.applied(to: x, in: trainingContext)\n",
+    "        epochAccuracy += accuracy(predictions: logits.argmax(squeezingAxis: 1), truths: y)\n",
+    "        epochLoss += loss.scalar!\n",
+    "        batchCount += 1\n",
+    "    }\n",
+    "    epochAccuracy /= Float(batchCount)\n",
+    "    epochLoss /= Float(batchCount)\n",
+    "    trainAccuracyResults.append(epochAccuracy)\n",
+    "    trainLossResults.append(epochLoss)\n",
+    "    if epoch % 50 == 0 {\n",
+    "        print(\"Epoch \\(epoch): Loss: \\(epochLoss), Accuracy: \\(epochAccuracy)\")\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "2FQHVUnm_rjw"
+   },
+   "source": [
+    "### Visualize the loss function over time"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "j3wdbmtLVTyr"
+   },
+   "source": [
+    "While it's helpful to print out the model's training progress, it's often *more* helpful to see this progress. We can create basic charts using Python's `matplotlib` module.\n",
+    "\n",
+    "Interpreting these charts takes some experience, but you really want to see the *loss* go down and the *accuracy* go up."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 518
+    },
+    "colab_type": "code",
+    "id": "agjvNd2iUGFn",
+    "outputId": "3d2b60f0-6440-4049-d97e-c55adc28b941",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize: [12, 8])\n",
+    "\n",
+    "let accuracyAxes = plt.subplot(2, 1, 1)\n",
+    "accuracyAxes.set_ylabel(\"Accuracy\")\n",
+    "accuracyAxes.plot(trainAccuracyResults)\n",
+    "\n",
+    "let lossAxes = plt.subplot(2, 1, 2)\n",
+    "lossAxes.set_ylabel(\"Loss\")\n",
+    "lossAxes.set_xlabel(\"Epoch\")\n",
+    "lossAxes.plot(trainLossResults)\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "axA6WuGVO0nR"
+   },
+   "source": [
+    "Note that the y-axes of the graphs are not zero-based."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Zg8GoMZhLpGH"
+   },
+   "source": [
+    "## Evaluate the model's effectiveness\n",
+    "\n",
+    "Now that the model is trained, we can get some statistics on its performance.\n",
+    "\n",
+    "*Evaluating* means determining how effectively the model makes predictions. To determine the model's effectiveness at iris classification, pass some sepal and petal measurements to the model and ask the model to predict what iris species they represent. Then compare the model's prediction against the actual label.  For example, a model that picked the correct species on half the input examples has an *[accuracy](https://developers.google.com/machine-learning/glossary/#accuracy)* of `0.5`. Figure 4 shows a slightly more effective model, getting 4 out of 5 predictions correct at 80% accuracy:\n",
+    "\n",
+    "<table cellpadding=\"8\" border=\"0\">\n",
+    "  <colgroup>\n",
+    "    <col span=\"4\" >\n",
+    "    <col span=\"1\" bgcolor=\"lightblue\">\n",
+    "    <col span=\"1\" bgcolor=\"lightgreen\">\n",
+    "  </colgroup>\n",
+    "  <tr bgcolor=\"lightgray\">\n",
+    "    <th colspan=\"4\">Example features</th>\n",
+    "    <th colspan=\"1\">Label</th>\n",
+    "    <th colspan=\"1\" >Model prediction</th>\n",
+    "  </tr>\n",
+    "  <tr>\n",
+    "    <td>5.9</td><td>3.0</td><td>4.3</td><td>1.5</td><td align=\"center\">1</td><td align=\"center\">1</td>\n",
+    "  </tr>\n",
+    "  <tr>\n",
+    "    <td>6.9</td><td>3.1</td><td>5.4</td><td>2.1</td><td align=\"center\">2</td><td align=\"center\">2</td>\n",
+    "  </tr>\n",
+    "  <tr>\n",
+    "    <td>5.1</td><td>3.3</td><td>1.7</td><td>0.5</td><td align=\"center\">0</td><td align=\"center\">0</td>\n",
+    "  </tr>\n",
+    "  <tr>\n",
+    "    <td>6.0</td> <td>3.4</td> <td>4.5</td> <td>1.6</td> <td align=\"center\">1</td><td align=\"center\" bgcolor=\"red\">2</td>\n",
+    "  </tr>\n",
+    "  <tr>\n",
+    "    <td>5.5</td><td>2.5</td><td>4.0</td><td>1.3</td><td align=\"center\">1</td><td align=\"center\">1</td>\n",
+    "  </tr>\n",
+    "  <tr><td align=\"center\" colspan=\"6\">\n",
+    "    <b>Figure 4.</b> An iris classifier that is 80% accurate.<br/>&nbsp;\n",
+    "  </td></tr>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "z-EvK7hGL0d8"
+   },
+   "source": [
+    "### Setup the test dataset\n",
+    "\n",
+    "Evaluating the model is similar to training the model. The biggest difference is the examples come from a separate *[test set](https://developers.google.com/machine-learning/crash-course/glossary#test_set)* rather than the training set. To fairly assess a model's effectiveness, the examples used to evaluate a model must be different from the examples used to train the model.\n",
+    "\n",
+    "The setup for the test `Dataset` is similar to the setup for training `Dataset`. Download the test set from http://download.tensorflow.org/data/iris_training.csv:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 35
+    },
+    "colab_type": "code",
+    "id": "SRMWCu30bnxH",
+    "outputId": "6147e89c-f209-46eb-f2d4-3aa3c39673bb",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "let urllib = Python.import(\"urllib.request\")\n",
+    "let downloadResult = urllib.urlretrieve(\"http://download.tensorflow.org/data/iris_test.csv\",\n",
+    "                                        \"iris_test.csv\")\n",
+    "let testDataFilename = String(downloadResult[0])!\n",
+    "testDataFilename"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "jEPPL6FUO0nV"
+   },
+   "source": [
+    " Now load it into a `Dataset`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "w6SCt95HO0nW",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "%include \"TutorialDatasetCSVAPI.swift\"\n",
+    "let testDataset: Dataset<TensorPair<Tensor<Float>, Tensor<Int32>>> = Dataset(\n",
+    "    contentsOfCSVFile: testDataFilename, hasHeader: true,\n",
+    "    featureColumns: [0, 1, 2, 3], labelColumns: [4]\n",
+    ").batched(batchSize)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "HFuOKXJdMAdm"
+   },
+   "source": [
+    "### Evaluate the model on the test dataset\n",
+    "\n",
+    "Unlike the training stage, the model only evaluates a single [epoch](https://developers.google.com/machine-learning/glossary/#epoch) of the test data. In the following code cell, we iterate over each example in the test set and compare the model's prediction against the actual label. This is used to measure the model's accuracy across the entire test set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 35
+    },
+    "colab_type": "code",
+    "id": "Tj4Rs8gwO0nY",
+    "outputId": "d1d6573f-9846-48b4-a917-3a33586db4ee",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "// NOTE: With `batchSize = 32` and 30 examples in the test dataset, only one batch will run in the loop.\n",
+    "for testBatch in testDataset {\n",
+    "    let testFeatures = testBatch.first\n",
+    "    let testLabels = testBatch.second\n",
+    "    let logits = model.applied(to: testFeatures, in: inferenceContext)\n",
+    "    let predictions = logits.argmax(squeezingAxis: 1)\n",
+    "    print(\"Test batch accuracy: \\(accuracy(predictions: predictions, truths: testLabels))\")\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "HcKEZMtCOeK-"
+   },
+   "source": [
+    "We can see on the first batch, for example, the model is usually correct:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 53
+    },
+    "colab_type": "code",
+    "id": "uNwt2eMeOane",
+    "outputId": "668ea70b-f56f-4642-9547-5f57e3ed1eb8",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "let firstTestBatch = testDataset.first!\n",
+    "let firstTestBatchFeatures = firstTestBatch.first\n",
+    "let firstTestBatchLabels = firstTestBatch.second\n",
+    "let firstTestBatchLogits = model.applied(to: firstTestBatchFeatures, in: inferenceContext)\n",
+    "let firstTestBatchPredictions = firstTestBatchLogits.argmax(squeezingAxis: 1)\n",
+    "\n",
+    "print(firstTestBatchPredictions)\n",
+    "print(firstTestBatchLabels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "7Li2r1tYvW7S"
+   },
+   "source": [
+    "## Use the trained model to make predictions\n",
+    "\n",
+    "We've trained a model and demonstrated that it's good—but not perfect—at classifying iris species. Now let's use the trained model to make some predictions on [unlabeled examples](https://developers.google.com/machine-learning/glossary/#unlabeled_example); that is, on examples that contain features but not a label.\n",
+    "\n",
+    "In real-life, the unlabeled examples could come from lots of different sources including apps, CSV files, and data feeds. For now, we're going to manually provide three unlabeled examples to predict their labels. Recall, the label numbers are mapped to a named representation as:\n",
+    "\n",
+    "* `0`: Iris setosa\n",
+    "* `1`: Iris versicolor\n",
+    "* `2`: Iris virginica"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 71
+    },
+    "colab_type": "code",
+    "id": "MTYOZr27O0ne",
+    "outputId": "2d9c965d-0196-4734-a660-a5590632b9c4",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "let unlabeledDataset: Tensor<Float> =\n",
+    "    [[5.1, 3.3, 1.7, 0.5],\n",
+    "     [5.9, 3.0, 4.2, 1.5],\n",
+    "     [6.9, 3.1, 5.4, 2.1]]\n",
+    "\n",
+    "let unlabeledDatasetPredictions = model.applied(to: unlabeledDataset, in: inferenceContext)\n",
+    "\n",
+    "for i in 0..<unlabeledDatasetPredictions.shape[0] {\n",
+    "    let logits = unlabeledDatasetPredictions[i]\n",
+    "    let classIdx = logits.argmax().scalar!\n",
+    "    print(\"Example \\(i) prediction: \\(classNames[Int(classIdx)]) (\\(softmax(logits)))\")\n",
+    "}"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "Custom training: walkthrough",
+   "provenance": [],
+   "toc_visible": true,
+   "version": "0.3.2"
+  },
+  "kernelspec": {
+   "display_name": "Swift",
+   "language": "swift",
+   "name": "swift"
+  },
+  "language_info": {
+   "file_extension": ".swift",
+   "mimetype": "text/x-swift",
+   "name": "swift",
+   "version": ""
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/docs/site/tutorials/walkthrough.ipynb
+++ b/docs/site/tutorials/walkthrough.ipynb
@@ -1,1245 +1,1494 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "rwxGnsA92emp"
-   },
-   "source": [
-    "##### Copyright 2018 The TensorFlow Authors."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "cellView": "form",
-    "colab": {},
-    "colab_type": "code",
-    "id": "CPII1rGR2rF9",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "// Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-    "// you may not use this file except in compliance with the License.\n",
-    "// You may obtain a copy of the License at\n",
-    "//\n",
-    "// https://www.apache.org/licenses/LICENSE-2.0\n",
-    "//\n",
-    "// Unless required by applicable law or agreed to in writing, software\n",
-    "// distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-    "// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-    "// See the License for the specific language governing permissions and\n",
-    "// limitations under the License."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "LrO3-gmDO0mH"
-   },
-   "source": [
-    "## Swift for TensorFlow is a work-in-progress\n",
-    "\n",
-    "Swift for TensorFlow is still a work-in-progress. If you modify the code in this tutorial, you will frequently get unexpected error messages and kernel crashes. Restarting the kernel might occasionally help (Kernel > Restart in the Jupyter toolbar).\n",
-    "\n",
-    "We are working on stabilizing the compiler. You can help us by filing bugs on https://bugs.swift.org (set the \"Component\" field to \"Swift for TensorFlow\") or by emailing the swift@tensorflow.org mailing list when you encounter unexpected error messages and kernel crashes."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "JtEZ1pCPn--z"
-   },
-   "source": [
-    "# Swift for TensorFlow: walkthrough"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "LDrzLFXE8T1l"
-   },
-   "source": [
-    "This guide introduces Swift for TensorFlow by using Swift for TensorFlow to build a machine learning model that categorizes iris flowers by species. It uses Swift for TensorFlow to:\n",
-    "1. Build a model,\n",
-    "2. Train this model on example data, and\n",
-    "3. Use the model to make predictions about unknown data.\n",
-    "\n",
-    "This guide is a Swift port of the [TensorFlow custom training walkthrough](https://www.tensorflow.org/tutorials/eager/custom_training_walkthrough).\n",
-    "\n",
-    "## TensorFlow programming\n",
-    "\n",
-    "This guide uses these high-level Swift for TensorFlow concepts:\n",
-    "\n",
-    "* Import data with the Datasets API.\n",
-    "* Build models and layers using Swift abstractions.\n",
-    "* Use Python libraries using Swift's Python interoperability when pure Swift libraries are not available.\n",
-    "\n",
-    "This tutorial is structured like many TensorFlow programs:\n",
-    "\n",
-    "1. Import and parse the data sets.\n",
-    "2. Select the type of model.\n",
-    "3. Train the model.\n",
-    "4. Evaluate the model's effectiveness.\n",
-    "5. Use the trained model to make predictions."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "yNr7H-AIoLOR"
-   },
-   "source": [
-    "## Setup program"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "1J3AuPBT9gyR"
-   },
-   "source": [
-    "### Configure imports\n",
-    "\n",
-    "Import TensorFlow and some useful Python modules."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
     "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 53
+      "name": "Swift for TensorFlow: walkthrough",
+      "version": "0.3.2",
+      "provenance": [],
+      "collapsed_sections": [],
+      "toc_visible": true
     },
-    "colab_type": "code",
-    "id": "g4Wzg69bnwK2",
-    "outputId": "fa0c0a7c-7905-4aad-a9c1-996432c9e7e0",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "import TensorFlow\n",
-    "\n",
-    "import Python\n",
-    "%include \"EnableIPythonDisplay.swift\"\n",
-    "IPythonDisplay.shell.enable_matplotlib(\"inline\")\n",
-    "let plt = Python.import(\"matplotlib.pyplot\")\n",
-    "\n",
-    "// Download some helper files that we will include later.\n",
-    "let path = Python.import(\"os.path\")\n",
-    "let urllib = Python.import(\"urllib.request\")\n",
-    "let helperFiles = [\"TutorialDatasetCSVAPI.swift\", \"TutorialModelHelpers.swift\"]\n",
-    "for helperFile in helperFiles {\n",
-    "  if !Bool(path.isfile(helperFile))! {\n",
-    "    print(\"Downloading \\(helperFile)\")\n",
-    "    urllib.urlretrieve(\n",
-    "        \"https://raw.githubusercontent.com/tensorflow/swift-tutorials/master/iris/\" + helperFile,\n",
-    "        filename: helperFile)\n",
-    "  } else {\n",
-    "    print(\"Not downloading \\(helperFile): already exists\")\n",
-    "  }\n",
-    "}"
-   ]
+    "kernelspec": {
+      "display_name": "Swift",
+      "language": "swift",
+      "name": "swift"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Zx7wc0LuuxaJ"
-   },
-   "source": [
-    "## The iris classification problem\n",
-    "\n",
-    "Imagine you are a botanist seeking an automated way to categorize each iris flower you find. Machine learning provides many algorithms to classify flowers statistically. For instance, a sophisticated machine learning program could classify flowers based on photographs. Our ambitions are more modest—we're going to classify iris flowers based on the length and width measurements of their [sepals](https://en.wikipedia.org/wiki/Sepal) and [petals](https://en.wikipedia.org/wiki/Petal).\n",
-    "\n",
-    "The Iris genus entails about 300 species, but our program will only classify the following three:\n",
-    "\n",
-    "* Iris setosa\n",
-    "* Iris virginica\n",
-    "* Iris versicolor\n",
-    "\n",
-    "<table>\n",
-    "  <tr><td>\n",
-    "    <img src=\"https://www.tensorflow.org/images/iris_three_species.jpg\"\n",
-    "         alt=\"Petal geometry compared for three iris species: Iris setosa, Iris virginica, and Iris versicolor\">\n",
-    "  </td></tr>\n",
-    "  <tr><td align=\"center\">\n",
-    "    <b>Figure 1.</b> <a href=\"https://commons.wikimedia.org/w/index.php?curid=170298\">Iris setosa</a> (by <a href=\"https://commons.wikimedia.org/wiki/User:Radomil\">Radomil</a>, CC BY-SA 3.0), <a href=\"https://commons.wikimedia.org/w/index.php?curid=248095\">Iris versicolor</a>, (by <a href=\"https://commons.wikimedia.org/wiki/User:Dlanglois\">Dlanglois</a>, CC BY-SA 3.0), and <a href=\"https://www.flickr.com/photos/33397993@N05/3352169862\">Iris virginica</a> (by <a href=\"https://www.flickr.com/photos/33397993@N05\">Frank Mayfield</a>, CC BY-SA 2.0).<br/>&nbsp;\n",
-    "  </td></tr>\n",
-    "</table>\n",
-    "\n",
-    "Fortunately, someone has already created a [data set of 120 iris flowers](https://en.wikipedia.org/wiki/Iris_flower_data_set) with the sepal and petal measurements. This is a classic dataset that is popular for beginner machine learning classification problems."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "3Px6KAg0Jowz"
-   },
-   "source": [
-    "## Import and parse the training dataset\n",
-    "\n",
-    "Download the dataset file and convert it into a structure that can be used by this Swift program.\n",
-    "\n",
-    "### Download the dataset\n",
-    "\n",
-    "Download the training dataset file from http://download.tensorflow.org/data/iris_training.csv. We use a Python library to demonstrate Swift's Python interoperability. Swift's Python interoperability makes it easy and natural to import and use Python libraries from Swift code."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 35
+  "cells": [
+    {
+      "metadata": {
+        "id": "zBH72IXMJ3JJ",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/swift/tutorials/walkthrough\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/swift/tutorials/walkthrough.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/swift/tutorials/walkthrough.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "  </td>\n",
+        "</table>"
+      ]
     },
-    "colab_type": "code",
-    "id": "DKkgac4WO0mP",
-    "outputId": "7066e07c-f142-4a79-92ca-2eedded056e1",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "let urllib = Python.import(\"urllib.request\")\n",
-    "let downloadResult = urllib.urlretrieve(\"http://download.tensorflow.org/data/iris_training.csv\",\n",
-    "                                        \"iris_training.csv\")\n",
-    "let trainDataFilename = String(downloadResult[0])!\n",
-    "trainDataFilename"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "qnX1-aLors4S"
-   },
-   "source": [
-    "### Inspect the data\n",
-    "\n",
-    "This dataset, `iris_training.csv`, is a plain text file that stores tabular data formatted as comma-separated values (CSV). Let's look a the first 5 entries."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 125
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "LrO3-gmDO0mH"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "## Swift for TensorFlow is a work-in-progress\n",
+        "\n",
+        "Swift for TensorFlow is still a work-in-progress. If you modify the code in this tutorial, you will frequently get unexpected error messages and kernel crashes. Restarting the kernel might occasionally help (Kernel > Restart in the Jupyter toolbar).\n",
+        "\n",
+        "We are working on stabilizing the compiler. You can help us by filing bugs on https://bugs.swift.org (set the \"Component\" field to \"Swift for TensorFlow\") or by emailing the swift@tensorflow.org mailing list when you encounter unexpected error messages and kernel crashes."
+      ]
     },
-    "colab_type": "code",
-    "id": "FQvb_JYdrpPm",
-    "outputId": "d8ee7217-3baf-4c74-950c-cac858d0227e",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "let f = Python.open(trainDataFilename)\n",
-    "for _ in 0..<5 {\n",
-    "    print(Python.next(f).strip())\n",
-    "}\n",
-    "f.close()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "kQhzD6P-uBoq"
-   },
-   "source": [
-    "From this view of the dataset, notice the following:\n",
-    "\n",
-    "1. The first line is a header containing information about the dataset:\n",
-    "  * There are 120 total examples. Each example has four features and one of three possible label names. \n",
-    "2. Subsequent rows are data records, one *[example](https://developers.google.com/machine-learning/glossary/#example)* per line, where:\n",
-    "  * The first four fields are *[features](https://developers.google.com/machine-learning/glossary/#feature)*: these are characteristics of an example. Here, the fields hold float numbers representing flower measurements.\n",
-    "  * The last column is the *[label](https://developers.google.com/machine-learning/glossary/#label)*: this is the value we want to predict. For this dataset, it's an integer value of 0, 1, or 2 that corresponds to a flower name.\n",
-    "\n",
-    "Let's write that out in code:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 53
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "JtEZ1pCPn--z"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "# Swift for TensorFlow: walkthrough"
+      ]
     },
-    "colab_type": "code",
-    "id": "9Edhevw7exl6",
-    "outputId": "aba9b8b2-d9e7-4fca-b086-42d4732a7093",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "let featureNames = [\"sepal_length\", \"sepal_width\", \"petal_length\", \"petal_width\"]\n",
-    "let labelName = \"species\"\n",
-    "let columnNames = featureNames + [labelName]\n",
-    "\n",
-    "print(\"Features: \\(featureNames)\")\n",
-    "print(\"Label: \\(labelName)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "CCtwLoJhhDNc"
-   },
-   "source": [
-    "Each label is associated with string name (for example, \"setosa\"), but machine learning typically relies on numeric values. The label numbers are mapped to a named representation, such as:\n",
-    "\n",
-    "* `0`: Iris setosa\n",
-    "* `1`: Iris versicolor\n",
-    "* `2`: Iris virginica\n",
-    "\n",
-    "For more information about features and labels, see the [ML Terminology section of the Machine Learning Crash Course](https://developers.google.com/machine-learning/crash-course/framing/ml-terminology)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "sVNlJlUOhkoX",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "let classNames = [\"Iris setosa\", \"Iris versicolor\", \"Iris virginica\"]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "dqPkQExM2Pwt"
-   },
-   "source": [
-    "### Create a Dataset\n",
-    "\n",
-    "Swift for TensorFlow's Dataset API handles loading data into a model. This is a high-level API for reading data and transforming it into a form used for training. Currently, Swift's Dataset API supports loading data only from CSV files, but we intend to extend it to handle many more types of data, like [TensorFlow's Dataset API](https://www.tensorflow.org/guide/datasets).\n",
-    "\n",
-    "Use the `Dataset(contentsOfCSVFile:hasHeader:featureColumns:labelColumns:)` initializer to initialize a `Dataset` with training data. Also batch the data into batches using the `.batched()` function."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "bBx_C6UWO0mc",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "public let batchSize = Int64(32)\n",
-    "\n",
-    "%include \"TutorialDatasetCSVAPI.swift\"\n",
-    "\n",
-    "let trainDataset: Dataset<TensorPair<Tensor<Float>, Tensor<Int32>>> = Dataset(\n",
-    "    contentsOfCSVFile: trainDataFilename, hasHeader: true,\n",
-    "    featureColumns: [0, 1, 2, 3], labelColumns: [4]\n",
-    ").batched(batchSize)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "gB_RSn62c-3G"
-   },
-   "source": [
-    "This returns a `Dataset` of `(features, labels)` pairs, where `feature` is a `Tensor<Float>` with shape `(batchSize, featureColumns.count)` and where `labels` is a `Tensor<Int32>` with shape `(batchSize, labelColumns.count)`\n",
-    "\n",
-    "These `Dataset` values are iterable. Let's look at the first element of the dataset."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 55
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "LDrzLFXE8T1l"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "This guide introduces Swift for TensorFlow by using Swift for TensorFlow to build a machine learning model that categorizes iris flowers by species. It uses Swift for TensorFlow to:\n",
+        "1. Build a model,\n",
+        "2. Train this model on example data, and\n",
+        "3. Use the model to make predictions about unknown data.\n",
+        "\n",
+        "This guide is a Swift port of the [TensorFlow custom training walkthrough](https://www.tensorflow.org/tutorials/eager/custom_training_walkthrough).\n",
+        "\n",
+        "## TensorFlow programming\n",
+        "\n",
+        "This guide uses these high-level Swift for TensorFlow concepts:\n",
+        "\n",
+        "* Import data with the Datasets API.\n",
+        "* Build models and layers using Swift abstractions.\n",
+        "* Use Python libraries using Swift's Python interoperability when pure Swift libraries are not available.\n",
+        "\n",
+        "This tutorial is structured like many TensorFlow programs:\n",
+        "\n",
+        "1. Import and parse the data sets.\n",
+        "2. Select the type of model.\n",
+        "3. Train the model.\n",
+        "4. Evaluate the model's effectiveness.\n",
+        "5. Use the trained model to make predictions."
+      ]
     },
-    "colab_type": "code",
-    "id": "iDuG94H-C122",
-    "outputId": "4f3f7c9b-8d1c-4181-f2cb-b1674f19d905",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "let firstTrainExamples = trainDataset.first!\n",
-    "let firstTrainFeatures = firstTrainExamples.first\n",
-    "let firstTrainLabels = firstTrainExamples.second\n",
-    "firstTrainFeatures"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "E63mArnQaAGz"
-   },
-   "source": [
-    "Notice that like-features are grouped together, or *batched*. Each example row's fields are appended to the corresponding feature array. Change the `batchSize` to set the number of examples stored in these feature arrays.\n",
-    "\n",
-    "You can start to see some clusters by plotting a few features from the batch, using Python's matplotlib:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 301
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "yNr7H-AIoLOR"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "## Setup program"
+      ]
     },
-    "colab_type": "code",
-    "id": "me5Wn-9FcyyO",
-    "outputId": "508fe06a-8cfe-48e5-8b2b-7ac2d57e5c23",
-    "scrolled": false
-   },
-   "outputs": [],
-   "source": [
-    "let firstTrainFeaturesTransposed = firstTrainFeatures.transposed()\n",
-    "let petalLengths = firstTrainFeaturesTransposed[3].scalars\n",
-    "let sepalLengths = firstTrainFeaturesTransposed[0].scalars\n",
-    "\n",
-    "plt.scatter(petalLengths, sepalLengths, c: firstTrainLabels.array.scalars)\n",
-    "plt.xlabel(\"Petal length\")\n",
-    "plt.ylabel(\"Sepal length\")\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "LsaVrtNM3Tx5"
-   },
-   "source": [
-    "## Select the type of model\n",
-    "\n",
-    "### Why model?\n",
-    "\n",
-    "A *[model](https://developers.google.com/machine-learning/crash-course/glossary#model)* is a relationship between features and the label.  For the iris classification problem, the model defines the relationship between the sepal and petal measurements and the predicted iris species. Some simple models can be described with a few lines of algebra, but complex machine learning models have a large number of parameters that are difficult to summarize.\n",
-    "\n",
-    "Could you determine the relationship between the four features and the iris species *without* using machine learning?  That is, could you use traditional programming techniques (for example, a lot of conditional statements) to create a model?  Perhaps—if you analyzed the dataset long enough to determine the relationships between petal and sepal measurements to a particular species. And this becomes difficult—maybe impossible—on more complicated datasets. A good machine learning approach *determines the model for you*. If you feed enough representative examples into the right machine learning model type, the program will figure out the relationships for you.\n",
-    "\n",
-    "### Select the model\n",
-    "\n",
-    "We need to select the kind of model to train. There are many types of models and picking a good one takes experience. This tutorial uses a neural network to solve the iris classification problem. *[Neural networks](https://developers.google.com/machine-learning/glossary/#neural_network)* can find complex relationships between features and the label. It is a highly-structured graph, organized into one or more *[hidden layers](https://developers.google.com/machine-learning/glossary/#hidden_layer)*. Each hidden layer consists of one or more *[neurons](https://developers.google.com/machine-learning/glossary/#neuron)*. There are several categories of neural networks and this program uses a dense, or *[fully-connected neural network](https://developers.google.com/machine-learning/glossary/#fully_connected_layer)*: the neurons in one layer receive input connections from *every* neuron in the previous layer. For example, Figure 2 illustrates a dense neural network consisting of an input layer, two hidden layers, and an output layer:\n",
-    "\n",
-    "<table>\n",
-    "  <tr><td>\n",
-    "    <img src=\"https://www.tensorflow.org/images/custom_estimators/full_network.png\"\n",
-    "         alt=\"A diagram of the network architecture: Inputs, 2 hidden layers, and outputs\">\n",
-    "  </td></tr>\n",
-    "  <tr><td align=\"center\">\n",
-    "    <b>Figure 2.</b> A neural network with features, hidden layers, and predictions.<br/>&nbsp;\n",
-    "  </td></tr>\n",
-    "</table>\n",
-    "\n",
-    "When the model from Figure 2 is trained and fed an unlabeled example, it yields three predictions: the likelihood that this flower is the given iris species. This prediction is called *[inference](https://developers.google.com/machine-learning/crash-course/glossary#inference)*. For this example, the sum of the output predictions is 1.0. In Figure 2, this prediction breaks down as: `0.02` for *Iris setosa*, `0.95` for *Iris versicolor*, and `0.03` for *Iris virginica*. This means that the model predicts—with 95% probability—that an unlabeled example flower is an *Iris versicolor*."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "W23DIMVPQEBt"
-   },
-   "source": [
-    "### Create a model using Swift abstractions\n",
-    "\n",
-    "We will build the model from scratch, starting with low-level TensorFlow APIs.\n",
-    "\n",
-    "Let's start by defining a dense neural network layer as a Swift `struct`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "wr5A5WvthvZ0",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "import TensorFlow\n",
-    "\n",
-    "// `Layer` is a protocol that makes it possible for an optimizer to update the\n",
-    "// struct during training.\n",
-    "struct DenseLayer : Layer {\n",
-    "    // Trainable parameters.\n",
-    "    var w: Tensor<Float>\n",
-    "    var b: Tensor<Float>\n",
-    "    \n",
-    "    init(inputSize: Int32, outputSize: Int32) {\n",
-    "        w = Tensor(glorotUniform: [inputSize, outputSize])\n",
-    "        b = Tensor(zeros: [outputSize])\n",
-    "    }\n",
-    "    \n",
-    "    // A requirement of the `Layer` protocol that specifies how this layer\n",
-    "    // transforms input to output.\n",
-    "    @differentiable(wrt: (self, input))\n",
-    "    func applied(to input: Tensor<Float>, in context: Context) -> Tensor<Float> {\n",
-    "        return input • w + b\n",
-    "    }\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "br5wwj0Z6C1z"
-   },
-   "source": [
-    "Next, let's use `DenseLayer` to define a neural network model for the iris classification problem."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "bZd1Ck4Y5xWN",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "let hiddenSize: Int32 = 10\n",
-    "struct IrisParameters : Layer {\n",
-    "    var layer1 = DenseLayer(inputSize: 4, outputSize: hiddenSize)\n",
-    "    var layer2 = DenseLayer(inputSize: hiddenSize, outputSize: hiddenSize)\n",
-    "    var layer3 = DenseLayer(inputSize: hiddenSize, outputSize: 3)\n",
-    "    \n",
-    "    @differentiable(wrt: (self, input))\n",
-    "    func applied(to input: Tensor<Float>, in context: Context) -> Tensor<Float> {\n",
-    "        let l1 = relu(layer1.applied(to: input, in: context))\n",
-    "        let l2 = relu(layer2.applied(to: l1, in: context))\n",
-    "        return layer3.applied(to: l2, in: context)\n",
-    "    }\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "fK0vrIRv_tcc"
-   },
-   "source": [
-    "Now, let's initialize the model."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "mIEZ5VlI_5WM",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "var model = IrisParameters()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "2wFKnhWCpDSS"
-   },
-   "source": [
-    "### Using the model\n",
-    "\n",
-    "Let's have a quick look at what this model does to a batch of features:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 35
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "1J3AuPBT9gyR"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Configure imports\n",
+        "\n",
+        "Import TensorFlow and some useful Python modules."
+      ]
     },
-    "colab_type": "code",
-    "id": "sKjJGIYzO0mr",
-    "outputId": "65ed9dce-b6f0-454c-c6c7-fad79695b4c4",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "let inferenceContext = Context(learningPhase: .inference)\n",
-    "let firstTrainPredictions = model.applied(to: firstTrainFeatures, in: inferenceContext)\n",
-    "firstTrainPredictions[0..<5]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "wxyXOhwVr5S3"
-   },
-   "source": [
-    "Here, each example returns a [logit](https://developers.google.com/machine-learning/crash-course/glossary#logits) for each class. \n",
-    "\n",
-    "To convert these logits to a probability for each class, use the [softmax](https://developers.google.com/machine-learning/crash-course/glossary#softmax) function:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 35
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "g4Wzg69bnwK2",
+        "outputId": "b147c0b3-efa5-4d44-ff55-711dc49fdb4b",
+        "scrolled": true,
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 51
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "import TensorFlow\n",
+        "\n",
+        "import Python\n",
+        "%include \"EnableIPythonDisplay.swift\"\n",
+        "IPythonDisplay.shell.enable_matplotlib(\"inline\")\n",
+        "let plt = Python.import(\"matplotlib.pyplot\")\n",
+        "\n",
+        "// Download some helper files that we will include later.\n",
+        "let path = Python.import(\"os.path\")\n",
+        "let urllib = Python.import(\"urllib.request\")\n",
+        "let helperFiles = [\"TutorialDatasetCSVAPI.swift\", \"TutorialModelHelpers.swift\"]\n",
+        "for helperFile in helperFiles {\n",
+        "  if !Bool(path.isfile(helperFile))! {\n",
+        "    print(\"Downloading \\(helperFile)\")\n",
+        "    urllib.urlretrieve(\n",
+        "        \"https://raw.githubusercontent.com/tensorflow/swift-tutorials/master/iris/\" + helperFile,\n",
+        "        filename: helperFile)\n",
+        "  } else {\n",
+        "    print(\"Not downloading \\(helperFile): already exists\")\n",
+        "  }\n",
+        "}"
+      ],
+      "execution_count": 2,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Not downloading TutorialDatasetCSVAPI.swift: already exists\r\n",
+            "Not downloading TutorialModelHelpers.swift: already exists\r\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
-    "colab_type": "code",
-    "id": "_tRwHZmTNTX2",
-    "outputId": "b71a8139-cbd6-41f2-e8c8-4f5122130af0",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "softmax(firstTrainPredictions[0..<5])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "uRZmchElo481"
-   },
-   "source": [
-    "Taking the `argmax` across classes gives us the predicted class index. But, the model hasn't been trained yet, so these aren't good predictions."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 53
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "Zx7wc0LuuxaJ"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "## The iris classification problem\n",
+        "\n",
+        "Imagine you are a botanist seeking an automated way to categorize each iris flower you find. Machine learning provides many algorithms to classify flowers statistically. For instance, a sophisticated machine learning program could classify flowers based on photographs. Our ambitions are more modest—we're going to classify iris flowers based on the length and width measurements of their [sepals](https://en.wikipedia.org/wiki/Sepal) and [petals](https://en.wikipedia.org/wiki/Petal).\n",
+        "\n",
+        "The Iris genus entails about 300 species, but our program will only classify the following three:\n",
+        "\n",
+        "* Iris setosa\n",
+        "* Iris virginica\n",
+        "* Iris versicolor\n",
+        "\n",
+        "<table>\n",
+        "  <tr><td>\n",
+        "    <img src=\"https://www.tensorflow.org/images/iris_three_species.jpg\"\n",
+        "         alt=\"Petal geometry compared for three iris species: Iris setosa, Iris virginica, and Iris versicolor\">\n",
+        "  </td></tr>\n",
+        "  <tr><td align=\"center\">\n",
+        "    <b>Figure 1.</b> <a href=\"https://commons.wikimedia.org/w/index.php?curid=170298\">Iris setosa</a> (by <a href=\"https://commons.wikimedia.org/wiki/User:Radomil\">Radomil</a>, CC BY-SA 3.0), <a href=\"https://commons.wikimedia.org/w/index.php?curid=248095\">Iris versicolor</a>, (by <a href=\"https://commons.wikimedia.org/wiki/User:Dlanglois\">Dlanglois</a>, CC BY-SA 3.0), and <a href=\"https://www.flickr.com/photos/33397993@N05/3352169862\">Iris virginica</a> (by <a href=\"https://www.flickr.com/photos/33397993@N05\">Frank Mayfield</a>, CC BY-SA 2.0).<br/>&nbsp;\n",
+        "  </td></tr>\n",
+        "</table>\n",
+        "\n",
+        "Fortunately, someone has already created a [data set of 120 iris flowers](https://en.wikipedia.org/wiki/Iris_flower_data_set) with the sepal and petal measurements. This is a classic dataset that is popular for beginner machine learning classification problems."
+      ]
     },
-    "colab_type": "code",
-    "id": "-Jzm_GoErz8B",
-    "outputId": "6e84e436-48e9-488b-d955-5b0463f0be33",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "print(\"Prediction: \\(firstTrainPredictions.argmax(squeezingAxis: 1))\")\n",
-    "print(\"    Labels: \\(firstTrainLabels)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Vzq2E5J2QMtw"
-   },
-   "source": [
-    "## Train the model\n",
-    "\n",
-    "*[Training](https://developers.google.com/machine-learning/crash-course/glossary#training)* is the stage of machine learning when the model is gradually optimized, or the model *learns* the dataset. The goal is to learn enough about the structure of the training dataset to make predictions about unseen data. If you learn *too much* about the training dataset, then the predictions only work for the data it has seen and will not be generalizable. This problem is called *[overfitting](https://developers.google.com/machine-learning/crash-course/glossary#overfitting)*—it's like memorizing the answers instead of understanding how to solve a problem.\n",
-    "\n",
-    "The iris classification problem is an example of *[supervised machine learning](https://developers.google.com/machine-learning/glossary/#supervised_machine_learning)*: the model is trained from examples that contain labels. In *[unsupervised machine learning](https://developers.google.com/machine-learning/glossary/#unsupervised_machine_learning)*, the examples don't contain labels. Instead, the model typically finds patterns among the features."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "RaKp8aEjKX6B"
-   },
-   "source": [
-    "### Define the loss and gradient function\n",
-    "\n",
-    "Both training and evaluation stages need to calculate the model's *[loss](https://developers.google.com/machine-learning/crash-course/glossary#loss)*. This measures how off a model's predictions are from the desired label, in other words, how bad the model is performing. We want to minimize, or optimize, this value.\n",
-    "\n",
-    "Our model will calculate its loss using the `softmaxCrossEntropy` function which takes the model's class probability predictions and the desired label, and returns the average loss across the examples."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "rHgwjCKqAWNz",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "%include \"TutorialModelHelpers.swift\"\n",
-    "extension IrisParameters {\n",
-    "  // We declare the loss as \"differentiable\" so that we can differentiate it\n",
-    "  // later while optimizing the model.\n",
-    "  @differentiable(wrt: (self))\n",
-    "  func loss(for input: Tensor<Float>, labels: Tensor<Int32>, in context: Context) -> Tensor<Float> {\n",
-    "      let logits = applied(to: input, in: context)\n",
-    "      return softmaxCrossEntropy(logits: logits, categoricalLabels: labels)\n",
-    "  }\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "9SIHZjYQATyz"
-   },
-   "source": [
-    "Let's calculate the loss for the current untrained model:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 35
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "3Px6KAg0Jowz"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "## Import and parse the training dataset\n",
+        "\n",
+        "Download the dataset file and convert it into a structure that can be used by this Swift program.\n",
+        "\n",
+        "### Download the dataset\n",
+        "\n",
+        "Download the training dataset file from http://download.tensorflow.org/data/iris_training.csv. We use a Python library to demonstrate Swift's Python interoperability. Swift's Python interoperability makes it easy and natural to import and use Python libraries from Swift code."
+      ]
     },
-    "colab_type": "code",
-    "id": "tMAT4DcMPwI-",
-    "outputId": "1a99433c-2560-427b-ad32-9f79265dd8fd",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "print(\"Loss test: \\(model.loss(for: firstTrainFeatures, labels: firstTrainLabels, in: inferenceContext))\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "lOxFimtlKruu"
-   },
-   "source": [
-    "### Create an optimizer\n",
-    "\n",
-    "An *[optimizer](https://developers.google.com/machine-learning/crash-course/glossary#optimizer)* applies the computed gradients to the model's variables to minimize the `loss` function. You can think of the loss function as a curved surface (see Figure 3) and we want to find its lowest point by walking around. The gradients point in the direction of steepest ascent—so we'll travel the opposite way and move down the hill. By iteratively calculating the loss and gradient for each batch, we'll adjust the model during training. Gradually, the model will find the best combination of weights and bias to minimize loss. And the lower the loss, the better the model's predictions.\n",
-    "\n",
-    "<table>\n",
-    "  <tr><td>\n",
-    "    <img src=\"https://cs231n.github.io/assets/nn3/opt1.gif\" width=\"70%\"\n",
-    "         alt=\"Optimization algorithms visualized over time in 3D space.\">\n",
-    "  </td></tr>\n",
-    "  <tr><td align=\"center\">\n",
-    "    <b>Figure 3.</b> Optimization algorithms visualized over time in 3D space.<br/>(Source: <a href=\"http://cs231n.github.io/neural-networks-3/\">Stanford class CS231n</a>, MIT License, Image credit: <a href=\"https://twitter.com/alecrad\">Alec Radford</a>)\n",
-    "  </td></tr>\n",
-    "</table>\n",
-    "\n",
-    "Swift for TensorFlow has many [optimization algorithms](https://github.com/rxwei/DeepLearning/blob/master/Sources/DeepLearning/Optimizer.swift) available for training. This model uses the SGD optimizer that implements the *[stochastic gradient descent](https://developers.google.com/machine-learning/crash-course/glossary#gradient_descent)* (SGD) algorithm. The `learning_rate` sets the step size to take for each iteration down the hill. This is a *hyperparameter* that you'll commonly adjust to achieve better results."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "8xxi2NNGKwG_",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "let optimizer: SGD<IrisParameters, Float> = SGD(learningRate: 0.001)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "pJVRZ0hP52ZB"
-   },
-   "source": [
-    "We'll use this to calculate a single gradient descent step:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 35
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "DKkgac4WO0mP",
+        "outputId": "3b49299f-ee97-4cbe-ab6c-28dd4de4b60b",
+        "scrolled": true,
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "let urllib = Python.import(\"urllib.request\")\n",
+        "let downloadResult = urllib.urlretrieve(\"http://download.tensorflow.org/data/iris_training.csv\",\n",
+        "                                        \"iris_training.csv\")\n",
+        "let trainDataFilename = String(downloadResult[0])!\n",
+        "trainDataFilename"
+      ],
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "\"iris_training.csv\"\n"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 3
+        }
+      ]
     },
-    "colab_type": "code",
-    "id": "rxRNTFVe56RG",
-    "outputId": "f25ee2d8-1cd6-4cb2-e37b-c95f387136d6",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "let trainingContext = Context(learningPhase: .training)\n",
-    "let (loss, grads) = valueWithGradient(at: model) { model in\n",
-    "  model.loss(for: firstTrainFeatures,labels: firstTrainLabels, in: trainingContext)\n",
-    "}\n",
-    "print(\"Initial Loss: \\(loss)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "5B27cIT0O0nE"
-   },
-   "source": [
-    "We call the `model.update(withGradients:)` method to iterate over all the model parameters and apply gradient descent to them, where `param` is the parameter and where `grad` is the gradient along that parameter."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 35
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "qnX1-aLors4S"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Inspect the data\n",
+        "\n",
+        "This dataset, `iris_training.csv`, is a plain text file that stores tabular data formatted as comma-separated values (CSV). Let's look a the first 5 entries."
+      ]
     },
-    "colab_type": "code",
-    "id": "icyvh-o6O0nF",
-    "outputId": "356105be-0d10-486d-b7f3-e33963b87ffb",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "optimizer.update(&model.allDifferentiableVariables, along: grads)\n",
-    "print(\"Next Loss: \\(model.loss(for: firstTrainFeatures, labels: firstTrainLabels, in: trainingContext))\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "nhpgM7UpO0nG"
-   },
-   "source": [
-    "If you run the above two steps repeatedly, you should expect the loss to go down gradually."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "7Y2VSELvwAvW"
-   },
-   "source": [
-    "### Training loop\n",
-    "\n",
-    "With all the pieces in place, the model is ready for training! A training loop feeds the dataset examples into the model to help it make better predictions. The following code block sets up these training steps:\n",
-    "\n",
-    "1. Iterate each *epoch*. An epoch is one pass through the dataset.\n",
-    "2. Within an epoch, iterate over each example in the training `Dataset` grabbing its *features* (`x`) and *label* (`y`).\n",
-    "3. Using the example's features, make a prediction and compare it with the label. Measure the inaccuracy of the prediction and use that to calculate the model's loss and gradients.\n",
-    "4. Use gradient descent to update the model's variables.\n",
-    "5. Keep track of some stats for visualization.\n",
-    "6. Repeat for each epoch.\n",
-    "\n",
-    "The `numEpochs` variable is the number of times to loop over the dataset collection. Counter-intuitively, training a model longer does not guarantee a better model. `numEpochs` is a *[hyperparameter](https://developers.google.com/machine-learning/glossary/#hyperparameter)* that you can tune. Choosing the right number usually requires both experience and experimentation."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "AIgulGRUhpto",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "let numEpochs = 501\n",
-    "var trainAccuracyResults: [Float] = []\n",
-    "var trainLossResults: [Float] = []"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 215
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "FQvb_JYdrpPm",
+        "outputId": "4ca91888-7474-4a5c-bcc9-f80c693c0d5a",
+        "scrolled": true,
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 119
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "let f = Python.open(trainDataFilename)\n",
+        "for _ in 0..<5 {\n",
+        "    print(Python.next(f).strip())\n",
+        "}\n",
+        "f.close()"
+      ],
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "120,4,setosa,versicolor,virginica\r\n",
+            "6.4,2.8,5.6,2.2,2\r\n",
+            "5.0,2.3,3.3,1.0,1\r\n",
+            "4.9,2.5,4.5,1.7,2\r\n",
+            "4.9,3.1,1.5,0.1,0\r\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "None\n"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 4
+        }
+      ]
     },
-    "colab_type": "code",
-    "id": "066kVZQFO0nL",
-    "outputId": "bd7a5c12-7872-400e-e10d-56596ace23d1",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "func accuracy(predictions: Tensor<Int32>, truths: Tensor<Int32>) -> Float {\n",
-    "    return Tensor<Float>(predictions .== truths).mean().scalar!\n",
-    "}\n",
-    "\n",
-    "for epoch in 0..<numEpochs {\n",
-    "    var epochLoss: Float = 0\n",
-    "    var epochAccuracy: Float = 0\n",
-    "    var batchCount: Int = 0\n",
-    "    for examples in trainDataset {\n",
-    "        let x = examples.first\n",
-    "        let y = examples.second\n",
-    "        let (loss, grad) = valueWithGradient(at: model) { model in\n",
-    "            model.loss(for: firstTrainFeatures, labels: firstTrainLabels, in: trainingContext)\n",
-    "        }\n",
-    "        optimizer.update(&model.allDifferentiableVariables, along: grad)\n",
-    "        \n",
-    "        let logits = model.applied(to: x, in: trainingContext)\n",
-    "        epochAccuracy += accuracy(predictions: logits.argmax(squeezingAxis: 1), truths: y)\n",
-    "        epochLoss += loss.scalar!\n",
-    "        batchCount += 1\n",
-    "    }\n",
-    "    epochAccuracy /= Float(batchCount)\n",
-    "    epochLoss /= Float(batchCount)\n",
-    "    trainAccuracyResults.append(epochAccuracy)\n",
-    "    trainLossResults.append(epochLoss)\n",
-    "    if epoch % 50 == 0 {\n",
-    "        print(\"Epoch \\(epoch): Loss: \\(epochLoss), Accuracy: \\(epochAccuracy)\")\n",
-    "    }\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "2FQHVUnm_rjw"
-   },
-   "source": [
-    "### Visualize the loss function over time"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "j3wdbmtLVTyr"
-   },
-   "source": [
-    "While it's helpful to print out the model's training progress, it's often *more* helpful to see this progress. We can create basic charts using Python's `matplotlib` module.\n",
-    "\n",
-    "Interpreting these charts takes some experience, but you really want to see the *loss* go down and the *accuracy* go up."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 518
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "kQhzD6P-uBoq"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "From this view of the dataset, notice the following:\n",
+        "\n",
+        "1. The first line is a header containing information about the dataset:\n",
+        "  * There are 120 total examples. Each example has four features and one of three possible label names. \n",
+        "2. Subsequent rows are data records, one *[example](https://developers.google.com/machine-learning/glossary/#example)* per line, where:\n",
+        "  * The first four fields are *[features](https://developers.google.com/machine-learning/glossary/#feature)*: these are characteristics of an example. Here, the fields hold float numbers representing flower measurements.\n",
+        "  * The last column is the *[label](https://developers.google.com/machine-learning/glossary/#label)*: this is the value we want to predict. For this dataset, it's an integer value of 0, 1, or 2 that corresponds to a flower name.\n",
+        "\n",
+        "Let's write that out in code:"
+      ]
     },
-    "colab_type": "code",
-    "id": "agjvNd2iUGFn",
-    "outputId": "3d2b60f0-6440-4049-d97e-c55adc28b941",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "plt.figure(figsize: [12, 8])\n",
-    "\n",
-    "let accuracyAxes = plt.subplot(2, 1, 1)\n",
-    "accuracyAxes.set_ylabel(\"Accuracy\")\n",
-    "accuracyAxes.plot(trainAccuracyResults)\n",
-    "\n",
-    "let lossAxes = plt.subplot(2, 1, 2)\n",
-    "lossAxes.set_ylabel(\"Loss\")\n",
-    "lossAxes.set_xlabel(\"Epoch\")\n",
-    "lossAxes.plot(trainLossResults)\n",
-    "\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "axA6WuGVO0nR"
-   },
-   "source": [
-    "Note that the y-axes of the graphs are not zero-based."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Zg8GoMZhLpGH"
-   },
-   "source": [
-    "## Evaluate the model's effectiveness\n",
-    "\n",
-    "Now that the model is trained, we can get some statistics on its performance.\n",
-    "\n",
-    "*Evaluating* means determining how effectively the model makes predictions. To determine the model's effectiveness at iris classification, pass some sepal and petal measurements to the model and ask the model to predict what iris species they represent. Then compare the model's prediction against the actual label.  For example, a model that picked the correct species on half the input examples has an *[accuracy](https://developers.google.com/machine-learning/glossary/#accuracy)* of `0.5`. Figure 4 shows a slightly more effective model, getting 4 out of 5 predictions correct at 80% accuracy:\n",
-    "\n",
-    "<table cellpadding=\"8\" border=\"0\">\n",
-    "  <colgroup>\n",
-    "    <col span=\"4\" >\n",
-    "    <col span=\"1\" bgcolor=\"lightblue\">\n",
-    "    <col span=\"1\" bgcolor=\"lightgreen\">\n",
-    "  </colgroup>\n",
-    "  <tr bgcolor=\"lightgray\">\n",
-    "    <th colspan=\"4\">Example features</th>\n",
-    "    <th colspan=\"1\">Label</th>\n",
-    "    <th colspan=\"1\" >Model prediction</th>\n",
-    "  </tr>\n",
-    "  <tr>\n",
-    "    <td>5.9</td><td>3.0</td><td>4.3</td><td>1.5</td><td align=\"center\">1</td><td align=\"center\">1</td>\n",
-    "  </tr>\n",
-    "  <tr>\n",
-    "    <td>6.9</td><td>3.1</td><td>5.4</td><td>2.1</td><td align=\"center\">2</td><td align=\"center\">2</td>\n",
-    "  </tr>\n",
-    "  <tr>\n",
-    "    <td>5.1</td><td>3.3</td><td>1.7</td><td>0.5</td><td align=\"center\">0</td><td align=\"center\">0</td>\n",
-    "  </tr>\n",
-    "  <tr>\n",
-    "    <td>6.0</td> <td>3.4</td> <td>4.5</td> <td>1.6</td> <td align=\"center\">1</td><td align=\"center\" bgcolor=\"red\">2</td>\n",
-    "  </tr>\n",
-    "  <tr>\n",
-    "    <td>5.5</td><td>2.5</td><td>4.0</td><td>1.3</td><td align=\"center\">1</td><td align=\"center\">1</td>\n",
-    "  </tr>\n",
-    "  <tr><td align=\"center\" colspan=\"6\">\n",
-    "    <b>Figure 4.</b> An iris classifier that is 80% accurate.<br/>&nbsp;\n",
-    "  </td></tr>\n",
-    "</table>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "z-EvK7hGL0d8"
-   },
-   "source": [
-    "### Setup the test dataset\n",
-    "\n",
-    "Evaluating the model is similar to training the model. The biggest difference is the examples come from a separate *[test set](https://developers.google.com/machine-learning/crash-course/glossary#test_set)* rather than the training set. To fairly assess a model's effectiveness, the examples used to evaluate a model must be different from the examples used to train the model.\n",
-    "\n",
-    "The setup for the test `Dataset` is similar to the setup for training `Dataset`. Download the test set from http://download.tensorflow.org/data/iris_training.csv:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 35
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "9Edhevw7exl6",
+        "outputId": "4fd2018f-e0fa-4941-f851-7fab74e0ee8c",
+        "scrolled": true,
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 51
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "let featureNames = [\"sepal_length\", \"sepal_width\", \"petal_length\", \"petal_width\"]\n",
+        "let labelName = \"species\"\n",
+        "let columnNames = featureNames + [labelName]\n",
+        "\n",
+        "print(\"Features: \\(featureNames)\")\n",
+        "print(\"Label: \\(labelName)\")"
+      ],
+      "execution_count": 5,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Features: [\"sepal_length\", \"sepal_width\", \"petal_length\", \"petal_width\"]\r\n",
+            "Label: species\r\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
-    "colab_type": "code",
-    "id": "SRMWCu30bnxH",
-    "outputId": "6147e89c-f209-46eb-f2d4-3aa3c39673bb",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "let urllib = Python.import(\"urllib.request\")\n",
-    "let downloadResult = urllib.urlretrieve(\"http://download.tensorflow.org/data/iris_test.csv\",\n",
-    "                                        \"iris_test.csv\")\n",
-    "let testDataFilename = String(downloadResult[0])!\n",
-    "testDataFilename"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "jEPPL6FUO0nV"
-   },
-   "source": [
-    " Now load it into a `Dataset`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "w6SCt95HO0nW",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "%include \"TutorialDatasetCSVAPI.swift\"\n",
-    "let testDataset: Dataset<TensorPair<Tensor<Float>, Tensor<Int32>>> = Dataset(\n",
-    "    contentsOfCSVFile: testDataFilename, hasHeader: true,\n",
-    "    featureColumns: [0, 1, 2, 3], labelColumns: [4]\n",
-    ").batched(batchSize)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "HFuOKXJdMAdm"
-   },
-   "source": [
-    "### Evaluate the model on the test dataset\n",
-    "\n",
-    "Unlike the training stage, the model only evaluates a single [epoch](https://developers.google.com/machine-learning/glossary/#epoch) of the test data. In the following code cell, we iterate over each example in the test set and compare the model's prediction against the actual label. This is used to measure the model's accuracy across the entire test set."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 35
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "CCtwLoJhhDNc"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "Each label is associated with string name (for example, \"setosa\"), but machine learning typically relies on numeric values. The label numbers are mapped to a named representation, such as:\n",
+        "\n",
+        "* `0`: Iris setosa\n",
+        "* `1`: Iris versicolor\n",
+        "* `2`: Iris virginica\n",
+        "\n",
+        "For more information about features and labels, see the [ML Terminology section of the Machine Learning Crash Course](https://developers.google.com/machine-learning/crash-course/framing/ml-terminology)."
+      ]
     },
-    "colab_type": "code",
-    "id": "Tj4Rs8gwO0nY",
-    "outputId": "d1d6573f-9846-48b4-a917-3a33586db4ee",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "// NOTE: With `batchSize = 32` and 30 examples in the test dataset, only one batch will run in the loop.\n",
-    "for testBatch in testDataset {\n",
-    "    let testFeatures = testBatch.first\n",
-    "    let testLabels = testBatch.second\n",
-    "    let logits = model.applied(to: testFeatures, in: inferenceContext)\n",
-    "    let predictions = logits.argmax(squeezingAxis: 1)\n",
-    "    print(\"Test batch accuracy: \\(accuracy(predictions: predictions, truths: testLabels))\")\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "HcKEZMtCOeK-"
-   },
-   "source": [
-    "We can see on the first batch, for example, the model is usually correct:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 53
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "sVNlJlUOhkoX",
+        "scrolled": true,
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "let classNames = [\"Iris setosa\", \"Iris versicolor\", \"Iris virginica\"]"
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
-    "colab_type": "code",
-    "id": "uNwt2eMeOane",
-    "outputId": "668ea70b-f56f-4642-9547-5f57e3ed1eb8",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "let firstTestBatch = testDataset.first!\n",
-    "let firstTestBatchFeatures = firstTestBatch.first\n",
-    "let firstTestBatchLabels = firstTestBatch.second\n",
-    "let firstTestBatchLogits = model.applied(to: firstTestBatchFeatures, in: inferenceContext)\n",
-    "let firstTestBatchPredictions = firstTestBatchLogits.argmax(squeezingAxis: 1)\n",
-    "\n",
-    "print(firstTestBatchPredictions)\n",
-    "print(firstTestBatchLabels)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "7Li2r1tYvW7S"
-   },
-   "source": [
-    "## Use the trained model to make predictions\n",
-    "\n",
-    "We've trained a model and demonstrated that it's good—but not perfect—at classifying iris species. Now let's use the trained model to make some predictions on [unlabeled examples](https://developers.google.com/machine-learning/glossary/#unlabeled_example); that is, on examples that contain features but not a label.\n",
-    "\n",
-    "In real-life, the unlabeled examples could come from lots of different sources including apps, CSV files, and data feeds. For now, we're going to manually provide three unlabeled examples to predict their labels. Recall, the label numbers are mapped to a named representation as:\n",
-    "\n",
-    "* `0`: Iris setosa\n",
-    "* `1`: Iris versicolor\n",
-    "* `2`: Iris virginica"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 71
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "dqPkQExM2Pwt"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Create a Dataset\n",
+        "\n",
+        "Swift for TensorFlow's Dataset API handles loading data into a model. This is a high-level API for reading data and transforming it into a form used for training. Currently, Swift's Dataset API supports loading data only from CSV files, but we intend to extend it to handle many more types of data, like [TensorFlow's Dataset API](https://www.tensorflow.org/guide/datasets).\n",
+        "\n",
+        "Use the `Dataset(contentsOfCSVFile:hasHeader:featureColumns:labelColumns:)` initializer to initialize a `Dataset` with training data. Also batch the data into batches using the `.batched()` function."
+      ]
     },
-    "colab_type": "code",
-    "id": "MTYOZr27O0ne",
-    "outputId": "2d9c965d-0196-4734-a660-a5590632b9c4",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "let unlabeledDataset: Tensor<Float> =\n",
-    "    [[5.1, 3.3, 1.7, 0.5],\n",
-    "     [5.9, 3.0, 4.2, 1.5],\n",
-    "     [6.9, 3.1, 5.4, 2.1]]\n",
-    "\n",
-    "let unlabeledDatasetPredictions = model.applied(to: unlabeledDataset, in: inferenceContext)\n",
-    "\n",
-    "for i in 0..<unlabeledDatasetPredictions.shape[0] {\n",
-    "    let logits = unlabeledDatasetPredictions[i]\n",
-    "    let classIdx = logits.argmax().scalar!\n",
-    "    print(\"Example \\(i) prediction: \\(classNames[Int(classIdx)]) (\\(softmax(logits)))\")\n",
-    "}"
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "collapsed_sections": [],
-   "name": "Custom training: walkthrough",
-   "provenance": [],
-   "toc_visible": true,
-   "version": "0.3.2"
-  },
-  "kernelspec": {
-   "display_name": "Swift",
-   "language": "swift",
-   "name": "swift"
-  },
-  "language_info": {
-   "file_extension": ".swift",
-   "mimetype": "text/x-swift",
-   "name": "swift",
-   "version": ""
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 1
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "bBx_C6UWO0mc",
+        "scrolled": true,
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "public let batchSize = Int64(32)\n",
+        "\n",
+        "%include \"TutorialDatasetCSVAPI.swift\"\n",
+        "\n",
+        "let trainDataset: Dataset<TensorPair<Tensor<Float>, Tensor<Int32>>> = Dataset(\n",
+        "    contentsOfCSVFile: trainDataFilename, hasHeader: true,\n",
+        "    featureColumns: [0, 1, 2, 3], labelColumns: [4]\n",
+        ").batched(batchSize)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "gB_RSn62c-3G"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "This returns a `Dataset` of `(features, labels)` pairs, where `feature` is a `Tensor<Float>` with shape `(batchSize, featureColumns.count)` and where `labels` is a `Tensor<Int32>` with shape `(batchSize, labelColumns.count)`\n",
+        "\n",
+        "These `Dataset` values are iterable. Let's look at the first element of the dataset."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "iDuG94H-C122",
+        "outputId": "d9c83db7-7071-4128-87d7-55fb9815c853",
+        "scrolled": true,
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 54
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "let firstTrainExamples = trainDataset.first!\n",
+        "let firstTrainFeatures = firstTrainExamples.first\n",
+        "let firstTrainLabels = firstTrainExamples.second\n",
+        "firstTrainFeatures"
+      ],
+      "execution_count": 8,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[[6.4, 2.8, 5.6, 2.2], [5.0, 2.3, 3.3, 1.0], [4.9, 2.5, 4.5, 1.7], [4.9, 3.1, 1.5, 0.1], [5.7, 3.8, 1.7, 0.3], [4.4, 3.2, 1.3, 0.2], [5.4, 3.4, 1.5, 0.4], [6.9, 3.1, 5.1, 2.3], [6.7, 3.1, 4.4, 1.4], [5.1, 3.7, 1.5, 0.4], [5.2, 2.7, 3.9, 1.4], [6.9, 3.1, 4.9, 1.5], [5.8, 4.0, 1.2, 0.2], [5.4, 3.9, 1.7, 0.4], [7.7, 3.8, 6.7, 2.2], [6.3, 3.3, 4.7, 1.6], [6.8, 3.2, 5.9, 2.3], [7.6, 3.0, 6.6, 2.1], [6.4, 3.2, 5.3, 2.3], [5.7, 4.4, 1.5, 0.4], [6.7, 3.3, 5.7, 2.1], [6.4, 2.8, 5.6, 2.1], [5.4, 3.9, 1.3, 0.4], [6.1, 2.6, 5.6, 1.4], [7.2, 3.0, 5.8, 1.6], [5.2, 3.5, 1.5, 0.2], [5.8, 2.6, 4.0, 1.2], [5.9, 3.0, 5.1, 1.8], [5.4, 3.0, 4.5, 1.5], [6.7, 3.0, 5.0, 1.7], [6.3, 2.3, 4.4, 1.3], [5.1, 2.5, 3.0, 1.1]]\n"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 8
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "E63mArnQaAGz"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "Notice that like-features are grouped together, or *batched*. Each example row's fields are appended to the corresponding feature array. Change the `batchSize` to set the number of examples stored in these feature arrays.\n",
+        "\n",
+        "You can start to see some clusters by plotting a few features from the batch, using Python's matplotlib:"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "me5Wn-9FcyyO",
+        "outputId": "884948e1-4e69-439e-9913-37cda4d4e902",
+        "scrolled": false,
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 300
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "let firstTrainFeaturesTransposed = firstTrainFeatures.transposed()\n",
+        "let petalLengths = firstTrainFeaturesTransposed[3].scalars\n",
+        "let sepalLengths = firstTrainFeaturesTransposed[0].scalars\n",
+        "\n",
+        "plt.scatter(petalLengths, sepalLengths, c: firstTrainLabels.array.scalars)\n",
+        "plt.xlabel(\"Petal length\")\n",
+        "plt.ylabel(\"Sepal length\")\n",
+        "plt.show()"
+      ],
+      "execution_count": 9,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEKCAYAAAD9xUlFAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAIABJREFUeJzt3Xl8XHW9//HXZ7ZkkjZdIwW6AYVi\nQVpK2BfZpYDsSwHZFJCrgqByL3q9iCiuXBfkp4gsipdF2REBAZFFFCSFUqBsBYq0FJruS9aZfH5/\nzOk0yySZtjlzsryfj0cenTnnzDnvnCb5zJzv93y/5u6IiIgAxKIOICIifYeKgoiI5KkoiIhInoqC\niIjkqSiIiEieioKIiOSpKIiISJ6KgoiI5KkoiIhIXiLqABtq9OjRPnHixKhjiIj0K7NmzVri7tU9\nbdfvisLEiROpra2NOoaISL9iZu8Vs50uH4mISJ6KgoiI5KkoiIhInoqCiIjkqSiIiEhev+t9JCLS\nH3lmPjQ/AzYUyg7EYkOijlSQioKISIjcHV/9A6i/FTAgBnYZjPgNlto16nid6PKRiEiYmv8BDbcD\nTUAjUA9ejy8/H/fmiMN1pqIgIhIib7gTvKHQGmh+vuR5eqKiICISpu4+DeiTgojI4GLpo4B05xWe\nhdTuJc/TEzU0i4hsAM9+BI1/AW+Esv2x5Hbdv6DsECjbO9e24PVAEojDsO9hsYpSRN4gKgoiIkVq\nbXgQVv5X8CwLa67BK04lVnVpl68xi8Hw/wfNz+JNfwOrwtJHY4lxpQm9gVQURESK4K2rgoLQ1GZp\nBhpuw8sPwVK7dPlaM4OyPbGyPUPPuanUpiAiUoymp8AKvI/2RrzhT6XPExIVBRERyVNREBEpRtm+\n4JnOy60cSx9Z+jwhCa0omNlkM5vd5muVmV3UYZv9zWxlm20uCyuPiMimsNgwGPZ9oCz4igPlkJ6J\npWqiDdeLQmtodvc3gGkAZhYHFgL3FNj0aXcfOGVWRAasWPpIPFUDjQ8HXVIPwJKTo47Vq0rV++gg\n4G13L2qOUBGRvsriY6DyrKhjhKZUbQozgdu6WLenmb1kZg+Z2Q4lyiMiIgWEXhTMLAUcBdxRYPUL\nwAR3nwr8Ari3i32cZ2a1ZlZbV1cXXlgRkUGuFJ8UZgAvuPtHHVe4+yp3XxM8fhBImtnoAttd5+41\n7l5TXV0dfmIRkUGqFEXhFLq4dGRmY8zMgse7BXmWliCTiIgUEGpDs5lVAocAn2+z7HwAd78WOAH4\nDzPLAA3ATHf3MDOJiEjXQi0K7r4WGNVh2bVtHl8DXBNmBhERKZ7uaBYRkTwVBRERyVNREBGRPBUF\nERHJU1EQEZE8FQUREclTURARkTwVBRERyVNREBGRvFLNpyAi/ZBn3sPX3gAtr0FyClb5OSwxPupY\nEiIVBREpyFtexpedDt4EZCHzKt54H4y8FUtOiTqehESXj0SkIF/1bfB6IBssyYDX46u+E2UsCZmK\ngoh04u7Q8nLhlS2zSxtGSkpFQUQ6MTOwii5WVpY2jJSUioKIFJaeCZR3WFgOFadGkUZKREVBRAqy\noRdD+YFAGdhQIAXlh2BDLog6moRIvY9EpCCzFDb8Z3j2Q8jMh8RELD4m6lgSMhUFEemWxceAisGg\noctHIiKSp6IgIiJ5KgoiIpIXWlEws8lmNrvN1yozu6jDNmZmV5vZPDObY2bTw8ojIiI9C62h2d3f\nAKYBmFkcWAjc02GzGcC2wdfuwK+Cf0VEJAKlunx0EPC2u7/XYfnRwM2e8yww3Mw2L1EmERHpoFRF\nYSZwW4HlWwLvt3m+IFgmIiIRCL0omFkKOAq4YxP2cZ6Z1ZpZbV1dXe+FExGRdkrxSWEG8IK7f1Rg\n3UJgXJvnY4Nl7bj7de5e4+411dXVIcUUEZFS3NF8CoUvHQHcD3zJzG4n18C80t0XlSCTyKAyf8Vy\nfvjMU/xzwfsMTZXx2WnTOXPadGJmUUeTbnjz8/jqH0NmHsTHYkMuwsoPDPWYoRYFM6sEDgE+32bZ\n+QDufi3wIHA4MA+oB84OM4/IYPThmtUcc/strGlpptWdVU1NXPXPv/POiuV854CDo44nXfCmZ/Hl\n5wGNuQWZ1/EVF+HDriSW/nRoxw318pG7r3X3Ue6+ss2ya4OCQNDr6Ivuvo27f8Lda8PMIzIY3fDi\nLBoyLbS655c1ZDLcMfcV6urXRphMuuOrf0i+IOQ1wuof5SZBConuaBYZ4GYt+oCW1tZOy8viceYt\nXRpBIilK5u3Cy1uXAE2hHVZFQWSAmzRiJPECbQfN2VbGVg2LIJEUJf6xwsutAkiFdlgVBZEB7pzp\nNaTi8XbLUvE4e4wdy7hhKgp9VuWFQLrDwjRUnotZeH+6VRREBrjtRo3mN58+lgnDhpOMxUjF4xyx\n7WSumRFeY6VsuljFUZA+hvV/pg3K9sUqP9/dyzaZJtkRGQT2Gjeex8/4LKuamihPJChL6Fe/r/Om\nJ6HhHmBde5BD01N4wx+xipNDO64+KYgMEmbGsPJyFYR+wldfRcHeR2t+pt5HIiKDTqbj+KGB1hV0\nLha9R0VBRKQvim9ReLkNBcpDO6yKgkg/1OpOtsC9B32Ju5Pp4xk3lnsr7tlQj2FDv0LnP/5pGPJF\nLMThSXRxUaQfWVJfzzcff5TH579Dqzt7jRvP9w48pE/db9CYaeHKp5/kzrmv0pzNMKX6Y3z3gIOZ\nOqb/T5XirSvxVd+Gxr8AWTy5CzbsO1hi614/lpUfig/7Hqz+MbQuAhsJQ76EVZzW68dqd9wwGyzC\nUFNT47W1Gg1DBp9saysH//4mFq5elX8HHjNjRHmaJ886h4pkMuKEOefcfw/PvP8eTdn176Qrkkn+\nfMoZTBg+PMJkm8bd8aXHQuYtoCVYamBDserHsFh435t7BrNNew9vZrPcvaan7XT5SKSfePK9+Syp\nX9vukkyrOw0tLTzw5usRJlvv/ZUreeb9f7crCADNmQw3zp4VUape0vICZOezviAAOHgzXn9XqIfe\n1IKwIVQURPqJd1csLziGUX2mhXnL+sYYRvNXLCcV7/xnJePOa0v6+QRZmXeh4IWVRsi8Ueo0oVFR\nEOknths1imSs869sRTLJlOouxskpsW1GjqQ527kBNhmLMXWzMREk6kWJbSlYFSwNyU+UPE5YVBRE\n+om9x01gXNUwkrH14xglzBheVs6MSdtFmGy9LYZW8alttqW8zQ1yBpQlEpw9bXp0wXpDcidITqH9\nYHQxII2lj4koVO9TURDpJ2Jm3H7CTI77+BQqkynSiQQztp3MPSef1qfuUv7xIYdx7vQaRpSnScXj\n7DVuPHedeCpbDK2KOtomMTNsxA1QcfL6ewXKDsJG343FhkYdr9eo95GIyCCg3kciIrLBVBRERCRP\nRUFERPJUFEREJC/UomBmw83sTjN73cxeM7M9O6zf38xWmtns4OuyMPOIiEj3euzHZmZ7A5cDE4Lt\nDXB3L2YEqJ8DD7v7CWaWAioKbPO0ux9ZfGQREQlLMZ2bbwAuBmYBRY8Va2bDgP2AswDcvRlo3vCI\nIiJSKsVcPlrp7g+5+2J3X7ruq4jXbQXUATeZ2Ytmdr2ZVRbYbk8ze8nMHjKzHQrtyMzOM7NaM6ut\nq+vn46eIiPRhXRYFM5tuZtOBv5nZj81sz3XLguU9SQDTgV+5+87AWuDSDtu8AExw96nAL4B7C+3I\n3a9z9xp3r6muri7m+xIRkY3Q3eWj/+3wvO2dcA4c2MO+FwAL3P254PmddCgK7r6qzeMHzeyXZjba\n3Zf0sG8Rkch4Zj54IyS2xSze4/YA7i25uRhsCJYYX/yxWldD9j2Ib4HFRm5k4uJ1WRTc/QAAM9va\n3d9pu87MemxkdvcPzex9M5vs7m8ABwFzO+xnDPCRu7uZ7Ubuk0vfGANYRKQDz7yLL/8CZBeCxYBy\nGH4VVrZPt69rbXgEVn0DyIJn8cTW2IhfYl3Nw0ww5efqH0L9rWDJ3LwN5Ydjw75Lrt9OOIppU7iz\nwLI7itz/BcAtZjYHmAZ8z8zON7Pzg/UnAK+Y2UvA1cBM72+DMYnIoOCewZd9BrLvAI3g9eDL8OVf\nxLMLu35dy5uw8mvgq8DX5l6beR1fdhbd/bnz+t9B/e1AE/gaoBkaH8ZXX9Xb31o7XX5SMLPtgR2A\nYWZ2XJtVVXSeTbogd59N+8tOANe2WX8NcE3RaUVEotL8TK4QdJpTIYPX34ENvajgy7z+Fjp3vGyF\n1sXQ8hKkphU+3tobgYYOCxuh/nZ86KWYhXObWXdtCpOBI4HhwKfbLF8NnBtKGhGRviq7hMJTr7VA\n66JuXrcI6DxjHsSgtZvelK0ru1ixrnd/Ue/NN1h3bQr3AfeZ2Z7u/s9Qji4i0l+kpoMXulWrAkt1\n06ZQti80P0end/3eDMmp3RxvavC6DuLjMQunIEBxN6+damandFi2EqgNCoeIbKS3ly1l8dq1fLy6\nmuHl6ajjFPTB6lXMX7GCrYaPYPOhA2cymQ1lia3w9JHQ+CD4uj/wZZAYB+Wf6vp16eNy7QPZD8lf\nRrI0pE/F4l1Po2pDv44vOzXXy4lWcoNJlGNV3+ql76iwYopCGbA96xuXjwfeBaaa2QHuXvhCmoh0\naVlDPef+6V5eW1JHMhanOZvh3Om7cvEee2FmUccDoCmT4auPPMRf332bVDxOczbLodtM4qpDZpCM\nF9cNc6CxqishtTtef2uuMJQfiVWc3m1vIItVwqh78LW/hcaHIVaFVZ4JZV0XEgBLToFRd+Nrfg0t\ncyAxCRtyPpYseI9vr+lx5jUzexbY2z33ucnMEsDTwD7Ay+4+JdSEHWjmNRkIPnP3HTz/wQJaWtdf\na04nkvzo4E9xxHaTI0y23veefoL/e/klGjOZ/LLyeG6u5Uv23jfCZLIxenPmtRHAkDbPK4GRQZFo\n2sh8IoNW3dq11C5a2K4gADRkWrj+xb7zhue2V+a0KwgAjdkMt7zyUkSJpBSKuXz0I2C2mT1B7qLW\nfuTuN6gEHgsxm8iAtKqpkUQsRnO2c6Pl8sbGCBJ15u7Ut7QUXLe2WeNaDmQ9FgV3v8HMHgR2CxZ9\nw90/CB5fEloykQFqwvARpGJx6mn/RzcZi3HAxK0iStWemTF1szHM/ujDTuumb971XbjS/xV790OM\n3Iiny4FJZrZfeJFEBrZELMZ3DzyYdCLBuiblsnicYeXlfKFm90iztXX5/gdRkUySCBq+E7EYFckk\n3/pkT8OeSX9WzCQ7PwROBl5l/R0YDjwVYi6RAe3wbScztmoYN744iwWrV7HPuAmcMXUaI9OF5qGK\nxk6bjeHPp5zB9S/WMrduMTt+bDPO2bmGccOGRR1NQlRM76M3gJ3cvU80Kqv3kYjIhuvN3kfvAMlN\njyQiIn1dMb2P6sn1PvorbbqguvuFoaUSEZFIFFMU7g++RERkgCumS+rvzCwNjA8myxGRCHnrGmh6\nCshC2b5YbHjUkWQAKab30aeBq4AUsJWZTQOucPejwg4nIu154+P4iotzs345QAavupxYxfFRR5MB\nopiG5svJ3bi2AvIT5/Q4HaeI9C5vXY6vuAhoCGbwWgs0warL8cy/I04nA0UxRaHF3TvO9lBoxggR\nCVPjY1BwBNUs3vhAyePIwFRMQ/OrZnYqEDezbYELgX+EG0tEOvFG8ELvx7LBNJEim66YTwoXkJur\nuQm4DVgFaA4FkVIr+2Th5VaOlR1c2iwyYPVYFNy93t3/2913dfea4HFRQzma2XAzu9PMXjez18xs\nzw7rzcyuNrN5ZjbHzKZv7DciMtBZYjxUngOkyf3qWm4Gr/Iju5/WUWQDdHn5yMz+ROFZqgEosvfR\nz4GH3f0Ey01N1HFglxnAtsHX7sCvgn9FpIDY0C/jZfvjDfcCGaz8CEjt3mdma5P+r7s2has2Zcdm\nNozc3AtnAbh7M/kJSvOOBm723ABMzwafLDZ390WbcmyRgcxSU7GUPhlIOLosCu7+5Cbueytyw23f\nZGZTgVnAl919bZtttgTeb/N8QbBMRUFEJALFzqewMRLAdOBX7r4zuU7Vl27MjszsPDOrNbPaurq6\n3swoIiJthFkUFgAL3P254Pmd5IpEWwuBcW2ejw2WtePu1wWN3DXV1dWhhBURkRCLgrt/CLxvZpOD\nRQcBcztsdj9wRtALaQ9gpdoTRAYvb3kLX3MtvvYGPLMg6jiDUti9jy4Abgl6Hr0DnG1m5wevvxZ4\nEDgcmEduiO6zi48uIgNJ6+qfwtobgQwQh9U/w6v+h1jFSVFHG1RC630E+XGSOs70c22b9Q58cVOP\nIyL9m7fMhbU3sX7Klmzun1XfwcsOxOKjo4o26ITZ+0hEpCje+Gc691gHiEHTX6Hi5FJHGrSKGTp7\nW+D7wBSgfN1yd9dIqSLSS7q4+c66WSehKKah+SZydxpngAOAm4H/CzOUiAwuVn4EuSlbOvBWKDuo\n5HkGs2JGSU27+1/NzNz9PeByM5sFXBZytj5h1dLVPHLzEyx65yN22HMy+xy/B6myZNSxpA9pymR4\naN6bvPjhIiYOH86x209heHk66lj9iiU/jg85F9ZcR25k/uD9atW3sfioKKMNOpZr6+1mA7N/APuQ\nu8/gcXL3EfzA3Sd3+8KQ1NTUeG1tbUmONe/Fd/nqAd8i05KluaGZ9JByRm05kl/883sMGV5ZkgzS\nty1vaOC4P95KXf1a6ltaKE8kSMbi/OGEk9l+tO6p2VCeeReaHgcSUP4pLD4m6kgDhpnNcveOHX86\nKeby0ZfJDWR3IbALcDpw5qbF6x++/5mrqV/VQHNDrgGsYU0jH81fzK3fuyviZNJX/OTZZ/hg9Srq\nW1oAaMxkWN3cxCWPPhxxsv7JElthlZ/DKs9UQYhIMUNnP+/ua8jNo3Chux/n7s+GHy1ayz5czqJ3\nPuq0vKUpw99ufyaCRNIXPTzvLVpaO0988+bSJaxsLGqEeZE+pceiYGY1ZvYyMAd42cxeMrNdwo8W\nrXgiTlf37iWSxTTFyGCQiBX+FXIg3sU6kb6smJ/aG4EvuPtEd59I7mazm0JN1QcMG13FpOlbE4u3\nP0WpdIoZ56g3hOScOGUHyuLxdsviZuy6xZYMSRXoTSPSxxXzljfr7k+ve+LufzezTIiZ+oz/vvUi\nLtr3m6xdWU+2pZVY3Nhhr8mc+NVP9/ja1557i7/c9DeaGpr45Il7sdvhOxPr4Z1jNpPl7/f8i3/c\n9y+qRg7l8HMPYqtPTOitb0dC8MVd9+D5Dxby8uKPyLY6iViM4eXlXHXIjKijiWyUYnof/Yzc/H+3\nkftUfDLQSHCvgru/EHLGdkrZ+whyf6iff3g2i/+9hMm7bsPkXSf1+JrbfnAPt3z3TpobW/BWp7yy\njF0P25n/+eNXupwhK9OS4T8P+Q5vzXqbxrVNxOIxkqkEX7rmcxx29oG9/W1JL3J3Zn+4iFfqFjO2\nqor9xk/UpSPpc4rtfVRMUfhbN6vd3Uv6F6vURWFDLVm4lDO3vYDmxpZ2y8sry/jWXZdQc2jhGbMe\n/f2TXP2F39C4tqnd8rJ0ij9+eD0VQ9XvXUQ2XrFFocfLR+5+QO9EGhxqH5nTqR0CoHFtE8/c81yX\nReGJP/yjU0EAiCfjvPz0a+x+eMepKEREel8xvY82M7MbzOyh4PkUM/tc+NH6p3RlGRbrfIkoFo+R\nHlpe4BU5FVVdfBLw3KcMEZFSKObC52+BvwBbBM/fBC4KK1B/t9sR0wv2ZE2mEhx6Ztcfuo487xDK\nKjr/8U+lU+y4z/a9GVFEpEvFFIXR7v5HcgOS4O4Z8oOdS0fpynK+c/+lpIemqahKkx5aTrI8yfk/\nPYuJO4zr8nVT99+Bmf91NMmyJOmh5VRUpakaNZTvP/TfxDt0eRQRCUsxXVLXmtkogve/66bNDDVV\nPzd1/x2448PfMOuROTQ3NjP94J2oGjW0x9d95n9OZMY5B/PSE69SOayCXQ7ZSTfKiUhJFdP7aDrw\nC2BH4BWgGjjB3eeEH6+zvt77SESkL+rN3kcvmNkngcnkZrt4w91beniZiIj0Q122KZjZrmY2BvLt\nCLsAVwL/a2YjS5RPRERKqLuG5l8TTJpqZvsBPyA369pK4Lrwo4mISKl1d/ko7u7LgscnA9e5+13A\nXWY2u5idm9l8YDW53kqZjtezzGx/4D7g3WDR3e5+RfHxRUSkN3VbFMwsEVw6Ogg4r8jXdXSAuy/p\nZv3T7n7kBuxPRERC0t0f99uAJ81sCdAAPA1gZpNQl1QRkQGpyzYFd78S+Cq5O5r38fV9V2PABUXu\n34FHzGyWmZ3XxTZ7BhP3PGRmOxS5XxERCUG3l4EKTbvp7m9uwP73cfeFZvYx4FEze93dn2qz/gVg\ngruvMbPDgXuBbTvuJCgo5wGMHz9+Aw4vIiIbItRB3919YfDvYuAeYLcO61cF8z/j7g8CSTMbXWA/\n17l7jbvXVFdXhxlZRGRQC20MBTOrBGLuvjp4fChwRYdtxgAfubub2W7kitTSsDL1dW/MmsdlR/2I\nZYuWYzFj+sE7ceWfv66xj2STLamv59ra53hi/ruMSKf53M41HDap04dykfCKArAZcE8w01gCuNXd\nHzaz8wHc/VrgBOA/guk9G4CZbdouBpX3XlvAl3b9ev65tzqzHnmJmWM/zx2Lro8wmfR3yxsaOPLW\nm1ne2EBLayusWM7cugd5c+muXLj7XlHHkz4mtKLg7u8AnWaUCYrBusfXANeElaE/ueLE/y24fMVH\nK3nx8TnsfOBOJU4kA8VvX3qBlU2NuYIQaMhk+FXtvzhr2nSqyrqe50MGH00k20csfHNRl+se+PVj\nJUwiA83f//0eTdnOo92n4nFeXbw4gkTSl6ko9BHdza42YcrYEiaRgWaLoVV0ngsQWlpb2WzIkJLn\nkb5NRaGPOOPyEwuvMDjtm8eXNowMKJ/beRfKE+2vFCdiMbYfNZqtR2hsS2lPRaGPOO7LR7L3se16\n7GIx48oHNfOabJppYzbn+wcdSlWqjMpkkrJ4nF0234LffPrYqKNJH9TjJDt9zUCfZKdhTQMP3/QE\nm00YxV5H7dbzC0SK1JLN8s6K5QwvK9dlo0Go1ybZkdJKD0lz7AUzoo4hA1AyHmfyqE73hoq0o8tH\nIiKSp6IgIiJ5KgoiIpKnNoUePPr7J7nlu3exbNFyJu28Fef+6HQ+vrvGjJForG1u5ifPPsN9b7xG\nttU5bNK2/Ode+zIinY46mgwQ6n3UjTt/+gC//Z/baapvyi8rq0jxkyevYLtdtilJBpF13J1j/nAL\nbyxdQnNwh3IiFmPLoVU8fNqZlCX0Hk+6VmzvI10+6kKmJcPvv/3HdgUBoKm+mZu+eXtEqWQwe3bB\n+7y9fFm+IABkWltZUr+Wv7z9VoTJZCBRUejCskXLyWZaC657e/a7JU4jAnOX1JFp7fwzubalRWMY\nSa9RUejCsOoq6OLS2uZbb1biNCIwYdgwkrHOd7dXJJJsNWJEBIlkIFJR6EJZuowjP38IZRWp9ssr\nUpz+rZMiSiWD2f4Tt2Z4eTlxWz+8nQGpRJwjt9s+umAyoKgodOPcH5/OsRccTnllGfFknFGbj+Br\nN36BmkM7TRPRK96b+z6XHPxtDiubydHDz+DXl9xMc1NLKMeSzt5bsYKz77ubydf8lB1/dTWX/e0x\n6lv6zvlPxGLcceJM9ho3nkQsRiIWY/rmW3DniacwJJXqeQciRVDvoyJkM1ka1zZSUVWBWaFBiDfd\nkg+Wcc4OF1O/qj5/1SpVnmSXQ6ZyxX3/FcoxZb0VjQ0cePONrGpqojX4D0jF40zdbAx/OGFmxOk6\na8y00OpQkUxGHUX6CfU+6kXxRJzKYZWhFQSA+//fwzQ3NLdrxmhubGHWY3NYOK/rCXikd9zx6is0\ntmTyBQGgOZvllcWLeXnxRxEmK6w8kVRBkFCoKPQRb9S+TUtzptPyRCrBe3MXRJBocHml7iMas53P\nvxnMW7o0gkQi0VBR6CMmTduKRKrzzUfZ5gzjt98ygkSDy8dHf6zTRDSQ64C29UhNRCODh4pCH3HM\nBTNIlrW/HJAsT7LTJ6cwdrstIkrVv2VbW9vd6NWdk3bYkbJ4vN20lal4nMmjR7PTx9QFWQaPUIuC\nmc03s5fNbLaZdWodtpyrzWyemc0xs+lh5unLqseO4mdPf4cd9t4eixllFWXM+OyBfOuur0Udrd9Z\n3dTEVx95iCm//DlTfvlzjrn9Fl6r6/7mrpHpCu466VT2GDuOmBmpeJyjJ3+cm485IdS2JJG+JtTe\nR2Y2H6hx9yVdrD8cuAA4HNgd+Lm7797dPgf6zGuQG+NGf4g23ol33MbLiz9q9ymhMpnisdPPLmrG\nsXW/E/o/kIGkv/Q+Ohq42XOeBYab2eYRZ4qc/hhtvLl1i5lbt7jTZaOW1iy3vDy7qH2Ymf4PZNAK\nuyg48IiZzTKz8wqs3xJ4v83zBcGydszsPDOrNbPaurq6kKLKQDB/xXLi1vnHujmb5fWlBT+wikgb\nYReFfdx9OjAD+KKZ7bcxO3H369y9xt1rqqurezehDCjbjRpNxjsPGlcWTzB1szERJBLpX0ItCu6+\nMPh3MXAPsFuHTRYC49o8HxssC0VrayvLPlxOc2NzWIeQiE0aOYo9x46jLL5+4LiYGelkglN23CnC\nZIOPt9bj2aX0t1ETBrvQioKZVZrZ0HWPgUOBVzpsdj9wRtALaQ9gpbuHcvvuY7c8xUmbn8vpW3+R\nY0edzS8uuJ5MS+eblaT/++XhR/HZabswojxNOpHgoK224d6TT2NkuiLqaIOCt66hdfmF+OLd8LpP\n4ksOwpv+EXUsKVJovY/MbGtynw4gN+3nre5+pZmdD+Du11quNe8a4DCgHjjb3bvtWrQxvY+e/8ts\nvn38j2mqX/8JoSyd4uDT9+Oiaz+/QfsSke61Lv0MtMwG2n4iT2Oj78ISk6KKNegV2/toUAyId9G+\n3+TVZ97otDxVnuTOxTeQHqL5bUV6g2fexZccDTR2WBOH9HHEhl0ZRSyh/3RJLYkP3y3cYykWj7Fi\n8aoSpxEZwLILwQoN1JeFjGYs7A8GRVHYfrdJBfudx+IxRo/VuDYivSYxGbxQR44UpHYteRzZcIOi\nKJz57ZMoq0jRti6UV5Rx5hVego6MAAAIZ0lEQVQnk0xp+GGR3mLxakgfC7S9JBsDq8AqTo8qlmyA\nQVEUtvrEBH729++y62E7M3TUELb6xHi+duMXOO7CI6KOJjLgWNXlMPQSiI8HGwHlR2Cj7sbio6OO\nJkUYFA3NIiKDnRqaRURkg6koiIhInoqCiIjkqSiIiEieioKIiOSpKIiISJ6KgoiI5KkoiIhInoqC\niIjkqSiIiEieioKIiOSpKIiISJ6KgoiI5KkoiIhInoqCiIjkhV4UzCxuZi+a2QMF1p1lZnVmNjv4\nOifsPCIi0rVECY7xZeA1oKqL9X9w9y+VIIeIiPQg1E8KZjYWOAK4PszjiIhI7wj78tHPgP8EWrvZ\n5ngzm2Nmd5rZuJDziIhIN0IrCmZ2JLDY3Wd1s9mfgInuvhPwKPC7LvZ1npnVmlltXV1dCGlFRATC\n/aSwN3CUmc0HbgcONLP/a7uBuy9196bg6fXALoV25O7XuXuNu9dUV1eHGFlEZHALrSi4+9fdfay7\nTwRmAo+7+2fabmNmm7d5ehS5Buk+JZvNUvvISzx4/V95+6X5UccREQlVKXoftWNmVwC17n4/cKGZ\nHQVkgGXAWaXO0526BUv5yn6XsXLpKlqzDjjTDtiRy+++hESy5KdORCR05u5RZ9ggNTU1XltbW5Jj\nXfzJy5j7jzdoza5vJy9Lpzjj8pM46ZKjS5JBRKQ3mNksd6/paTvd0dyFVUtX8/pzb7UrCABNDc08\ncN2jEaUSEQmXikIXWpozmFnhdY0tJU4jIlIaKgpdGDlmOJtN6NzTKZlKsN+Je0aQSEQkfCoKXTAz\nLv39BaSHpkmVJwEoryyjetwoTvvm8RGnExEJh7rQdGPyrpP43ZtX8/CNj/PB2x+x4z7bs//Je1GW\nLos6mohIKFQUejBis+Gc8vXjoo4hIlISunwkIiJ5KgoiIpKnoiAiInkqCiIikqeiICIieSoKIiKS\n1+8GxDOzOuC94OloYEmEcfoinZP2dD460zlpb7Ccjwnu3uOENP2uKLRlZrXFjPo3mOictKfz0ZnO\nSXs6H+3p8pGIiOSpKIiISF5/LwrXRR2gD9I5aU/nozOdk/Z0Ptro120KIiLSu/r7JwUREelF/aIo\nmNlhZvaGmc0zs0sLrC8zsz8E658zs4mlT1k6RZyPs8yszsxmB1/nRJGzVMzsRjNbbGavdLHezOzq\n4HzNMbPppc5YakWck/3NbGWbn5HLSp2xlMxsnJn9zczmmtmrZvblAtsMup+Tgty9T38BceBtYGsg\nBbwETOmwzReAa4PHM4E/RJ074vNxFnBN1FlLeE72A6YDr3Sx/nDgIcCAPYDnos7cB87J/sADUecs\n4fnYHJgePB4KvFng92bQ/ZwU+uoPnxR2A+a5+zvu3gzcDhzdYZujgd8Fj+8EDrKuJlju/4o5H4OK\nuz8FLOtmk6OBmz3nWWC4mW1emnTRKOKcDCruvsjdXwgerwZeA7bssNmg+zkppD8UhS2B99s8X0Dn\n/8z8Nu6eAVYCo0qSrvSKOR8Axwcfge80s3GlidZnFXvOBps9zewlM3vIzHaIOkypBJeXdwae67BK\nPyf0j6IgG+5PwER33wl4lPWfokTWeYHcsAdTgV8A90acpyTMbAhwF3CRu6+KOk9f1B+KwkKg7Tvd\nscGygtuYWQIYBiwtSbrS6/F8uPtSd28Knl4P7FKibH1VMT9Dg4q7r3L3NcHjB4GkmY2OOFaozCxJ\nriDc4u53F9hEPyf0j6LwPLCtmW1lZilyDcn3d9jmfuDM4PEJwOMetBwNQD2ejw7XQY8id/10MLsf\nOCPoXbIHsNLdF0UdKkpmNmZdu5uZ7Ubub8FAfSNF8L3eALzm7j/pYjP9nACJqAP0xN0zZvYl4C/k\net7c6O6vmtkVQK2730/uP/v3ZjaPXOPazOgSh6vI83GhmR0FZMidj7MiC1wCZnYbud40o81sAfAt\nIAng7tcCD5LrWTIPqAfOjiZp6RRxTk4A/sPMMkADMHMAv5EC2Bs4HXjZzGYHy74BjIfB+3NSiO5o\nFhGRvP5w+UhEREpERUFERPJUFEREJE9FQURE8lQUREQkT0VBBiwzywYjgL5iZneYWUUP23+jyP3O\nL3SjV1fLN4WZTTSzU9s8P8vMrunNY4i0paIgA1mDu09z9x2BZuD8HrYvqiiU2ETg1J42EuktKgoy\nWDwNTAIws8+Y2b+CTxG/NrO4mf0ASAfLbgm2u9fMZgXj75+3IQcrdIxg+RozuzIYiO5ZM9ssWL5N\n8PxlM/uuma0JdvUDYN9gPxcHy7Yws4fN7C0z+1EvnBuRPBUFGfCC8bBmkLub9ePAycDe7j4NyAKn\nufulrP9kcVrw0s+6+y5ADbm7xIsaeberYwSrK4Fng4HongLODZb/HPi5u3+C3Oic61wKPB3k+mmw\nbFqw/08AJ2sUXOlNfX6YC5FNkG4zpMHT5IZDOY/cAIHPB0P/pIHFXbz+QjM7Nng8DtiW4sYHOqib\nYzQDDwSPZwGHBI/3BI4JHt8KXNXN/v/q7isBzGwuMIH2Qz6LbDQVBRnIGoJ36nnBwGi/c/evd/dC\nM9sfOBjY093rzewJoLzI43Z3jJY2Ywxl2bjfwaY2jzd2HyIF6fKRDDZ/BU4ws48BmNlIM5sQrGsJ\nhleG3PDry4OCsD256Rl74xhdeRY4PnjcdkDH1eSmjxQpCRUFGVTcfS7wTeARM5tDbhKidUONXwfM\nCRqaHwYSZvYaucbeZ3vpGF25CPhKsP0kcrMHAswBskHD9MVdvlqkl2iUVJE+ILiHosHd3cxmAqe4\n+6Cee1uioWuRIn3DLsA1QZvHCuCzEeeRQUqfFEREJE9tCiIikqeiICIieSoKIiKSp6IgIiJ5Kgoi\nIpKnoiAiInn/HyiGJAewdQnLAAAAAElFTkSuQmCC\n",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          }
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "None\n"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 9
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "LsaVrtNM3Tx5"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "## Select the type of model\n",
+        "\n",
+        "### Why model?\n",
+        "\n",
+        "A *[model](https://developers.google.com/machine-learning/crash-course/glossary#model)* is a relationship between features and the label.  For the iris classification problem, the model defines the relationship between the sepal and petal measurements and the predicted iris species. Some simple models can be described with a few lines of algebra, but complex machine learning models have a large number of parameters that are difficult to summarize.\n",
+        "\n",
+        "Could you determine the relationship between the four features and the iris species *without* using machine learning?  That is, could you use traditional programming techniques (for example, a lot of conditional statements) to create a model?  Perhaps—if you analyzed the dataset long enough to determine the relationships between petal and sepal measurements to a particular species. And this becomes difficult—maybe impossible—on more complicated datasets. A good machine learning approach *determines the model for you*. If you feed enough representative examples into the right machine learning model type, the program will figure out the relationships for you.\n",
+        "\n",
+        "### Select the model\n",
+        "\n",
+        "We need to select the kind of model to train. There are many types of models and picking a good one takes experience. This tutorial uses a neural network to solve the iris classification problem. *[Neural networks](https://developers.google.com/machine-learning/glossary/#neural_network)* can find complex relationships between features and the label. It is a highly-structured graph, organized into one or more *[hidden layers](https://developers.google.com/machine-learning/glossary/#hidden_layer)*. Each hidden layer consists of one or more *[neurons](https://developers.google.com/machine-learning/glossary/#neuron)*. There are several categories of neural networks and this program uses a dense, or *[fully-connected neural network](https://developers.google.com/machine-learning/glossary/#fully_connected_layer)*: the neurons in one layer receive input connections from *every* neuron in the previous layer. For example, Figure 2 illustrates a dense neural network consisting of an input layer, two hidden layers, and an output layer:\n",
+        "\n",
+        "<table>\n",
+        "  <tr><td>\n",
+        "    <img src=\"https://www.tensorflow.org/images/custom_estimators/full_network.png\"\n",
+        "         alt=\"A diagram of the network architecture: Inputs, 2 hidden layers, and outputs\">\n",
+        "  </td></tr>\n",
+        "  <tr><td align=\"center\">\n",
+        "    <b>Figure 2.</b> A neural network with features, hidden layers, and predictions.<br/>&nbsp;\n",
+        "  </td></tr>\n",
+        "</table>\n",
+        "\n",
+        "When the model from Figure 2 is trained and fed an unlabeled example, it yields three predictions: the likelihood that this flower is the given iris species. This prediction is called *[inference](https://developers.google.com/machine-learning/crash-course/glossary#inference)*. For this example, the sum of the output predictions is 1.0. In Figure 2, this prediction breaks down as: `0.02` for *Iris setosa*, `0.95` for *Iris versicolor*, and `0.03` for *Iris virginica*. This means that the model predicts—with 95% probability—that an unlabeled example flower is an *Iris versicolor*."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "W23DIMVPQEBt"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Create a model using Swift abstractions\n",
+        "\n",
+        "We will build the model from scratch, starting with low-level TensorFlow APIs.\n",
+        "\n",
+        "Let's start by defining a dense neural network layer as a Swift `struct`:"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "wr5A5WvthvZ0",
+        "scrolled": true,
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "import TensorFlow\n",
+        "\n",
+        "// `Layer` is a protocol that makes it possible for an optimizer to update the\n",
+        "// struct during training.\n",
+        "struct DenseLayer : Layer {\n",
+        "    // Trainable parameters.\n",
+        "    var w: Tensor<Float>\n",
+        "    var b: Tensor<Float>\n",
+        "    \n",
+        "    init(inputSize: Int32, outputSize: Int32) {\n",
+        "        w = Tensor(glorotUniform: [inputSize, outputSize])\n",
+        "        b = Tensor(zeros: [outputSize])\n",
+        "    }\n",
+        "    \n",
+        "    // A requirement of the `Layer` protocol that specifies how this layer\n",
+        "    // transforms input to output.\n",
+        "    @differentiable(wrt: (self, input))\n",
+        "    func applied(to input: Tensor<Float>, in context: Context) -> Tensor<Float> {\n",
+        "        return input • w + b\n",
+        "    }\n",
+        "}"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "br5wwj0Z6C1z"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "Next, let's use `DenseLayer` to define a neural network model for the iris classification problem."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "bZd1Ck4Y5xWN",
+        "scrolled": true,
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "let hiddenSize: Int32 = 10\n",
+        "struct IrisParameters : Layer {\n",
+        "    var layer1 = DenseLayer(inputSize: 4, outputSize: hiddenSize)\n",
+        "    var layer2 = DenseLayer(inputSize: hiddenSize, outputSize: hiddenSize)\n",
+        "    var layer3 = DenseLayer(inputSize: hiddenSize, outputSize: 3)\n",
+        "    \n",
+        "    @differentiable(wrt: (self, input))\n",
+        "    func applied(to input: Tensor<Float>, in context: Context) -> Tensor<Float> {\n",
+        "        let l1 = relu(layer1.applied(to: input, in: context))\n",
+        "        let l2 = relu(layer2.applied(to: l1, in: context))\n",
+        "        return layer3.applied(to: l2, in: context)\n",
+        "    }\n",
+        "}"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "fK0vrIRv_tcc"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "Now, let's initialize the model."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "mIEZ5VlI_5WM",
+        "scrolled": true,
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "var model = IrisParameters()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "2wFKnhWCpDSS"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Using the model\n",
+        "\n",
+        "Let's have a quick look at what this model does to a batch of features:"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "sKjJGIYzO0mr",
+        "outputId": "dfc178cb-ae72-4441-a3cf-c452a75f0627",
+        "scrolled": true,
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 54
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "let inferenceContext = Context(learningPhase: .inference)\n",
+        "let firstTrainPredictions = model.applied(to: firstTrainFeatures, in: inferenceContext)\n",
+        "firstTrainPredictions[0..<5]"
+      ],
+      "execution_count": 13,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[[-1.0850735, 0.58772403, 0.54447114], [-0.82561255, 0.4280503, 0.48014793], [-0.80194116, 0.51608425, 0.5210287], [-0.9769387, 0.28767025, 0.38124347], [-1.1494671, 0.31118792, 0.41913664]]\n"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 13
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "wxyXOhwVr5S3"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "Here, each example returns a [logit](https://developers.google.com/machine-learning/crash-course/glossary#logits) for each class. \n",
+        "\n",
+        "To convert these logits to a probability for each class, use the [softmax](https://developers.google.com/machine-learning/crash-course/glossary#softmax) function:"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "_tRwHZmTNTX2",
+        "outputId": "ac7de5e5-c3e4-4752-d0f3-4d65328a50f3",
+        "scrolled": true,
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 54
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "softmax(firstTrainPredictions[0..<5])"
+      ],
+      "execution_count": 14,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[[0.087499775, 0.4661156, 0.44638455], [0.1220458, 0.4275449, 0.45040938], [0.11777741, 0.44002074, 0.4422018], [0.118612364, 0.42009032, 0.4612974], [0.098924465, 0.42624387, 0.47483167]]\n"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 14
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "uRZmchElo481"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "Taking the `argmax` across classes gives us the predicted class index. But, the model hasn't been trained yet, so these aren't good predictions."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "-Jzm_GoErz8B",
+        "outputId": "17851a17-3130-41d0-f3c9-6c9d35c7b88b",
+        "scrolled": true,
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 51
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "print(\"Prediction: \\(firstTrainPredictions.argmax(squeezingAxis: 1))\")\n",
+        "print(\"    Labels: \\(firstTrainLabels)\")"
+      ],
+      "execution_count": 15,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Prediction: [1, 2, 2, 2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 2, 2, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]\r\n",
+            "    Labels: [2, 1, 2, 0, 0, 0, 0, 2, 1, 0, 1, 1, 0, 0, 2, 1, 2, 2, 2, 0, 2, 2, 0, 2, 2, 0, 1, 2, 1, 1, 1, 1]\r\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "Vzq2E5J2QMtw"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "## Train the model\n",
+        "\n",
+        "*[Training](https://developers.google.com/machine-learning/crash-course/glossary#training)* is the stage of machine learning when the model is gradually optimized, or the model *learns* the dataset. The goal is to learn enough about the structure of the training dataset to make predictions about unseen data. If you learn *too much* about the training dataset, then the predictions only work for the data it has seen and will not be generalizable. This problem is called *[overfitting](https://developers.google.com/machine-learning/crash-course/glossary#overfitting)*—it's like memorizing the answers instead of understanding how to solve a problem.\n",
+        "\n",
+        "The iris classification problem is an example of *[supervised machine learning](https://developers.google.com/machine-learning/glossary/#supervised_machine_learning)*: the model is trained from examples that contain labels. In *[unsupervised machine learning](https://developers.google.com/machine-learning/glossary/#unsupervised_machine_learning)*, the examples don't contain labels. Instead, the model typically finds patterns among the features."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "RaKp8aEjKX6B"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Define the loss and gradient function\n",
+        "\n",
+        "Both training and evaluation stages need to calculate the model's *[loss](https://developers.google.com/machine-learning/crash-course/glossary#loss)*. This measures how off a model's predictions are from the desired label, in other words, how bad the model is performing. We want to minimize, or optimize, this value.\n",
+        "\n",
+        "Our model will calculate its loss using the `softmaxCrossEntropy` function which takes the model's class probability predictions and the desired label, and returns the average loss across the examples."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "rHgwjCKqAWNz",
+        "scrolled": true,
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "%include \"TutorialModelHelpers.swift\"\n",
+        "extension IrisParameters {\n",
+        "  // We declare the loss as \"differentiable\" so that we can differentiate it\n",
+        "  // later while optimizing the model.\n",
+        "  @differentiable(wrt: (self))\n",
+        "  func loss(for input: Tensor<Float>, labels: Tensor<Int32>, in context: Context) -> Tensor<Float> {\n",
+        "      let logits = applied(to: input, in: context)\n",
+        "      return softmaxCrossEntropy(logits: logits, categoricalLabels: labels)\n",
+        "  }\n",
+        "}"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "9SIHZjYQATyz"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "Let's calculate the loss for the current untrained model:"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "tMAT4DcMPwI-",
+        "outputId": "91f913b3-eada-4991-86e1-662a18df4c49",
+        "scrolled": true,
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "print(\"Loss test: \\(model.loss(for: firstTrainFeatures, labels: firstTrainLabels, in: inferenceContext))\")"
+      ],
+      "execution_count": 17,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Loss test: 1.2482454\r\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "lOxFimtlKruu"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Create an optimizer\n",
+        "\n",
+        "An *[optimizer](https://developers.google.com/machine-learning/crash-course/glossary#optimizer)* applies the computed gradients to the model's variables to minimize the `loss` function. You can think of the loss function as a curved surface (see Figure 3) and we want to find its lowest point by walking around. The gradients point in the direction of steepest ascent—so we'll travel the opposite way and move down the hill. By iteratively calculating the loss and gradient for each batch, we'll adjust the model during training. Gradually, the model will find the best combination of weights and bias to minimize loss. And the lower the loss, the better the model's predictions.\n",
+        "\n",
+        "<table>\n",
+        "  <tr><td>\n",
+        "    <img src=\"https://cs231n.github.io/assets/nn3/opt1.gif\" width=\"70%\"\n",
+        "         alt=\"Optimization algorithms visualized over time in 3D space.\">\n",
+        "  </td></tr>\n",
+        "  <tr><td align=\"center\">\n",
+        "    <b>Figure 3.</b> Optimization algorithms visualized over time in 3D space.<br/>(Source: <a href=\"http://cs231n.github.io/neural-networks-3/\">Stanford class CS231n</a>, MIT License, Image credit: <a href=\"https://twitter.com/alecrad\">Alec Radford</a>)\n",
+        "  </td></tr>\n",
+        "</table>\n",
+        "\n",
+        "Swift for TensorFlow has many [optimization algorithms](https://github.com/rxwei/DeepLearning/blob/master/Sources/DeepLearning/Optimizer.swift) available for training. This model uses the SGD optimizer that implements the *[stochastic gradient descent](https://developers.google.com/machine-learning/crash-course/glossary#gradient_descent)* (SGD) algorithm. The `learning_rate` sets the step size to take for each iteration down the hill. This is a *hyperparameter* that you'll commonly adjust to achieve better results."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "8xxi2NNGKwG_",
+        "scrolled": true,
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "let optimizer: SGD<IrisParameters, Float> = SGD(learningRate: 0.001)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "pJVRZ0hP52ZB"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "We'll use this to calculate a single gradient descent step:"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "rxRNTFVe56RG",
+        "outputId": "d6133e50-c11d-4d6e-934e-dd66afe38def",
+        "scrolled": true,
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "let trainingContext = Context(learningPhase: .training)\n",
+        "let (loss, grads) = valueWithGradient(at: model) { model in\n",
+        "  model.loss(for: firstTrainFeatures,labels: firstTrainLabels, in: trainingContext)\n",
+        "}\n",
+        "print(\"Initial Loss: \\(loss)\")"
+      ],
+      "execution_count": 19,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Initial Loss: 1.2482454\r\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "5B27cIT0O0nE"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "We call the `model.update(withGradients:)` method to iterate over all the model parameters and apply gradient descent to them, where `param` is the parameter and where `grad` is the gradient along that parameter."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "icyvh-o6O0nF",
+        "outputId": "8ad55a83-2c38-4f56-b79e-be70c0fe26c1",
+        "scrolled": true,
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "optimizer.update(&model.allDifferentiableVariables, along: grads)\n",
+        "print(\"Next Loss: \\(model.loss(for: firstTrainFeatures, labels: firstTrainLabels, in: trainingContext))\")"
+      ],
+      "execution_count": 20,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Next Loss: 1.2105298\r\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "nhpgM7UpO0nG"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "If you run the above two steps repeatedly, you should expect the loss to go down gradually."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "7Y2VSELvwAvW"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Training loop\n",
+        "\n",
+        "With all the pieces in place, the model is ready for training! A training loop feeds the dataset examples into the model to help it make better predictions. The following code block sets up these training steps:\n",
+        "\n",
+        "1. Iterate each *epoch*. An epoch is one pass through the dataset.\n",
+        "2. Within an epoch, iterate over each example in the training `Dataset` grabbing its *features* (`x`) and *label* (`y`).\n",
+        "3. Using the example's features, make a prediction and compare it with the label. Measure the inaccuracy of the prediction and use that to calculate the model's loss and gradients.\n",
+        "4. Use gradient descent to update the model's variables.\n",
+        "5. Keep track of some stats for visualization.\n",
+        "6. Repeat for each epoch.\n",
+        "\n",
+        "The `numEpochs` variable is the number of times to loop over the dataset collection. Counter-intuitively, training a model longer does not guarantee a better model. `numEpochs` is a *[hyperparameter](https://developers.google.com/machine-learning/glossary/#hyperparameter)* that you can tune. Choosing the right number usually requires both experience and experimentation."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "AIgulGRUhpto",
+        "scrolled": true,
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "let numEpochs = 501\n",
+        "var trainAccuracyResults: [Float] = []\n",
+        "var trainLossResults: [Float] = []"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "066kVZQFO0nL",
+        "outputId": "5e11beeb-f6e5-4455-e2d6-d2de3482f244",
+        "scrolled": true,
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 204
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "func accuracy(predictions: Tensor<Int32>, truths: Tensor<Int32>) -> Float {\n",
+        "    return Tensor<Float>(predictions .== truths).mean().scalar!\n",
+        "}\n",
+        "\n",
+        "for epoch in 0..<numEpochs {\n",
+        "    var epochLoss: Float = 0\n",
+        "    var epochAccuracy: Float = 0\n",
+        "    var batchCount: Int = 0\n",
+        "    for examples in trainDataset {\n",
+        "        let x = examples.first\n",
+        "        let y = examples.second\n",
+        "        let (loss, grad) = valueWithGradient(at: model) { model in\n",
+        "            model.loss(for: firstTrainFeatures, labels: firstTrainLabels, in: trainingContext)\n",
+        "        }\n",
+        "        optimizer.update(&model.allDifferentiableVariables, along: grad)\n",
+        "        \n",
+        "        let logits = model.applied(to: x, in: trainingContext)\n",
+        "        epochAccuracy += accuracy(predictions: logits.argmax(squeezingAxis: 1), truths: y)\n",
+        "        epochLoss += loss.scalar!\n",
+        "        batchCount += 1\n",
+        "    }\n",
+        "    epochAccuracy /= Float(batchCount)\n",
+        "    epochLoss /= Float(batchCount)\n",
+        "    trainAccuracyResults.append(epochAccuracy)\n",
+        "    trainLossResults.append(epochLoss)\n",
+        "    if epoch % 50 == 0 {\n",
+        "        print(\"Epoch \\(epoch): Loss: \\(epochLoss), Accuracy: \\(epochAccuracy)\")\n",
+        "    }\n",
+        "}"
+      ],
+      "execution_count": 22,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Epoch 0: Loss: 1.1748748, Accuracy: 0.328125\n",
+            "Epoch 50: Loss: 0.3127958, Accuracy: 0.7942708\n",
+            "Epoch 100: Loss: 0.109036565, Accuracy: 0.9505208\n",
+            "Epoch 150: Loss: 0.057829764, Accuracy: 0.9817708\n",
+            "Epoch 200: Loss: 0.040497053, Accuracy: 0.9921875\n",
+            "Epoch 250: Loss: 0.025295708, Accuracy: 0.984375\n",
+            "Epoch 300: Loss: 0.016933823, Accuracy: 0.984375\n",
+            "Epoch 350: Loss: 0.012143221, Accuracy: 0.984375\n",
+            "Epoch 400: Loss: 0.00922173, Accuracy: 0.984375\n",
+            "Epoch 450: Loss: 0.007300851, Accuracy: 0.984375\n",
+            "Epoch 500: Loss: 0.0059675537, Accuracy: 0.984375\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "2FQHVUnm_rjw"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Visualize the loss function over time"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "j3wdbmtLVTyr"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "While it's helpful to print out the model's training progress, it's often *more* helpful to see this progress. We can create basic charts using Python's `matplotlib` module.\n",
+        "\n",
+        "Interpreting these charts takes some experience, but you really want to see the *loss* go down and the *accuracy* go up."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "agjvNd2iUGFn",
+        "outputId": "e28f9ce9-30e7-46d6-9bb2-71eede5fcbd6",
+        "scrolled": true,
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 517
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "plt.figure(figsize: [12, 8])\n",
+        "\n",
+        "let accuracyAxes = plt.subplot(2, 1, 1)\n",
+        "accuracyAxes.set_ylabel(\"Accuracy\")\n",
+        "accuracyAxes.plot(trainAccuracyResults)\n",
+        "\n",
+        "let lossAxes = plt.subplot(2, 1, 2)\n",
+        "lossAxes.set_ylabel(\"Loss\")\n",
+        "lossAxes.set_xlabel(\"Epoch\")\n",
+        "lossAxes.plot(trainLossResults)\n",
+        "\n",
+        "plt.show()"
+      ],
+      "execution_count": 23,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAtQAAAHjCAYAAAADuoh4AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAIABJREFUeJzs3Xl4XHd59//PrdFmSZZkW/K+J7YT\nOytx7JBA4gABhyUB2oDNnpK69CEtBUobnvIEmpb2Bw+FFshDatKUQCFhK2DAJWFJSCAksbPHTmQ7\ntmPLm+RN+zLL/ftjZqSxJFtjS0dnNPN+XZcua84cjW7pOM5HX93n/pq7CwAAAMCZKQq7AAAAAGA8\nI1ADAAAAI0CgBgAAAEaAQA0AAACMAIEaAAAAGAECNQAAADACBGoAAABgBAjUAAAAwAgQqAEAAIAR\nKA67gNNVV1fn8+fPD7sMAAAA5LknnnjisLvXD3feuAvU8+fP1+bNm8MuAwAAAHnOzF7O5jxaPgAA\nAIARIFADAAAAIxBYoDazu8ysycyeP8nzZmZfNrMdZvasmb0iqFoAAACAoAS5Qv0NSatP8fy1khal\n3tZJ+lqAtQAAAACBCCxQu/tDko6e4pTrJX3Tkx6VVGtmM4KqBwAAAAhCmD3UsyTtzXjcmDo2iJmt\nM7PNZra5ubl5TIoDAAAAsjEuxua5+3pJ6yVp+fLlHnI5AMaxbz36sv7z97vCLmPUnF1fpS+vvVjl\nJZGwSwGAghVmoN4naU7G49mpYwAQiO5oXF+8v0GTKku1dEZ12OWMWG8sofu3HtJdv9+l/7Xq7LDL\nAYCCFWag3iDpZjO7V9JKSS3ufiDEeoCc4+7qjSdC+/xFZiqJZNcZFosnFPfc/gXSj5/ap2OdUd3+\n7lfo8rPqwi5nVNx092Z95dc79MiOI2GXAgCB+dc1F6muqizsMk4qsEBtZvdIWiWpzswaJX1aUokk\nufsdkjZKeqOkHZI6Jd0YVC3AeBSLJ/TuOx/TY7tOdW9vsEoipu9/6HJdNKf2lOc9teeY3nfX42rr\njo1RZWduybSJeuXCKWGXMWo+/ZaluvUnz6t1HHzvAeBM5fh6TXCB2t3XDvO8S/pwUJ8fyNZPnt6n\nieXFes0508Iu5QT3bNqrx3Yd1ftfOU9Tq8vH/PPH4q4v/WqbHt915JSBOpFwfXrDFlWURvShq84a\nwwrPzGvOmSozC7uMUTNncoX+88YVYZcBAAVtXNyUCATlWEev/vaHz6qkqEgPfGLVaf066eUjHVr3\nzSd0pKMnkNpauqJauWCyPnPdstAC4Lcfe1kNB9tPec7G5w/o2cYWfemdF+ptF88eo8oAAMgdBGoU\ntO9u3qvuaELRIte/3L9N//z287P+2H/42VY1HuvUWy8ectrjiJUWF+mDr1oQ6mrqkukTte1Q2ynP\neXzXUVWVFev6C4P5PgAAkOsI1Mh7rd1RfeL7z2j/8e5Bz+063KFXLpyi+XWV+uGTjfr0W5ZmNX7s\n0Z1H9KsXmvS3q8/Rn6/K/TaHM7Vk2kT912MvK55wRYqGDvYvHmzT4mlVKjrJ8wAA5LswN3YBAnWs\no1eP7jyir/x6u+7fekhTqkpVP7HshLfLFk7W36xeotecM1W9sYSe2Xs8q9d+cs8xSdJ7XzkvyC8h\ndIunT1R3NKE9RzuHfN7dte1Qm5ZMH/8j6AAAOFOsUCNvfe23L2n9QzslSTdcMlv/94YLT3puS2dU\nZtKjO49qZRYTIJpae1RVVqyqsvz+T2jJtImSpIaDbVpQVzno+ea2Hh3vjGrJtKqxLg0AgJzBCjXy\n1t6jnaqZUKJVS+r1idVLTnluTUWJzp1ercd2ZTfLt7m9R1Mn5u48zNGyaFqVzKQXDrQO+XxDqr96\n8fSJY1kWAAA5hUBdAJ7ac0wbnyu8PXMOtHTr/Fk1+saNKzR14vBj51YunKwn9xxTTyw+7LnNrT2q\nL4BAXVFarPNm1uj3Ow4P+XzDwWSgTq9kAwBQiAjUeWj34Q7dcMcj2nOkU+6uT/zgWX3se0+rOzp8\nUMwnB1u6Nb0m+/nNr1w4Rd3RhJ58efg+6ub2wgjUknT1kno9ueeYjnf2Dnpu26E2Taks1ZQc3r0K\nAICgEajz0I+f3qdNu4/pH3++VQ9vP6wdTe3qjib0eIg77o21WDyh5vYezTiNQH352XUqiZgebGga\n9tym1u6sVr3zwapzpirh0sPbB69SH2jp1uzJFSFUBQBA7iBQ56EHGpoVKTLdv/WQ/vr7z6iuqlRl\nxUV6IIugmC8Ot/cqnnBNO40dBqvKirViweRhv08dPTF19MYLZoX6wtm1mlRRMuT35Uh7r6ZUloZQ\nFQAAuYNAnWeOtPfo2cbj+tBVC3XDJbO1oK5Sf/emc/XKs6bowYbmsMsbMwdbkzOnT2eFWpKuXjJV\n2w61q/HY0GPipORkC0kFcVOiJEWKTOfOqNaeI4O/J0c7ejWZQA0AKHD5PfOrAD20vVnu0huWTdcF\ns2v7jh9p79WDDS+oua0wen8PtnRJ0mn1UEvSlYvrpZ+/oEdeOqJ3LB+6laEpFagL4fuYVllWrKMd\nJwZqd9fRDlaoAQBghTrPPPBis+qqSnXezJoTjs+qnSBJamobvFtgPjrQkvw6p59Gy4cknV1fpYrS\niLbsaznpOX0r1NWFE6iryorV2XviTa3tPTH1xhOsUAMACh6BOo/EE66HtjfrqsVTB20DnV5NPdw+\neFJDPjrY2q3SSNFph72iVHvDlv1Dz12W+n8oqS+gyRYVpRF19sZOOHa0I/l3iUANACh0BOo88vTe\n4zreGdWqJfWDnqtLhb/DqdXVfJcemWdmw588wHkzq/XCgVYlEj7k881tPSouMk2qKJwgWVlWrI6e\nE1eoj6QC9ZSqwvk+AAAwFAJ1nnhyzzF9/aGdKjLpykVDBOrUCnVze/4H6kTCtXV/62nfkJi2bGaN\nOnrj2n2kY8jnm9t6VFdVNui3APmsojSirmhc8YwfMo6mftsxpbJwVuoBABgKgToPbD/Uphvu+IN+\nseWgrji7TjUVJYPOqSyNqLykqCBWqH/4ZKO2N7VrzYo5Z/TxS2dWS9JJ2z7ae2KaWF5Y9/NWlSW/\n3sy2D1o+AABIKqxUkGcSCdeju47oy7/ersrSiH784Ss05ySbbJiZ6ieW6XCer1C7u/7l/m26aE6t\nrr9w1hm9xuJpE1USMW3Z36q3XDhz0PMdvXFVlhXWfzoVpelAHdfE8uQPbLR8AACQFOgKtZmtNrMG\nM9thZrcM8fw8M/u1mT1rZg+a2ewg68k3X/rVNr3r64/p0Z1H9fHXL9HC+iqVRE5+SeuqyvL+psSW\nrqgOtnbrzRfMOOOWjNLiIi2aOlFb9g896aOjJ6bKsshIyhx30l9ve0/mCnWPykuK+sI2AACFKrBA\nbWYRSbdLulbSUklrzWzpgNO+IOmb7n6BpNsk/XNQ9eSTrt64Ht15RP/+0E5de950/epjV+r9l88f\n9uOSgTq/V6j3HU/On06PCTxT582q1tb9rXIffGNiR0+s4EJkZXqFOuPGxCMdvfRPAwCgYFeoV0ja\n4e473b1X0r2Srh9wzlJJv0m9/8AQz2OAnlhcb/7Kw1qz/lFFzHTrW5bq7KkTs/rYuqqyvhnK+erA\n8dQOiSMM1Mtm1uhIR68OtQ7+fnX2xvt6igtFRWqFumNADzX90wAABNtDPUvS3ozHjZJWDjjnGUlv\nl/Rvkt4maaKZTXH3I5knmdk6Seskae7cuYEVnOs6e2O663e79FJzhz71pnP1unOnaUZN9sGxfmKZ\njnb2KhZPqPgUrSG5YvuhNv2fnzyvaLx/lXj1sun60ysXnvRj9qd2SJxZe2YTPtKW9d2Y2DJot8XO\n3pgqSgus5SO1Qt3RQ6AGAGCgsFPVX0u6ysyeknSVpH2S4gNPcvf17r7c3ZfX1w8eCVcIntpzTOd/\n5n594f5tet25U3XTqxdqfl3lab1GfVWp3KWjneOjj/oXzx/UozuPakJJRBNKIuroiemzG1/QM3uP\nn/Rj9h/vVknEVDfCVoRzZ1TLTHp+3+BJH+09sYK7KbGyb4W6/z9PAjUAAElBpoJ9kjLnls1OHevj\n7vuVXKGWmVVJ+iN3P3laKmB3PrxLlaURfeINS3TdGU6v6N/cpVdTJ45sBXcsPL+/RQvqKvVfNyV/\nsdHWHdXVX3hQ//CzrfrBn18+5MfsP96lGTUTRjwjurKsWAumVA66MTGecHVHE4W3Qp0em5exQt3S\nFVXNhMEjGgEAKDRBrlBvkrTIzBaYWamkNZI2ZJ5gZnVmlq7hk5LuCrCecWv/8S79YstBrV0xV+99\n5fwh50xno36cbe6yZX9r30xoSZpYXqIbr1igzS8fU0tndMiPOdDSNeJ2j7QFdZVqPNZ1wrH0HOaC\n66FOtXykp3y4e0HO4wYAYCiBBWp3j0m6WdJ9kl6Q9D1332Jmt5nZdanTVklqMLNtkqZJ+mxQ9Yxn\nd/z2Jbm73nPZvBG9TnpVuqm1ezTKClRLZ1SNx7r6epnTFk2tkiTtOskuhvuPd2vmafSVn0plWbG6\noid2IKW33y68KR/JFfnOVMtHR29c7iJQAwCggDd2cfeNkjYOOHZrxvs/kPSDIGsY7xoOtunbj+3R\nu1fOO+mmLdmaWp1coW4aB5M+thxItlosm1lzwvEFqb7x3Yc7dNGc2hOeiydcB1u7NXOEEz7SKssi\nJ8xdlvqnXBTaHOriSJHKiov6vv627uRvCNKbvAAAUMjCvikRw/i/9zWosjSij16zeMSvVV4SUc2E\nEh0aByvUW1Pbfg9coZ4zuUJm0q7Dg1eom9t6FE+4ZoxSy0dFafEJPcNS/xzmygJboZaSK/bpr7+t\nuzBbXwAAGAqBOoftPtyhX794SB+4fP6oTVOYVl02LgL1Ey8f06zaCX03UqaVl0Q0s2aCXh6i5aPx\nWKckjd4KdWlEndG4Eon+sX3pFdqKAluhlqSK0kjf2Lz+FWoCNQAABOocdvcfditipnePsHc607Tq\n8iE3K8kl0XhCv9t+WFcurhvy+fl1Fdp1pHPQ8fSq9YIppzdO8GQqy4rlLnXH+vuo04GyEFeoq8qK\nM1o+kn/S8gEAAIE6Zx1q7dZ3N+3Vmy+YoWnVozfiburE8py/KfGJl4+prSemqxZPHfL5+VMqtXuI\nlo/dRzpUXGSaPWl0Vqgryk6cbCH1z2EutDnUUnKFOn1TYjpQV7NCDQAAgTpXff4XDYrFXR+7Zsmo\nvu606jI1tfWc0MYw1o4Ps7HMAw1NKomYrjh7ypDPL6irVEtXVMc6Tnyd3Yc7NWdyxajtAtk32aKn\nf4U63VNdaDclSskfItp7TlyhriJQAwBAoM5Fe4926odPNurGV83X3Ckjm+wx0LTqcsUSHtpuid95\nbI8u+cdf6ZEdh096zoMvNuvS+ZNP2k6wsD7Z0tFwqO2E47sOd2jeKH6/0qPx0m0OUv9qdaGNzZNS\nK9R9NyUy5QMAgDQCdQ56oKFJkrT20rmj/trTUqPzwrgx8Xhnrz5/34uKJ1x//9Otam7rkfuJK+X7\nj3ep4VCbrl4ydLuHJF0yb7IiRaaHtzf3HXN37T7Sofmj1D8t9U+w6MzYbjv9fmWB7ZQoJVeo0z9c\ntPfEVGSF+X0AAGAgAnUOerChWfOnVGh+3eiFw7Sp1enNXcb+xsT/+N0utXZF9ZHXLlLDoTZd+tlf\n6Z//58UTznmwIRmSVy2pP+nr1Ewo0SXzJumBF/sDdXNbjzp7431zqkdDepLHiT3UMZUVF41aW8l4\nUllanDHlI6aqsmKZjWyLdwAA8kHhpYIc1x2N65GXDmvVKVZoRyJ9g2MYK9S/3HpIKxZM1l+9bpH+\n4/3LddGcWv382QMnrFI/0NCkWbUTdHZqR8STuXrJVG090KqDLcmvIz3hYzR/CElP8jixhzpekDck\nSsl+6bbumNxdrd1R2j0AAEghUOeYBxua1B1NnHKFdiTqU3OdD45xoD7Q0qUXDyZbOcxMrz13mt6x\nfI72He/SjqZ2SVJLV1S/33FYq5bUD7vyefU5ye/Pb7cl22N2jvLIPKn/xsPMHuqOnpgqCrTNYerE\nMsUSrmOdUbV1x5hBDQBACoE6h0TjCX3+vgYtrKvU5WcNPYN5pEqLi1RXVda3sjtW+ls5+lfe0z80\npHvGv/zr7eqKxvWulcP3ji+ZNlHTq8v7XveRl46orqps1EbmSZkr1Ce2fBTq7oCZv91o644SqAEA\nSCFQ55B7N+3VzuYOferN56q0OLhLM6u2XPuOdwX2+kP55dZDmllTrsXT+ls5ZtZO0DnTJ+r+LYe0\no6lddz+yW2sunaNlM2uGfT0z09Xn1Ovh7YfVHY3roW3NWrWkXkVFo9fTW9G3Qn3iTYmFukKdeUNr\ne0+Mlg8AAFII1Dnk4W3JmxFPNeFiNMyomaADY7hCvWn3Uf3mxSa949I5g1o5blg+R5tfPqab7t6k\nCSURffz12c/dXrVkqtp7Yrrz4Z1q6YqO+vetNFKk4iLruxFPSt6gWKg91FMn9t/QSssHAAD9CNQ5\nZMv+Vp03qybwyQkzaydo//GuQSPrgpBIuP7+p1s0o6Zcf3blWYOef+9l87SwrlK7j3TqL1+7SHWp\nHu9sXHF2nUoipq8+sEORItOrFo1um4yZqbKs+MSxeT3xgtx2XJKmZqxQp6d8AAAAAnXOON7Zq33H\nu7JqdxipmbXl6uyNq7UrNvzJI/SDJxr1/L5W3XLtOZowRKtEaXGR/uUdF+rdK+fq/ZfPP63Xrior\n1v9adbYumFWrP7/qLNVMGP0WhMrSyAlj8wp5hbqsOKJJFSU62NdDTcsHAACSVJjJIAdt3d8qSVo2\nszrwzzWzNnnj3r7jXaqpCC4UdfTE9Pn7GvSKubW67sKZJz3v4rmTdPHcSWf0OT56zWJ99JozrXB4\nFWXF6syY8tHSFQ0kuI8X06rLtfdYl6Jxp+UDAIAUVqhzxJYxDNQzapK9sPsDvjHxNy826XB7j/76\nDUvG7QYglWXF6kjNoY7FE2rvial6QuEGyanV5dp2MLnlezWBGgAASQTqnLFlf4tm1JRrymn0EJ+p\nWakV6gMtwQbqBxqaVFtRopULpgT6eYJUWRrpW6Fu607+WdAr1BPL+maYXzC7NuRqAADIDYEGajNb\nbWYNZrbDzG4Z4vm5ZvaAmT1lZs+a2RuDrCeXvdTcocXTJo7J56qrKlNJxLTveHCTPhIJ128bmnXl\nonpFRnGU3VirKC1We2qFurU7KkmqLuDe4fQs6nlTKnTB7OD7/QEAGA8C+52tmUUk3S7pGkmNkjaZ\n2QZ335px2qckfc/dv2ZmSyVtlDQ/qJpy2aHW7jFp95CkoiLT9JryM1qhdnf9+oUmHWpLhvHLFk7R\nvMkV+p/nD/YFTkk63NarIx29ge34OFYqy/pXqNM3cRb0CnVq0sdbLpg5btt4AAAYbUE2Qa6QtMPd\nd0qSmd0r6XpJmYHaJaVTZI2k/QHWk7Ni8YQOt/do6sTg2z3SZtdWaPeRztP+uB8/vU8f/e4zfY8n\nVZToj14xW3f+btegcytKI7pq8XgP1P091C1dqRXqAg7US2dWq7ykSG97xaywSwEAIGcEGahnSdqb\n8bhR0soB53xG0v1m9heSKiW9bqgXMrN1ktZJ0ty5w29LPd4c6ehVwpM3fI2Vc2dU6zuPv6x4wk/a\nkrHrcIcW1FX2Pe7oien/+58XdcHsGn39fcu1+3CH1nz9Ud35u11avWy6brt+2QkfX1FWPO5nFWf2\nUPe1fBTwTYmXzJus5z7zBpVEuP0CAIC0sP+vuFbSN9x9tqQ3SvqWmQ2qyd3Xu/tyd19eXz++VzyH\ncih1k9e0MQzUy2ZWqzua0M7m9iGf//7mvbr6Cw/qnsf39B2747cv6VBrjz79lqWaVl2ulQun6D0r\n56miNKK/e9O5mlpdfsLbeA/Tkvo2doknvG+FupBbPiQRpgEAGCDIxLNP0pyMx7NTxzJ9UNJqSXL3\nP5hZuaQ6SU0B1pVzDrX2SOrvTx0Ly2YlO2227G/VotTNkO09Me071qVoPKHP/aJBkvSF+xp0/qwa\ndfbGtf6hnbruwpm6ZN7kvtf5++uW6aPXLNbkytIxq30s1abCc0tXVK1d3JQIAAAGCzJQb5K0yMwW\nKBmk10h614Bz9kh6raRvmNm5ksolNQdYU04KY4X6rPoqlRYXacv+Fr314llq7Y7qDV96SAda+id/\n/NPbztff/fg5vfkrv5MklZcU6ZZrzznhdYqKLG/DtCTVViS/tuOdvWrtjqq4yFQxxI6PAACgcAUW\nqN09ZmY3S7pPUkTSXe6+xcxuk7TZ3TdI+rikr5vZR5W8QfED7u5B1ZSrmlq7VWTSlDEMpiWRIp07\nfaKebWxRa3dU//ar7TrY2q3Pvu08Taoo1dzJFTpvVo0umlOr3Uc6JEnnTJ/Yt8tioUjvJHmsM6qW\nrqiqJ5Qw3QIAAJwg0CZXd9+o5Ci8zGO3Zry/VdIVQdYwHhxq7VFdVZmKx7g39bxZNfr2Y3t0wWfu\nlyS9Y/lsvXvlvBPOWTqzWkvHaJxfLpqUWqFu6epVa1eM3QEBAMAgpIMccLC1e0zbPdJufs3ZWlhf\nJXdXeUlEb7uYUWgDpXuoj3UkV6gL/YZEAAAwGIE6Bxxq7dbsSWPfSjGjZoI++KoFY/55x5P0CvXx\nrqhau6MFPYMaAAAMjflXOaCprWdMZ1AjexPLi1VkUktnr1q7CNQAAGAwAnXI2ntiOtrRq1kFdrPf\neFFUZKqZUJK6KTHGyDwAADAIgTpk2w61SZIWp2ZBI/fUVpRmtHzQJQUAAE5EoA7ZtoPJQL2EQJ2z\naitKdKilW72xBDclAgCAQQjUIWs41KYJJZFQbkpEdmonlGjL/hZJ0owaet0BAMCJCNQh23aoTYun\nVamoiM1CclVtRak6euOSpGUza0KuBgAA5BoCdcgaDrbRP53jalO7JZYVF2lhXWXI1QAAgFxDoA7R\n4fYeHW7v1ZLpBOpcVjshOYv6nBnVY76bJQAAyH2kgxA1pG9IJFDntEmVyRXqZQW8BTsAADi5YQO1\nmf2FmU0ai2IKTfpGN/pyc1t6sgeBGgAADCWbFeppkjaZ2ffMbLWZcffcKNmyv1Uzaso1ubI07FJw\nCmfVV6kkYlq5YHLYpQAAgBw0bKB2909JWiTpPyR9QNJ2M/snMzsr4Nry3pb9raxOjwPnzarRc595\ng86eSmsOAAAYLKseand3SQdTbzFJkyT9wMw+H2Btea2zN6aXmttpIxgnyksiYZcAAABy1LD7KJvZ\nRyS9T9JhSXdK+oS7R82sSNJ2SX8TbIn56YUDbXKnLxcAAGC8GzZQS5os6e3u/nLmQXdPmNmbgykr\n/23efVRSsp0AAAAA41c2LR//I+lo+oGZVZvZSkly9xeCKiyfxROubz+2R8vnTdLMWrYcBwAAGM+y\nCdRfk9Se8bg9dWxYqakgDWa2w8xuGeL5L5nZ06m3bWZ2PLuyx7ffvNikPUc7deMVC8IuBQAAACOU\nTcuHpW5KlNTX6pFN73VE0u2SrpHUqOTovQ3uvjXjtT6acf5fSLr4dIofjxIJ11d/s10za8r1hmXT\nwi4HAAAAI5TNCvVOM/tLMytJvX1E0s4sPm6FpB3uvtPdeyXdK+n6U5y/VtI9WbzuuPbfT+3TM40t\n+sTqJWxjDQAAkAeySXQfknS5pH1KrjSvlLQui4+bJWlvxuPG1LFBzGyepAWSfnOS59eZ2WYz29zc\n3JzFp85N7T0xfe4XL+qiObW6/sIhvxUAAAAYZ4Zt3XD3JklrAq5jjaQfuHv8JDWsl7RekpYvX+5D\nnZOr3F2H23vl7vr6wzvV3Naj9e+9REVFbDgJAACQD7LphS6X9EFJyySVp4+7+58M86H7JM3JeDw7\ndWwoayR9eLhaxqM7H96lz27sH4bytotn6eK5k0KsCAAAAKMpm5sSvyXpRUlvkHSbpHdLymZc3iZJ\ni8xsgZJBeo2kdw08yczOUXLnxT9kWfO48vPnDujsqVW68Yr5Ko0U6U0XzAi7JAAAAIyibAL12e5+\ng5ld7+53m9l3JD083Ae5e8zMbpZ0n6SIpLvcfYuZ3SZps7tvSJ26RtK9mZNE8sWR9h4903hcf/Xa\nxXr3ynlhlwMAAIAAZBOoo6k/j5vZeZIOSpqazYu7+0ZJGwccu3XA489k81rj0cPbD8tduvqc+rBL\nAQAAQECyCdTrzWySpE9J2iCpStL/CbSqPPHbbc2qqyrVeTPZXhwAACBfnTJQm1mRpFZ3PybpIUkL\nx6SqPHGgpUsL66uY6AEAAJDHTjmH2t0Tkv5mjGrJOz2xhMqK2bwFAAAgn2WT9n5lZn9tZnPMbHL6\nLfDK8kBPNKGy4kjYZQAAACBA2fRQvzP1Z+acaBftH8PqicVVVsIKNQAAQD7LZqfEBWNRSD7qjtLy\nAQAAkO+y2SnxfUMdd/dvjn45+SXZQ03LBwAAQD7LpuXj0oz3yyW9VtKTkgjUw+iJxVVOywcAAEBe\ny6bl4y8yH5tZraR7A6soj7BCDQAAkP/OZPm0QxJ91cNwd/UyNg8AACDvZdND/VMlp3pIyQC+VNL3\ngiwqH/TEEpLElA8AAIA8l00P9Rcy3o9JetndGwOqJ2/0RFOBmpYPAACAvJZNoN4j6YC7d0uSmU0w\ns/nuvjvQysa5nlhckmj5AAAAyHPZpL3vS0pkPI6njuEU0i0f5SWsUAMAAOSzbAJ1sbv3ph+k3i8N\nrqT8wAo1AABAYcgm7TWb2XXpB2Z2vaTDwZWUH7r7eqgJ1AAAAPksmx7qD0n6tpl9NfW4UdKQuyei\nX/+UD1o+AAAA8lk2G7u8JOkyM6tKPW4PvKo80BOl5QMAAKAQDJv2zOyfzKzW3dvdvd3MJpnZP2bz\n4ma22swazGyHmd1yknPeYWZbzWyLmX3ndL+AXNW3Qk2gBgAAyGvZpL1r3f14+oG7H5P0xuE+yMwi\nkm6XdK2Sm8GsNbOlA85ZJOmTkq5w92WS/uo0as9p6ZsSmfIBAACQ37IJ1BEzK0s/MLMJkspOcX7a\nCkk73H1najLIvZKuH3DOn0q6PRXS5e5N2ZWd+1ihBgAAKAzZpL1vS/q1mX3QzG6S9EtJd2fxcbMk\n7c143Jg6lmmxpMVm9nsze9RaaszRAAAgAElEQVTMVg/1Qma2zsw2m9nm5ubmLD51+Pp2SmSFGgAA\nIK9lc1Pi58zsGUmvk+SS7pM0bxQ//yJJqyTNlvSQmZ2f2WKSqmG9pPWStHz5ch+lzx0o5lADAAAU\nhmzT3iElw/QNkl4j6YUsPmafpDkZj2enjmVqlLTB3aPuvkvSNiUD9rjHHGoAAIDCcNK0Z2aLzezT\nZvaipK9I2iPJ3P1qd//qyT4uwyZJi8xsgZmVSlojacOAc36s5Oq0zKxOyRaQnaf/ZeSe/hVqWj4A\nAADy2alaPl6U9LCkN7v7Dkkys49m+8LuHjOzm5VsEYlIusvdt5jZbZI2u/uG1HOvN7OtkuKSPuHu\nR87wa8kpPbGEikwqiVjYpQAAACBApwrUb1dyVfkBM/uFklM6TisduvtGSRsHHLs1432X9LHUW17p\niSVUVhyRGYEaAAAgn5205cPdf+zuaySdI+kBJWdETzWzr5nZ68eqwPGqJxpXWQn90wAAAPlu2MTn\n7h3u/h13f4uSNxY+JelvA69snEuuUBOoAQAA8t1pJT53P+bu6939tUEVlC+6o3FuSAQAACgALKEG\nhBVqAACAwkDiC0hPLKFydkkEAADIewTqgPTE4qxQAwAAFAASX0B6ogmmfAAAABQAEl9AumPclAgA\nAFAICNQB6YlyUyIAAEAhIPEFhCkfAAAAhYHEF5CeWJwpHwAAAAWAQB2QnlhCpaxQAwAA5D0SX0B6\nafkAAAAoCCS+gETjCZVE+PYCAADkOxJfANxd0bgTqAEAAAoAiS8AvfGEJNFDDQAAUABIfAGIxl2S\nVBKxkCsBAABA0AjUAYjGUivUtHwAAADkvUATn5mtNrMGM9thZrcM8fwHzKzZzJ5Ovd0UZD1jJZpq\n+Sih5QMAACDvFQf1wmYWkXS7pGskNUraZGYb3H3rgFO/6+43B1VHGNI91NyUCAAAkP+CTHwrJO1w\n953u3ivpXknXB/j5cka6h5qWDwAAgPwXZOKbJWlvxuPG1LGB/sjMnjWzH5jZnKFeyMzWmdlmM9vc\n3NwcRK2jKsoKNQAAQMEIO/H9VNJ8d79A0i8l3T3USe6+3t2Xu/vy+vr6MS3wTPTG0oGaKR8AAAD5\nLshAvU9S5orz7NSxPu5+xN17Ug/vlHRJgPWMmV5uSgQAACgYQSa+TZIWmdkCMyuVtEbShswTzGxG\nxsPrJL0QYD1jJj02r4yWDwAAgLwX2JQPd4+Z2c2S7pMUkXSXu28xs9skbXb3DZL+0syukxSTdFTS\nB4KqZyz1bezCCjUAAEDeCyxQS5K7b5S0ccCxWzPe/6SkTwZZQxi4KREAAKBwkPgC0D+HmpsSAQAA\n8h2BOgC9bD0OAABQMEh8AaDlAwAAoHCQ+AIQZWweAABAwSDxBaCXrccBAAAKBokvAFF6qAEAAAoG\niS8A/S0fTPkAAADIdwTqAHBTIgAAQOEg8QUgPTavuIgVagAAgHxHoA5Ab9xVGimSGYEaAAAg3xGo\nAxCNJ1TKyDwAAICCQOoLQDSeYNtxAACAAkGgDkAyUPOtBQAAKASkvgD0xpxADQAAUCBIfQGghxoA\nAKBwkPoC0BujhxoAAKBQEKgDQA81AABA4SD1BaCXlg8AAICCEWjqM7PVZtZgZjvM7JZTnPdHZuZm\ntjzIesYKK9QAAACFI7DUZ2YRSbdLulbSUklrzWzpEOdNlPQRSY8FVctYi6Z2SgQAAED+CzL1rZC0\nw913unuvpHslXT/Eef8g6XOSugOsZUyxsQsAAEDhCDJQz5K0N+NxY+pYHzN7haQ57v7zU72Qma0z\ns81mtrm5uXn0Kx1lySkfrFADAAAUgtBSn5kVSfqipI8Pd667r3f35e6+vL6+PvjiRqg3nlAJNyUC\nAAAUhCBT3z5JczIez04dS5so6TxJD5rZbkmXSdqQDzcmRuMJeqgBAAAKRJCpb5OkRWa2wMxKJa2R\ntCH9pLu3uHudu8939/mSHpV0nbtvDrCmMRGNcVMiAABAoQgs9bl7TNLNku6T9IKk77n7FjO7zcyu\nC+rz5oJoPKGSYm5KBAAAKATFQb64u2+UtHHAsVtPcu6qIGsZS73MoQYAACgYpL4A0EMNAABQOEh9\nAYjGnRVqAACAAkHqG2XxhCueIFADAAAUClLfKIvGE5LETYkAAAAFgkA9ynpTgZoeagAAgMJA6htl\n0VgqULNTIgAAQEEg9Y2yaNwliR5qAACAAkHqG2V9PdQEagAAgIJA6htlxzp7JUlltHwAAAAUBFLf\nKPv+5kaVFhfp8rOmhF0KAAAAxkCgW4/nm6bWbu1oaj/p89GE64dPNuq6C2dqSlXZGFYGAACAsBCo\ns3SkvUfXfOkhtXRFhz33A5fPD74gAAAA5AQCdZb+5Zfb1N4T0x3vuUSTKkpOel5NRYnOmV49hpUB\nAAAgTATqLGw71KZ7H9+j918+X6vPmx52OQAAAMghBOosnFVfpX9++/lavWxG2KUAAAAgxxCosxAp\nMr3z0rlhlwEAAIAcxNg8AAAAYAQI1AAAAMAIBBqozWy1mTWY2Q4zu2WI5z9kZs+Z2dNm9jszWxpk\nPQAAAMBoCyxQm1lE0u2SrpW0VNLaIQLzd9z9fHe/SNLnJX0xqHoAAACAIAS5Qr1C0g533+nuvZLu\nlXR95gnu3prxsFKSB1gPAAAAMOqCnPIxS9LejMeNklYOPMnMPizpY5JKJb1mqBcys3WS1knS3LlM\n2wAAAEDuCP2mRHe/3d3PkvS3kj51knPWu/tyd19eX18/tgUCAAAApxDkCvU+SXMyHs9OHTuZeyV9\nbbgXfeKJJw6b2csjrO1M1Uk6HNLnxtjgGhcGrnNh4DoXBq5z/gvzGs/L5qQgA/UmSYvMbIGSQXqN\npHdlnmBmi9x9e+rhmyRt1zDcPbQlajPb7O7Lw/r8CB7XuDBwnQsD17kwcJ3z33i4xoEFanePmdnN\nku6TFJF0l7tvMbPbJG129w2Sbjaz10mKSjom6f1B1QMAAAAEIdCtx919o6SNA47dmvH+R4L8/AAA\nAEDQQr8pcZxZH3YBCBzXuDBwnQsD17kwcJ3zX85fY3Nn9DMAAABwplihBgAAAEaAQJ0FM1ttZg1m\ntsPMbgm7Hpw5M7vLzJrM7PmMY5PN7Jdmtj3156TUcTOzL6eu+7Nm9orwKke2zGyOmT1gZlvNbIuZ\nfSR1nOucR8ys3MweN7NnUtf571PHF5jZY6nr+V0zK00dL0s93pF6fn6Y9eP0mFnEzJ4ys5+lHnOd\n84yZ7Taz58zsaTPbnDo2bv7dJlAPw8wikm6XdK2kpZLWmtnScKvCCHxD0uoBx26R9Gt3XyTp16nH\nUvKaL0q9rVMWc9KRE2KSPu7uSyVdJunDqf9muc75pUfSa9z9QkkXSVptZpdJ+pykL7n72UpOj/pg\n6vwPSjqWOv6l1HkYPz4i6YWMx1zn/HS1u1+UMSJv3Py7TaAe3gpJO9x9p7v3KrkBzfUh14Qz5O4P\nSTo64PD1ku5OvX+3pLdmHP+mJz0qqdbMZoxNpThT7n7A3Z9Mvd+m5P+EZ4nrnFdS16s99bAk9eaS\nXiPpB6njA69z+vr/QNJrzczGqFyMgJnNVnKvijtTj01c50Ixbv7dJlAPb5akvRmPG1PHkD+mufuB\n1PsHJU1Lvc+1H+dSv+69WNJj4jrnnVQbwNOSmiT9UtJLko67eyx1Sua17LvOqedbJE0Z24pxhv5V\n0t9ISqQeTxHXOR+5pPvN7AkzW5c6Nm7+3Q50DjUw3ri7mxmjb/KAmVVJ+qGkv3L31sxFKq5zfnD3\nuKSLzKxW0o8knRNySRhlZvZmSU3u/oSZrQq7HgTqVe6+z8ymSvqlmb2Y+WSu/7vNCvXw9kmak/F4\nduoY8seh9K+KUn82pY5z7ccpMytRMkx/293/O3WY65yn3P24pAckvVLJX/2mF4syr2XfdU49XyPp\nyBiXitN3haTrzGy3ki2Xr5H0b+I65x1335f6s0nJH5BXaBz9u02gHt4mSYtSdxSXSlojaUPINWF0\nbVD/tvfvl/STjOPvS91NfJmkloxfPSFHpfol/0PSC+7+xYynuM55xMzqUyvTMrMJkq5Rsl/+AUl/\nnDpt4HVOX/8/lvQbZyOGnOfun3T32e4+X8n///7G3d8trnNeMbNKM5uYfl/S6yU9r3H07zYbu2TB\nzN6oZA9XRNJd7v7ZkEvCGTKzeyStklQn6ZCkT0v6saTvSZor6WVJ73D3o6lg9lUlp4J0SrrR3TeH\nUTeyZ2avkvSwpOfU33P5v5Xso+Y65wkzu0DJm5QiSi4Ofc/dbzOzhUquZE6W9JSk97h7j5mVS/qW\nkj31RyWtcfed4VSPM5Fq+fhrd38z1zm/pK7nj1IPiyV9x90/a2ZTNE7+3SZQAwAAACNAywcAAAAw\nAgRqAAAAYAQI1AAAAMAIEKgBAACAESBQAwAAACNAoAYAAABGgEANAAAAjACBGgAAABgBAjUAAAAw\nAgRqAAAAYAQI1AAAAMAIEKgBAACAESBQAwAAACNAoAYAAABGgEANAAAAjACBGgAAABgBAjUAAAAw\nAgRqAAAAYAQI1AAAAMAIEKgBAACAESBQAwAAACNAoAYAAABGgEANAAAAjEBx2AWcrrq6Op8/f37Y\nZQAAACDPPfHEE4fdvX6488ZdoJ4/f742b94cdhkAAADIc2b2cjbn0fIBAAAAjACBGgAAABgBAjUA\nAAAwAgRqAAAAYAQI1AAAAMAIBBaozewuM2sys+dP8vy7zexZM3vOzB4xswuDqgUAAAAISpAr1N+Q\ntPoUz++SdJW7ny/pHyStD7AWAKOgpSuqL/5ym2LxRNilAACQMwIL1O7+kKSjp3j+EXc/lnr4qKTZ\nQdUCYHQ8suOwvvzr7dp2qD3sUgAAyBm50kP9QUn/c7InzWydmW02s83Nzc1jWBaATHF3SVIi9ScA\nAMiBQG1mVysZqP/2ZOe4+3p3X+7uy+vrh939EUBA4olkkI4lCNQAAKSFuvW4mV0g6U5J17r7kTBr\nATC89MJ0nEANAECf0FaozWyupP+W9F533xZWHdloauvW//7Rc3ri5WPDnwzksXSQpuUDAIB+ga1Q\nm9k9klZJqjOzRkmfllQiSe5+h6RbJU2R9P/MTJJi7r48qHpGorioSN95bI/Oqq/SJfMmhV0OEJp0\nkI7FCdQAAKQFFqjdfe0wz98k6aagPv9omlRRoqqyYu092hl2KUCo0gvTrFADANAv9JsSxwMz0+xJ\nEwjUKHjpKR/0UAMA0I9AnaW5kyu0h0CNApcgUAMAMAiBOkvpQO38qhsFLJEgUAMAMBCBOktzp1So\nJ5ZQc1tP2KUAoUnn6Dg/WAIA0IdAnaU5kyokSXuP0faBwhVnhRoAgEEI1FmaMzkZqOmjRiGjhxoA\ngMEI1FmaPWmCJGnPka6QKwHCkw7UjM0DAKAfgTpL5SURzaqdoO1NbWGXAoQmvTDNxi4AAPQjUJ+G\ni+fWavPuY0z6QMHqa/ngvwEAAPoQqE/DygWTdbC1W43HaPtAYUqPzUvQQw0AQB8C9WlYsWCKJOmx\nXUdDrgQIR1/LB4EaAIA+BOrTsGhqlWomlGgTgRoFKj3dg5sSAQDoR6A+DUVFphULJut3Ow7zK28U\nJGdsHgAAgxCoT9Obzp+hfce7tPnlY2GXAoy5OIEaAIBBCNSn6fXLpqmiNKIfPbUv7FKAMde39TiB\nGgCAPgTq01RRWqw3LJuunz+7X1298bDLAcZUutWJsXkAAPQjUJ+BtSvmqrU7pu8/sTfsUoAx1TeH\nmo1dAADoQ6A+A5fOn6SL59bq6w/vVCyeCLscYMyk/7qzQg0AQD8C9RkwM33oqrO092iXNj5/MOxy\ngDGTXqFmyg0AAP0I1GfomnOnaWF9pf79ty+xFTkKhrP1OAAAgxCoz1BRkenPrlyoLftb9bsdh8Mu\nBxgT6SDNTokAAPQLLFCb2V1m1mRmz5/keTOzL5vZDjN71sxeEVQtQXnrxbM0rbpMd/z2pbBLAcZE\nOkfT8gEAQL8gV6i/IWn1KZ6/VtKi1Ns6SV8LsJZAlBVH9CdXLNDvdxzRc40tYZcDBK5vbB734gIA\n0CewQO3uD0k6eopTrpf0TU96VFKtmc0Iqp6grF05VxPLivWNR3aHXQoQuL6xeQkSNQAAaWH2UM+S\nlDnIuTF1bBAzW2dmm81sc3Nz85gUl63q8hKtXDhZz+07HnYpQOAYmwcAwGDj4qZEd1/v7svdfXl9\nfX3Y5QyyaNpE7TrcoSi/B0ee65vywV91AAD6hBmo90mak/F4durYuLNoapWicdfLRzrCLgUIVJyW\nDwAABgkzUG+Q9L7UtI/LJLW4+4EQ6zlji6dNlCRtP9QeciVAsNLDPVihBgCgX3FQL2xm90haJanO\nzBolfVpSiSS5+x2SNkp6o6Qdkjol3RhULUE7q75KZtK2Q+269vywqwGCk57ykaCHGgCAPoEFandf\nO8zzLunDQX3+sTShNKI5kyq0vakt7FKAQCXY2AUAgEHGxU2J48GiqVW0fCDvpQM1G7sAANCPQD1K\nzp9do21NbTra0Rt2KUBg+sbmEagBAOhDoB4lq5ZMlbv08PbcmpMNjCan5QMAgEEI1KPkglk1mlJZ\nqgdebAq7FCAw6bF53JQIAEA/AvUoKSoyXbWkXr/d1syvw5G3+sfm8XccAIA0AvUouubcaTrWGdVD\ntH0gT6VvRiRQAwDQj0A9il577jRNnVimux/ZHXYpQCASTqAGAGAgAvUoKi0u0rtWztWDDc3afZht\nyJF/0kE6Tg81AAB9CNSj7F0r56okYvrmH14OuxRg1Dk91AAADEKgHmVTJ5br2vNm6Pub96qjJxZ2\nOcCoitPyAQDAIATqALz/8vlq64npR0/tC7sUYFQlGJsHAMAgBOoAvGJurc6fVaNv/mF330YYQD5g\nbB4AAIMRqANgZnrfK+dp26F2/eGlI2GXA4waxuYBADAYgTogb7lwpiZXluruP+wOuxRg1DA2DwCA\nwQjUASkviWjNpXP0y62H1HisM+xygFHB2DwAAAYjUAfo3ZfNkyT916N7Qq4EGB2MzQMAYDACdYBm\n1U7Q65dO172b9qirNx52OcCIMTYPAIDBCNQBu/GK+TreGdV/P9UYdinAiPWNzSNQAwDQh0AdsBUL\nJuuC2TX6j4d3EUIw7qX/Dsf4uwwAQB8CdcDMTDe9eqF2Hu7Qb15sCrscYETSOZqNXQAA6EegHgPX\nnjddM2vK9fWHd4ZdCjAiceZQAwAwSKCB2sxWm1mDme0ws1uGeH6umT1gZk+Z2bNm9sYg6wlLSaRI\nN16xQI/tOqrnGlvCLgc4Y+mdP2n5AACgX2CB2swikm6XdK2kpZLWmtnSAad9StL33P1iSWsk/b+g\n6gnbO1fMUVVZse78HavUGL/6Wj4I1AAA9AlyhXqFpB3uvtPdeyXdK+n6Aee4pOrU+zWS9gdYT6iq\ny0v0zkvn6GfPHtD+411hlwOckb6xefRQAwDQJ8hAPUvS3ozHjaljmT4j6T1m1ihpo6S/GOqFzGyd\nmW02s83Nzc1B1DombrxiviTpG4/sDrUO4Ew5c6gBABgk7JsS10r6hrvPlvRGSd8ys0E1uft6d1/u\n7svr6+vHvMjRMntSha49b7rueWyP2ntiYZcDnDZuSgQAYLAgA/U+SXMyHs9OHcv0QUnfkyR3/4Ok\nckl1AdYUuptevVBtPTF9d9Pe4U8Gckz/2Lz+1WoAAApdkIF6k6RFZrbAzEqVvOlww4Bz9kh6rSSZ\n2blKBurx29ORhYvm1OrS+ZN01+92KRpPhF0OcFoyb0ZklRoAgKTAArW7xyTdLOk+SS8oOc1ji5nd\nZmbXpU77uKQ/NbNnJN0j6QNeAMtef3blWdp3vEs/f/ZA2KUApyVzQxduTAQAIKk4yBd3941K3myY\neezWjPe3SroiyBpy0WvOmarF06r0tQdf0vUXzZSZhV0SkJXMEJ3gFywAAEgK/6bEglRUZPrQVWep\n4VCbHmhgO3KMHwmXiouSPwDGSNQAAEgiUIfmLRfO1KzaCbrjQTZ6wfjh7iqOJAM1eRoAgCQCdUhK\nIkW66dUL9Pjuo9q8+2jY5QBZiSdcJZHkPxv0UAMAkESgDtE7L52jSRUluuO3L4VdCpCVhEulqUBN\nywcAAEkE6hBVlBbrA5cv0K9eaFLDwbawywFOKT0yL71CTZ4GACCJQB2y971ynipKI/r3h1ilRm5L\nj8wrKU72UNPyAQBAEoE6ZJMqS7Xm0rna8PR+NR7rDLsc4KTSAbp/hZpADQCARKDOCTe9eoEk6c6H\nd4VcCXBy6QXp/h5qAjUAABKBOifMrJ2gt148S9/dtFfHOnrDLgcYUnxADzVbjwMAkESgzhHrrlyo\nrmhc33r05bBLAYaU7qHum0NNDzUAAJII1Dlj8bSJes05U3X3I7vVHY2HXQ4wSHqqR3qFOhYnUAMA\nIBGoc8q6KxfqSEevfvBEY9ilAIOkV6TTPdSsUAMAkESgziErF0zWhXNqdefDO+lPRc4Z2PLB31EA\nAJII1DnEzPRnVy7U7iOdun/LwbDLAU4wcGweUz4AAEgiUOeYNyybrnlTKnTHQzvl/EodOWTg2Dxa\nPgAASMoqUJvZWWZWlnp/lZn9pZnVBltaYYoUmW569UI9s/e4Ht91NOxygD79Y/No+QAAIFO2K9Q/\nlBQ3s7MlrZc0R9J3AquqwN1wyWzVVpToP3+/O+xSgD4JZw41AABDyTZQJ9w9Jultkr7i7p+QNCO4\nsgpbeUlEa1fM1f1bD2rvUbYjR27oG5tXTKAGACBTtoE6amZrJb1f0s9Sx0qCKQmS9N7L5snM9F9s\n9IIc0bdCXZRq+aCHGgAASdkH6hslvVLSZ919l5ktkPSt4MrCzNoJWr1suu55fI86e2NhlwMMmvIR\nZ2MXAAAkZRmo3X2ru/+lu99jZpMkTXT3zwVcW8H7wBXz1dod04+f2h92KUDf1Jm+lg9WqAEAkJT9\nlI8HzazazCZLelLS183si1l83GozazCzHWZ2y0nOeYeZbTWzLWbGjY4Zls+bpGUzq3X3I7sZoYfQ\nxdM91KmWjwQ91AAASMq+5aPG3VslvV3SN919paTXneoDzCwi6XZJ10paKmmtmS0dcM4iSZ+UdIW7\nL5P0V6dZf14zM73nsnlqONSmp/YeD7scFLiBUz7Y2AUAgKRsA3Wxmc2Q9A7135Q4nBWSdrj7Tnfv\nlXSvpOsHnPOnkm5392OS5O5NWb52wXjLhTNVURrRPY/tCbsUFLjEgJYPNnYBACAp20B9m6T7JL3k\n7pvMbKGk7cN8zCxJezMeN6aOZVosabGZ/d7MHjWz1UO9kJmtM7PNZra5ubk5y5LzQ1VZsa67cKZ+\n9uwBtXVHwy4HBaxvbB5zqAEAOEG2NyV+390vcPc/Tz3e6e5/NAqfv1jSIkmrJK1Vsjd70A6M7r7e\n3Ze7+/L6+vpR+LTjy5oVc9UVjesnT3NzIsKTXpEuTe2USMsHAABJ2d6UONvMfmRmTam3H5rZ7GE+\nbJ+SOyqmzU4dy9QoaYO7R919l6RtSgZsZLhwdo3OnVGtezfR9oHwDBqbR6AGAEBS9i0f/ylpg6SZ\nqbefpo6dyiZJi8xsgZmVSlqTeo1MP1ZydVpmVqdkC8jOLGsqGGamtSvm6Pl9rXp+X0vY5aBApSfN\nTKoslSQd6+wNsxwAAHJGtoG63t3/091jqbdvSDpl70Vqq/Kbley9fkHS99x9i5ndZmbXpU67T9IR\nM9sq6QFJn3D3I2f0leS56y+apfKSIt3zOKvUY23v0U6t/teH1NTWHXYpoUqPzassLVbNhBIdbCns\n7wcAAGnZBuojZvYeM4uk3t4jadjg6+4b3X2xu5/l7p9NHbvV3Tek3nd3/5i7L3X389393jP/UvJb\nzYQSvfH8GfrJ0/vZOXGMvXiwTS8ebFPDwbawSwlVuoe6qEiaXl1OoAYAICXbQP0nSo7MOyjpgKQ/\nlvSBgGrCSaxdMVftPTH97NkDYZdSUHpjyaXZ452FPWUlvZFLkZmm15TrYCuBGgAAKfspHy+7+3Xu\nXu/uU939rZJGY8oHTsPyeZO0sL5S39+8d/iTMWp6YnFJ0vGuAg/UqXsQI0Wm6dXlOsAKNQAAkrJf\noR7Kx0atCmTFzHTDJXO0afcx7TrcEXY5BSO9Qt1S4Dfhpad8FJk0vaZch9t7FE03VgMAUMBGEqht\n1KpA1t7+ilkqMumHTzSGXUrB6KHlQ1J/D7WlWj7cpaa2npCrAgAgfCMJ1AyhDcG06nJdubheP3yy\nkTnAY6RvhbrAWz7SY/MiqUAtSQdbusIsCQCAnHDKQG1mbWbWOsRbm5LzqBGCGy6ZowMt3fr9jsNh\nl1IQelNtDYXeQ53u7iiyZA+1JB1sYYUaAIBTBmp3n+ju1UO8TXT34rEqEid63dKpqplQou/T9jEm\neqLJmxJbaPmQlBybNyO1Qn2AFWoAAEbU8oGQlBVHdP1FM3XfloMFH/LGQk/fCnVh35SYOTavZkKJ\nyoqLdIjReQAAEKjHqxsumaPeWEI/fXZ/2KXkPeZQJ2WOzTMzTaks1dGOwv6eAAAgEajHrfNmVeuc\n6RNp+xgDfVM+uqJ9N+YVosyxeZJUVhLp6y8HAKCQEajHKTPTH18yW8/sPa7thwp7S+ygpVeoe2MJ\ndUcLN0C697d8SFJZcVFffzkAAIWMQD2OvfXiWSouMlapA5YO1FJh91HHEycG6tLiIlaoAQAQgXpc\nq6sq09XnTNV/P7mPHesClN56XCrsPurMHmopvULN3zv8/+3deXgc1Znv8e/bq3bJlmVjWxhjbEOU\nGIgRO4RAgAAzQDJAgGwk4RkymSSXyXqZmefm3snMJGSZLNyQXLaQ5WZCgGwmFyYQGwKEsNgBzGIM\nxhi84V271Orl3D+qulWSW7Zsqd1W1+/zPHq66pzqqiMXtN9+/dY5IiKigHqSu+y4Vrb3pHj45W3l\nHkrFGpahDnNAncuvlNl9PfcAAB72SURBVOjtK0MtIiLiUUA9yZ151HSm1SW4a7nKPkollclRm4gC\n0Bniko/cbjXU0WHZexERkbBSQD3JxaMR3nPsbJa+tIWdveEN9kppMJNjur8yYJiXHx9Z8pGIRoZl\n70VERMJKAXUFuLS9lXTW8ZunN5Z7KBVpMJtjWl0CgK7+TJlHUz75afOsMG1epDCloIiISJgpoK4A\nRx3SwKLZjZrto0RS6RyN1V5A3TcY3hKH/LR5UVOGWkREJEgBdYW4rL2VVZu7eGFTZ7mHUnEGszmq\nE1GSsQh96RBnqEdMm6cMtYiIiEcBdYW46JhZJKIRPZxYAoOZHMlYhJpElL5UeDPU+RrqSKGGOqoM\ntYiICAqoK0ZTTYJz3jqD3z6zUUHOBEtlsiRiEWoSsVCXfORyI5cej2iWDxEREUocUJvZeWa22szW\nmNl1ezjuEjNzZtZeyvFUukuPa2VXX5qlq7aUeygVJeVnqKsTUfpDXPKRnzYvOMtHOusKgbaIiEhY\nlSygNrMocCNwPtAGXGlmbUWOqweuBZ4o1VjC4h0LWpjRkNTDiRNsMJPzM9TRUGeosyPnoY57Hx9a\n3EVERMKulBnqE4A1zrm1zrlB4A7g4iLH/SvwNWCghGMJhWjEuGRxKw+t3sr6nX3lHk5FcM55Gepo\nhOp4uANql6+hDszyAejBRBERCb1SBtSzgfWB/Q1+W4GZLQYOdc79vz2dyMyuMbPlZrZ82zYtsb0n\nHzzpMCJm/OixdeUeSkVIZ70oMhmPUpuM0R/igHr3Gmpv9UjVUYuISNiV7aFEM4sA3wI+t7djnXM3\nO+fanXPtLS0tpR/cJDarqZq/Onomv3hqPV0D4V3Vb6Lkg8VE1Kuh7hsMbw31biUffoZaD8GKiEjY\nlTKg3ggcGthv9dvy6oG3AQ+Z2TrgJGCJHkwcv789fR49qQx3PPlGuYcy6eWDxUQsQk3ISz5GTpuX\nr6FWyYeIiIRdKQPqp4AFZna4mSWAK4Al+U7nXKdzbppzbq5zbi7wOHCRc255CccUCm+b3chJ86Zy\n+5/WkdYDY+OSf+AuqYcSyeVcodwDhmqolaEWEZGwK1lA7ZzLAJ8Cfg+sAu50zr1gZl82s4tKdV3x\n/O3p89jcOcDvVm4q91AmtVR6KENdnQh5DbVzhSnzQBlqERGRvFgpT+6cuxe4d0Tbl0Y59p2lHEvY\nnHnkdI46pJ4blq7hwqNnEYvu/t1p/c4+7ly+nqp4lI+cMpfaZEn/c5iUhjLUUWoSUQazOTLZXNE/\nz0qXdQ6zoYA6EfUeSlSGWkREwi58UUFIRCLGZ85ZyGvbe/n10xt363fO8emfP833HlzDN36/mitv\neZxdvYNlGOnBbVgNdcILIPvS4cxSZ7OOWCBDnYjlM9Th/PMQERHJU0Bdwc5tm8Gi2Y3csOyV3Wqp\nl720lWfWd/DV9y7i1g+3s2pzF1+9b1WZRnrwKszy4S89DoS27CO/YmReflsZahERCTsF1BXMzPjs\nOQtZv7Ofu5YPrZ6Yyzm+ef/LHNZcwyXHtXJ22ww+cspc7lqxgRc3dZVxxAeffH1wMpCh7k2Fc+q8\nVCZLMhYt7A9lqBVQi4hIuCmgrnDvPLKFxXOa+PYfXmanX9Jx3/NvsmpzF/9w9gLifi3wp85cQFN1\nnC/+8lkGQlrSUEyw5KM6X/IR4gx1VVwZahERkZEUUFc4M+Pf3rOIzr40X7jrWTZ39vPN+1ezYHod\nFx0ztHBlY02cr196DM9v7OILd68MbVnDSMUy1P0h/cKRSudGyVCH889DREQkTwF1CLTNauCfLjiK\npS9t5dTrl7Gpo59/ueitw6ZAAzinbQZfePeR3PPsJi763qO8saMPgNVvdrNhV185hl52g0UC6rBm\nqAcy2cJUeUAhuFaGWkREwk7zpIXER049nHktddz+p9f4+zPnc/zcqUWP++SZ8zm6tZFP//xpLr7x\nUdpmNfCnNTtork3wi4+fxPzp9Qd45OWVz1AnolGq495Sgf0hXX7cy1APBdSqoRYREfEoQx0i71jY\nwu0fPWHUYDrv9AUt/PITp3DcYVPY1p3iI6fMJRIx3n/LE6zb3nuARntwKGSo4xFqk+HOUKcyWari\nQyUfSQXUIiIigDLUMoojWuq49arjC/vvP3EOl9/0Zz5w6xP87tOnMaU2UcbRHTiD+WnzohHya5qE\nNaAeSOeYWhvIUEcVUIuIiIAy1DJGC2fU8+OPncCbXQN87b9eKvdwDpjUsIVdvO+ffWEt+RgxbV4k\nYiSiEdVQi4hI6ClDLWN2dGsTV592ODc/vJZZTdVs7hxg9ZtdzGys5pNnzqdtVkO5hzjhgg8l5pfd\nDmuGOpXJDXsoEbwvGgqoRUQk7BRQyz659l0LWLuth2898DLJWITjDpvCn17dzr3Pb+Zv3t7K585d\nyKym6nIPc8L0DmZJRCPE/PKGZCwS2ikFvZUSo8PakrGIps0TEZHQU0At+6Q2GePWq45nzdYeptTE\naa5L0tmf5vsPruH2x9Zxz8pNvPuth3DqEc1ccPRMGqri5R7yuHT2p2msGfodahLR0GaoB9LZYbN8\ngDLUIiIioBpq2U/zp9fRXJcEoLE6zj9e8BaWfe4M/ubts3nqtZ1c96vnOPkrS/neslcm9cqLnf2D\nNFYHA+pYaANqb6XEYhlqBdQiIhJuylDLhGmdUsP1lxyNc46VGzr5/kNr+Ob9L/OfT7zB9ZcczTsW\ntpR7iPussz89LKCuS8boSaXLOKLycM4xmMkpQy0iIlKEMtQy4cyMYw5t4qYPtXPHNSdRVxXjoz96\nil+u2FD0+Ew2x9augf26Vjqb49FXtrPi9V3jGfKoOvrSNAUC6saaOJ394QuoU4H5uIOSsahqqEVE\nJPQUUEtJnTSvmV9+4hROntfM5+56lp898fqw/jVbe3jv9x/jhK8s5fzvPsLTb4w9MHbO8YFbnuCD\ntz3Bh257oiSB7sgMdVN1nI6+EAbU6fxsJ8NLPhKxCINZZahFRCTcFFBLydVXxbn1qnbOOmo6//zr\n57n54VfZ3NnPI69s45IfPMbGjn7+27sW0D2Q5vKbH+exNdvHdN6VGzp5ct1OLj2ulb7BLHc+tX7C\nx97Zn6YhmKGuDmuG2stCV+2WoY4Ugm0REZGwUkAtB0RVPMr/+eBxvPutM/jKvS9x8leX8aHbnqSx\nOs5vP3kqnz1nIUs+dRrTahN8/6FXx3TOO5evpyoe4UsXtnHi4VP50WPryObchI05m3N0D2RoCszy\n0VQT0gx1RhlqERGR0eihRDlgErEIN75/MY+8sp1Nnf00VMU5fcE0mmq8Zcyn1iZ43/GH8p0/vML6\nnX0cOrVm1HMNpLMseWYTF7zNm5rv/SfO4do7nuG5jZ0ce2jThIy3y89EDyv5qEnQn87utmpgpcvP\n1DLyocRkLDKpZ3ERERGZCMpQywEVi0Y486jpfODEw7jwmFmFYDrv0uNaMYO7R3mAMe+h1VvpTmV4\n7+LZAJx8RDMAf351x4SNtaNIQJ3fDlvZRz5DPXLavNoQTyMoIiKSV9KA2szOM7PVZrbGzK4r0v9Z\nM3vRzFaa2VIzO6yU45GDX+uUGk6bP427V2wgt4fyjXtWbqa5NsHJ87xAenp9FfOn1/H42okLqPNB\nc7DkoxBQh6zsI19DPTJDXVcVoyeVKceQREREDholC6jNLArcCJwPtAFXmlnbiMOeBtqdc0cDdwNf\nL9V4ZPK4rP1QNnb089go2ea+wQzLVm3l/EWHFJYEBzh5XjNPrdtJeoJqejuLlnx42x0hy1APFGb5\nGBFQJ2P0DGRwbuJq10VERCabUmaoTwDWOOfWOucGgTuAi4MHOOcedM71+buPA60lHI9MEue2zaCx\nOs4vlhefteOeZzfRn85y4dGzhrWffEQzfYNZVm7onJBxdPQNAtBYPVSW0uRvh+3BxEKGekTJR31V\nnEzOabVEEREJtVIG1LOBYES0wW8bzdXAfcU6zOwaM1tuZsu3bds2gUOUg1FVPMoli1u597nNPL9x\neHCczTl+8NCrLJrdyAmHTx3Wd6K/P1FlH8UfSvQz1H6wHRb5qfFGTptXV+U919w1EK4vGCIiIkEH\nxUOJZvZBoB34RrF+59zNzrl251x7S8vkW75a9t2171pAc22Cz9/1LL2BGt1f/WUD63b08ckzj8DM\nhr2nuS7JkTPqJyygzmehG0eslAjhfShx5Mwm9UkvoO4ZUB21iIiEVykD6o3AoYH9Vr9tGDM7G/hn\n4CLnXKqE45FJpLEmzvWXLOLlLd1cecvjvLipi0de2cb/+O3zLJ7TxLlthxR938lHNLN83S4GJ6AE\nobM/TU0iSiJQN1yXiBGx8AXUo02bV5cPqPVgooiIhFgpA+qngAVmdriZJYArgCXBA8zs7cBNeMH0\n1hKORSahs46awS0fbufVrT1ccMMjfOi2J2mpT3Lzh9uJRKzoe06a10x/OsuzGzrGff2Ry44DRCJG\nYwiXHx9t2rx8yYcy1CIiEmYlW9jFOZcxs08BvweiwA+dcy+Y2ZeB5c65JXglHnXAXf4/37/hnLuo\nVGOSyeddb5nBn647i3ue3URdVYyzjpqxW5AbdNK8qZjBo69s5/i5U0c9biw6igTU4C3uErZZPkad\nNs/PUHcrQy0iIiFW0pUSnXP3AveOaPtSYPvsUl5fKkNTTYIPnTx3zMcef9hU7nt+M585Z+G4rrtm\naw9HtNTt1u5lqMP5UOLIgLpeGWoREZGD46FEkYl04TEzeXlLDy+92bXf59jRk+K17b0cd9iU3fqa\nauKFGUDCYiCTJRqxYfN+gzdtHqiGWkREwk0BtVSc8xfNJBoxljyzab/PseL1XQC0zy0SUFfH2d4T\nvgx1VWz3j4vapFdTrYBaRETCTAG1VJxpdUnOWNjCHU+tp3s/50de8cYu4lFj0ezG3frmtdSxqbM/\nVEFkKpPbbVEX8KbRS8QidKvkQ0REQkwBtVSkz5y9kJ29g9z0x7X79f4V63bxttmNu81qAdA2swHn\nYPU4Skomm4F0drf66bz6ZGy/v7iIiIhUAgXUUpEWtTZy0TGzuOnhV1m6ass+vffVbT08vb6Dk+c1\nF+1vm9UAwIubwhNQpzK5ol8uwJs6L0zZehERkZEUUEvF+teL38ZbZjbwd/93BV+9bxU7esa2btD1\n971EdTzKx047vGj/zMYqmmrivLg5TAH16BnqumRMs3yIiEiolXTaPJFyaqyJ89OrT+TL97zITX9c\ny+2PruPU+c2ctqCFEw+fyvzpdcOyrps7+7lh6RoeeHELnz93IdPqkkXPa2a0zWwIXYZ6TwG15qEW\nEZEwU0AtFa2xOs5/vO8Y/u6Mefz8yfU8tHorD65+sdA/q7GKmmSMrv40W7tTmMHHz5jHx884Yo/n\nbZvZwE8ff93P3BYvhagkXg118d+zvirOpo7+AzwiERGRg4cCagmFBTPq+dKFbXzpwjY27Orj6Tc6\neG17L+u29zKQyVKXjHFESx1nt80oupjLSGcc2cKtj77GF+9eyTcvO4Z4tHKrp5xzrNnay+kLphXt\nr1cNtYiIhJwCagmd1ik1tE6pGdc5Tl/QwhfefSTf+P1qHn55G8fPncpRMxt4yyH1LDyknjlTayom\nyH5jZx/be1JFF7kBv4ZaAbWIiISYAmqR/fT37zyCtlkNLHlmEys3dPCHVVvIOa8vGjFmN1VzWHMN\nc5trC69zp9Uwu6mG6sTkKRPJL3IzakBdpYcSRUQk3BRQi+wnM+PMI6dz5pHTAa/O+JUtPaze0s3r\nO3pZt6OP13f08ptnNu628MmUmjgzG6uZ1VTFrKbqEdtVzGioOmgy3Mtf30V9MsbCGfVF++uSMQaz\nOboH0oWlyEVERMJEAbXIBKmKR1nU2sii1uGrKzrn6OhLs25HL6/v6GNjRz+bOvrZ3DnAhl39PPna\nTrpGBNxm0FyboKW+ipb6JC11Se+1Psn0+qHtlvok9ckYZlay32vFul0cO6eJaKT4NU4+wpuv++4V\nG/joqcWnGhQREalkCqhFSszMmFKbYEptgrfPKV420ZPKsLmjn02dA4Vge1t3im3d3uuaLd1s60mR\nzrrd3puMRWipT9Jcm2Cqf53m4GuN157/aaiKExklOB7p7hUbWL2lm8vaW0c9ZvGcKbQfNoVbH3mN\n9xw7mym1ibH9wYiIiFQIc273v6APZu3t7W758uXlHobIAZfPdG/rSfnBtvez1Q+6d/al2dmbYldv\nmh29KQbSuaLniUaMKTXxQqA9pSZBXVWMumSMev/VDFa/2cM9z26ife4UfvKxE4jtoQRl2Utb+NiP\nvP8vm2riHNJQxfSGKmbUJ5nRUMWMhiTT6pJM8YP6Jv/6B0tZi4iISDFmtsI5177X4xRQi1Sm/sEs\nO/sG2dkz6L32ptjZm2ZX7yA7egfZ1eu1d/QN0jOQoTuVoSeVIf+RUJ+MccGimVx3/lFjyjr/5Y1d\nPLF2Jxs7+tjSlWJr1wBvdnnBfm6Uj5n6qlghqB96jdNYHaehOk5DVZz6qlhhu6E6RkNVnJpEtKRl\nLiIiIjD2gFolHyIVqjoRZXaimtlN1WN+j3OO/nSWbM75meqxB62L50xhcZGSlmzOsaMnNSyI39U7\n6AX3fYPs7B1kV98gW7sHWP1m9x6z63nRiHmBdiDIHtqPU5uMUZeMUpPwMu61yRi1ySi1iZjf5+3X\nJGKj1oaLiIiMlQJqESkwM2oSE/uxEI0Y0/0SkLFKZbJ0D2ToHsjQ1Z+mayBNV3+GroE03YHtrv60\nd8xAmnXb+wptvYPZMV+rOh4tEoB7bbWJGDXJKDWJKNXxKFXxKNX+dk3C3w+0BV+rYtEx16qLiMjk\npoBaRA46yViUZF2UaXXJ/Xp/LufoS2fp88tYelNZ/zVD76C33+v39Q1m6PH3823bewZ5fUef358t\nZO33/feIDAXj+WA7EHhXxaNUxSMkY1ESsQjJmLedjAe2YxF/39+ORUjGR9mORYlHTeUwIiIHmAJq\nEak4kYhR55d2TJ+gcw5mcvSnswyks/T7QXbf4PD9/uB2vs8/rj+dZcB/7Ull2Nadoj+dZTCTI5XJ\nkUpnSWVyZPYjcA8yY7dgPBGNEI9GSMS813jUvH2/PR7z2hLDjomQ8I+Lx0bs+22JqA07vnDOmH9c\nJEIsasQiRiwaIRox4lHzXiMRZfBFpGKUNKA2s/OA7wJR4Fbn3PUj+pPAT4DjgB3A5c65daUck4jI\n/kjEvGCzsbq0i9dksjkGszlSaT/QzmT9gDuwncnusb8QpGeyDKS986UzOdLZHOmsYzCboyeVIZ31\njk1nnf86/JjBzJ5r2cfLDC/YjkT8oNuIRiKFoDsfiA/ri/h90eHvi/nBez5Yj+YD+WBQHzEiESNq\n3mvMP1fE/Fe/Lxqh0Bbsjxb6g+dht7b8e2LRwHvzxwauX3gN9MciESKG/pVBZJIpWUBtZlHgRuAc\nYAPwlJktcc69GDjsamCXc26+mV0BfA24vFRjEhE52MWiEWLRCDUHwXTezjmyOVcIsPMBdz74Hsy4\noTY/EM8H7vn9bC7/6h2bzTkyOUcm68jkvIx8sC//Hq9/RF9u6HwD6RyZXJZM4X3B9wfOnXWkc0N9\nk0XEvODbzIiYF+BH8tuRoe2R/VbYZsR+YDuS7xs6LrqX/rFdK9Af8Y6PDnvv0PiD7zW8fTPD8L5o\nGfn3DX25yF8zf0zEb7fCefxz7OlceAdGgv1FzxW81vDtPZ7LvxbDrruXc/nXGvY7jhg3wXON+P0p\n/B7Dx1FoZ2g8wbbg8d4hXkew339r4ZzB73nBtqLHh+xLYSkz1CcAa5xzawHM7A7gYiAYUF8M/C9/\n+27ge2ZmbrLN5SciUoHMz7LGolBNtNzDmRC5nCPrf1HI+tu5YdsUafNeM1lHzn+v90pge/i58v2Z\nXK6wHbx2LjCGQr9/jeA1nRv6YpNz3jHODW3n/P6cC/YzYt/7vUY7Phfoz3/xGH7sWK7lncONPG9+\nO1dsXPi/o8NBYcpOqSxDAfsegniKfxHIH4/B/Z95BzMbxz5r1YFWyoB6NrA+sL8BOHG0Y5xzGTPr\nBJqB7SUcl4iIhFQkYkQw4pXx/aDiuPyXCIaCc4crBNu5Iv34x+QD/nxwPmw72L+nc5EP/Ieum/8i\nQLFzFbtWYNyMPJd/XQJtYx33sDEHxwTDzpf/XuKKtFHkOkPHDl0n/2cUfH/+fMP63V6uGRhjsG9k\nG8POUfyaEz0D1UQ7uEfnM7NrgGsA5syZU+bRiIiISCnkSyL8vXIORWSflHLd343AoYH9Vr+t6DFm\nFgMa8R5OHMY5d7Nzrt05197S0lKi4YqIiIiI7LtSBtRPAQvM7HAzSwBXAEtGHLMEuMrfvhRYpvpp\nEREREZlMSlby4ddEfwr4Pd60eT90zr1gZl8GljvnlgC3AT81szXATrygW0RERERk0ihpDbVz7l7g\n3hFtXwpsDwCXlXIMIiIiIiKlVMqSDxERERGRiqeAWkRERERkHBRQi4iIiIiMg022STXMbBvwepku\nPw0tOlPpdI/DQfc5HHSfw0H3ufKV8x4f5pzb65zNky6gLiczW+6cay/3OKR0dI/DQfc5HHSfw0H3\nufJNhnuskg8RERERkXFQQC0iIiIiMg4KqPfNzeUegJSc7nE46D6Hg+5zOOg+V76D/h6rhlpERERE\nZByUoRYRERERGQcF1CIiIiIi46CAegzM7DwzW21ma8zsunKPR/afmf3QzLaa2fOBtqlm9oCZveK/\nTvHbzcxu8O/7SjNbXL6Ry1iZ2aFm9qCZvWhmL5jZtX677nMFMbMqM3vSzJ717/O/+O2Hm9kT/v38\nhZkl/Pakv7/G759bzvHLvjGzqJk9bWa/8/d1nyuMma0zs+fM7BkzW+63TZrPbQXUe2FmUeBG4Hyg\nDbjSzNrKOyoZhx8B541ouw5Y6pxbACz198G75wv8n2uAHxygMcr4ZIDPOefagJOAT/r/z+o+V5YU\ncJZz7hjgWOA8MzsJ+BrwbefcfGAXcLV//NXALr/92/5xMnlcC6wK7Os+V6YznXPHBuacnjSf2wqo\n9+4EYI1zbq1zbhC4A7i4zGOS/eScexjYOaL5YuDH/vaPgfcE2n/iPI8DTWY288CMVPaXc26zc+4v\n/nY33l/Cs9F9rij+/erxd+P+jwPOAu7220fe5/z9vxt4l5nZARqujIOZtQJ/Bdzq7xu6z2ExaT63\nFVDv3WxgfWB/g98mlWOGc26zv/0mMMPf1r2f5Px/7n078AS6zxXHLwN4BtgKPAC8CnQ45zL+IcF7\nWbjPfn8n0HxgRyz76TvAF4Gcv9+M7nMlcsD9ZrbCzK7x2ybN53asnBcXOdg455yZaS7JCmBmdcAv\ngX9wznUFk1S6z5XBOZcFjjWzJuDXwFFlHpJMMDP7a2Crc26Fmb2z3OORkjrNObfRzKYDD5jZS8HO\ng/1zWxnqvdsIHBrYb/XbpHJsyf9Tkf+61W/XvZ+kzCyOF0z/zDn3K79Z97lCOec6gAeBk/H+6Tef\nLArey8J99vsbgR0HeKiy704FLjKzdXgll2cB30X3ueI45zb6r1vxviCfwCT63FZAvXdPAQv8J4oT\nwBXAkjKPSSbWEuAqf/sq4LeB9g/7TxOfBHQG/ulJDlJ+veRtwCrn3LcCXbrPFcTMWvzMNGZWDZyD\nVy//IHCpf9jI+5y//5cCy5xWNjvoOef+0TnX6pybi/f37zLn3AfQfa4oZlZrZvX5beBc4Hkm0ee2\nVkocAzO7AK+GKwr80Dn372UekuwnM/s58E5gGrAF+J/Ab4A7gTnA68D7nHM7/cDse3izgvQBH3XO\nLS/HuGXszOw04BHgOYZqLv8Jr45a97lCmNnReA8pRfGSQ3c6575sZvPwMplTgaeBDzrnUmZWBfwU\nr6Z+J3CFc25teUYv+8Mv+fi8c+6vdZ8ri38/f+3vxoD/dM79u5k1M0k+txVQi4iIiIiMg0o+RERE\nRETGQQG1iIiIiMg4KKAWERERERkHBdQiIiIiIuOggFpEREREZBwUUIuITCJmljWzZwI/103gueea\n2fMTdT4RkbDQ0uMiIpNLv3Pu2HIPQkREhihDLSJSAcxsnZl93cyeM7MnzWy+3z7XzJaZ2UozW2pm\nc/z2GWb2azN71v85xT9V1MxuMbMXzOx+fxVCERHZAwXUIiKTS/WIko/LA32dzrlFeCuIfcdv+9/A\nj51zRwM/A27w228A/uicOwZYDLzgty8AbnTOvRXoAC4p8e8jIjLpaaVEEZFJxMx6nHN1RdrXAWc5\n59aaWRx40znXbGbbgZnOubTfvtk5N83MtgGtzrlU4BxzgQeccwv8/f8OxJ1z/1b630xEZPJShlpE\npHK4Ubb3RSqwnUXP2oiI7JUCahGRynF54PXP/vZjwBX+9geAR/ztpcAnAMwsamaNB2qQIiKVRpkH\nEZHJpdrMngns/5dzLj913hQzW4mXZb7Sb/s0cLuZfQHYBnzUb78WuNnMrsbLRH8C2Fzy0YuIVCDV\nUIuIVAC/hrrdObe93GMREQkblXyIiIiIiIyDMtQiIiIiIuOgDLWIiIiIyDgooBYRERERGQcF1CIi\nIiIi46CAWkRERERkHBRQi4iIiIiMw/8Hcy/Lg1yjCfIAAAAASUVORK5CYII=\n",
+            "text/plain": [
+              "<Figure size 864x576 with 2 Axes>"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          }
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "None\n"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 23
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "axA6WuGVO0nR"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "Note that the y-axes of the graphs are not zero-based."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "Zg8GoMZhLpGH"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "## Evaluate the model's effectiveness\n",
+        "\n",
+        "Now that the model is trained, we can get some statistics on its performance.\n",
+        "\n",
+        "*Evaluating* means determining how effectively the model makes predictions. To determine the model's effectiveness at iris classification, pass some sepal and petal measurements to the model and ask the model to predict what iris species they represent. Then compare the model's prediction against the actual label.  For example, a model that picked the correct species on half the input examples has an *[accuracy](https://developers.google.com/machine-learning/glossary/#accuracy)* of `0.5`. Figure 4 shows a slightly more effective model, getting 4 out of 5 predictions correct at 80% accuracy:\n",
+        "\n",
+        "<table cellpadding=\"8\" border=\"0\">\n",
+        "  <colgroup>\n",
+        "    <col span=\"4\" >\n",
+        "    <col span=\"1\" bgcolor=\"lightblue\">\n",
+        "    <col span=\"1\" bgcolor=\"lightgreen\">\n",
+        "  </colgroup>\n",
+        "  <tr bgcolor=\"lightgray\">\n",
+        "    <th colspan=\"4\">Example features</th>\n",
+        "    <th colspan=\"1\">Label</th>\n",
+        "    <th colspan=\"1\" >Model prediction</th>\n",
+        "  </tr>\n",
+        "  <tr>\n",
+        "    <td>5.9</td><td>3.0</td><td>4.3</td><td>1.5</td><td align=\"center\">1</td><td align=\"center\">1</td>\n",
+        "  </tr>\n",
+        "  <tr>\n",
+        "    <td>6.9</td><td>3.1</td><td>5.4</td><td>2.1</td><td align=\"center\">2</td><td align=\"center\">2</td>\n",
+        "  </tr>\n",
+        "  <tr>\n",
+        "    <td>5.1</td><td>3.3</td><td>1.7</td><td>0.5</td><td align=\"center\">0</td><td align=\"center\">0</td>\n",
+        "  </tr>\n",
+        "  <tr>\n",
+        "    <td>6.0</td> <td>3.4</td> <td>4.5</td> <td>1.6</td> <td align=\"center\">1</td><td align=\"center\" bgcolor=\"red\">2</td>\n",
+        "  </tr>\n",
+        "  <tr>\n",
+        "    <td>5.5</td><td>2.5</td><td>4.0</td><td>1.3</td><td align=\"center\">1</td><td align=\"center\">1</td>\n",
+        "  </tr>\n",
+        "  <tr><td align=\"center\" colspan=\"6\">\n",
+        "    <b>Figure 4.</b> An iris classifier that is 80% accurate.<br/>&nbsp;\n",
+        "  </td></tr>\n",
+        "</table>"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "z-EvK7hGL0d8"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Setup the test dataset\n",
+        "\n",
+        "Evaluating the model is similar to training the model. The biggest difference is the examples come from a separate *[test set](https://developers.google.com/machine-learning/crash-course/glossary#test_set)* rather than the training set. To fairly assess a model's effectiveness, the examples used to evaluate a model must be different from the examples used to train the model.\n",
+        "\n",
+        "The setup for the test `Dataset` is similar to the setup for training `Dataset`. Download the test set from http://download.tensorflow.org/data/iris_training.csv:"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "SRMWCu30bnxH",
+        "outputId": "7bcae900-80e7-42ed-cfba-63f84913f815",
+        "scrolled": true,
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "let urllib = Python.import(\"urllib.request\")\n",
+        "let downloadResult = urllib.urlretrieve(\"http://download.tensorflow.org/data/iris_test.csv\",\n",
+        "                                        \"iris_test.csv\")\n",
+        "let testDataFilename = String(downloadResult[0])!\n",
+        "testDataFilename"
+      ],
+      "execution_count": 24,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "\"iris_test.csv\"\n"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 24
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "jEPPL6FUO0nV"
+      },
+      "cell_type": "markdown",
+      "source": [
+        " Now load it into a `Dataset`:"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "w6SCt95HO0nW",
+        "scrolled": true,
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "%include \"TutorialDatasetCSVAPI.swift\"\n",
+        "let testDataset: Dataset<TensorPair<Tensor<Float>, Tensor<Int32>>> = Dataset(\n",
+        "    contentsOfCSVFile: testDataFilename, hasHeader: true,\n",
+        "    featureColumns: [0, 1, 2, 3], labelColumns: [4]\n",
+        ").batched(batchSize)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "HFuOKXJdMAdm"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Evaluate the model on the test dataset\n",
+        "\n",
+        "Unlike the training stage, the model only evaluates a single [epoch](https://developers.google.com/machine-learning/glossary/#epoch) of the test data. In the following code cell, we iterate over each example in the test set and compare the model's prediction against the actual label. This is used to measure the model's accuracy across the entire test set."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "Tj4Rs8gwO0nY",
+        "outputId": "5dbb9327-30bc-4fa9-b59e-24d4b391d9f7",
+        "scrolled": true,
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "// NOTE: With `batchSize = 32` and 30 examples in the test dataset, only one batch will run in the loop.\n",
+        "for testBatch in testDataset {\n",
+        "    let testFeatures = testBatch.first\n",
+        "    let testLabels = testBatch.second\n",
+        "    let logits = model.applied(to: testFeatures, in: inferenceContext)\n",
+        "    let predictions = logits.argmax(squeezingAxis: 1)\n",
+        "    print(\"Test batch accuracy: \\(accuracy(predictions: predictions, truths: testLabels))\")\n",
+        "}"
+      ],
+      "execution_count": 26,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Test batch accuracy: 0.96666664\r\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "HcKEZMtCOeK-"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "We can see on the first batch, for example, the model is usually correct:"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "uNwt2eMeOane",
+        "outputId": "1b8d67e7-fc23-4cbe-d8e7-6b168411992c",
+        "scrolled": true,
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 51
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "let firstTestBatch = testDataset.first!\n",
+        "let firstTestBatchFeatures = firstTestBatch.first\n",
+        "let firstTestBatchLabels = firstTestBatch.second\n",
+        "let firstTestBatchLogits = model.applied(to: firstTestBatchFeatures, in: inferenceContext)\n",
+        "let firstTestBatchPredictions = firstTestBatchLogits.argmax(squeezingAxis: 1)\n",
+        "\n",
+        "print(firstTestBatchPredictions)\n",
+        "print(firstTestBatchLabels)"
+      ],
+      "execution_count": 27,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "[1, 2, 0, 1, 1, 1, 0, 2, 1, 2, 2, 0, 2, 1, 1, 0, 1, 0, 0, 2, 0, 1, 2, 2, 1, 1, 0, 1, 2, 1]\r\n",
+            "[1, 2, 0, 1, 1, 1, 0, 2, 1, 2, 2, 0, 2, 1, 1, 0, 1, 0, 0, 2, 0, 1, 2, 1, 1, 1, 0, 1, 2, 1]\r\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "7Li2r1tYvW7S"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "## Use the trained model to make predictions\n",
+        "\n",
+        "We've trained a model and demonstrated that it's good—but not perfect—at classifying iris species. Now let's use the trained model to make some predictions on [unlabeled examples](https://developers.google.com/machine-learning/glossary/#unlabeled_example); that is, on examples that contain features but not a label.\n",
+        "\n",
+        "In real-life, the unlabeled examples could come from lots of different sources including apps, CSV files, and data feeds. For now, we're going to manually provide three unlabeled examples to predict their labels. Recall, the label numbers are mapped to a named representation as:\n",
+        "\n",
+        "* `0`: Iris setosa\n",
+        "* `1`: Iris versicolor\n",
+        "* `2`: Iris virginica"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "MTYOZr27O0ne",
+        "outputId": "ea09c04f-676e-46e4-bda0-482137515ccf",
+        "scrolled": true,
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 68
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "let unlabeledDataset: Tensor<Float> =\n",
+        "    [[5.1, 3.3, 1.7, 0.5],\n",
+        "     [5.9, 3.0, 4.2, 1.5],\n",
+        "     [6.9, 3.1, 5.4, 2.1]]\n",
+        "\n",
+        "let unlabeledDatasetPredictions = model.applied(to: unlabeledDataset, in: inferenceContext)\n",
+        "\n",
+        "for i in 0..<unlabeledDatasetPredictions.shape[0] {\n",
+        "    let logits = unlabeledDatasetPredictions[i]\n",
+        "    let classIdx = logits.argmax().scalar!\n",
+        "    print(\"Example \\(i) prediction: \\(classNames[Int(classIdx)]) (\\(softmax(logits)))\")\n",
+        "}"
+      ],
+      "execution_count": 28,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Example 0 prediction: Iris setosa ([0.9952336, 0.0047664195, 2.17275e-11])\r\n",
+            "Example 1 prediction: Iris versicolor ([3.0507525e-05, 0.99973875, 0.00023078383])\r\n",
+            "Example 2 prediction: Iris virginica ([2.31475e-08, 0.007963826, 0.99203616])\r\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "rwxGnsA92emp"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "##### Copyright 2019 The TensorFlow Authors."
+      ]
+    },
+    {
+      "metadata": {
+        "cellView": "form",
+        "colab_type": "code",
+        "id": "CPII1rGR2rF9",
+        "scrolled": true,
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "// Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "// you may not use this file except in compliance with the License.\n",
+        "// You may obtain a copy of the License at\n",
+        "//\n",
+        "// https://www.apache.org/licenses/LICENSE-2.0\n",
+        "//\n",
+        "// Unless required by applicable law or agreed to in writing, software\n",
+        "// distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "// See the License for the specific language governing permissions and\n",
+        "// limitations under the License."
+      ],
+      "execution_count": 0,
+      "outputs": []
+    }
+  ]
 }


### PR DESCRIPTION
Creates the `docs/site` directory for content at https://www.tensorflow.org/swift

Notebook stage: https://colab.sandbox.google.com/github/lamberta/swift/blob/merge-iris/docs/site/tutorials/walkthrough.ipynb

Moves content from the [tensorflow/swift-tutorials](https://github.com/tensorflow/swift-tutorials/) repo to `docs/site/tutorials`. 
Uses git subtree split and merge to keep notebook history. I believe that repo should be deprecated now and new tutorials added here.
For useful notebooks that *do not* belong in the official S4TF docs, consider adding them to the [tensorflow/examples/community](https://github.com/tensorflow/examples/tree/master/community/en) repo.

For now, notebooks __must__ be saved with outputs to display on tensorflow.org. When your docker image is properly integrated into our import script, you can save them without outputs. (We recommend saving without outputs because it makes the diffs a bit cleaner and doesn't bloat your repo with generated images.)

Submit with cl/235624811