### PR TITLE
Fixes Tensor Links

### DIFF
--- a/docs/DifferentiableTypes.md
+++ b/docs/DifferentiableTypes.md
@@ -121,7 +121,7 @@ public protocol Differentiable {
 }
 ```
 
-Mathematically, `Differentiable` represents a [differentiable manifold]: this is a technical term for smooth-surfaced objects like spheres and generalizes types that are compatible with differentiation, like `Float`, `Double`, [`Tensor`][TensorFlow_Tensor], and `SIMD4<Float>`. This definition comes from differential geometry and is quite technical, and not all details are relevant for most use cases.
+Mathematically, `Differentiable` represents a [differentiable manifold]: this is a technical term for smooth-surfaced objects like spheres and generalizes types that are compatible with differentiation, like `Float`, `Double`, [`Tensor`][https://www.tensorflow.org/guide/tensors], and `SIMD4<Float>`. This definition comes from differential geometry and is quite technical, and not all details are relevant for most use cases.
 
 <p align="center">
   <img src="https://upload.wikimedia.org/wikipedia/commons/3/37/Pushforward.svg" align=center>
@@ -149,7 +149,7 @@ Here is a detailed explanation of the `Differentiable` protocol:
 * Manifold operations.
   * These currently involve `tangentVector(from:)` and `moved(along:)`. These operations can be useful for implementing manifold-related algorithms, like optimization on manifolds, but are not relevant for simple differentiation use cases.
 
-The standard library defines conformances to the `Differentiable` protocol for `Float`, `Double`, and `Float80`. Conditional conformances will be added to floating-point [SIMD vector types][SIMD]. The [`Tensor`][TensorFlow_Tensor] type defined in the TensorFlow library also conditionally conforms to `Differentiable`:
+The standard library defines conformances to the `Differentiable` protocol for `Float`, `Double`, and `Float80`. Conditional conformances will be added to floating-point [SIMD vector types][SIMD]. The [`Tensor`][https://www.tensorflow.org/guide/tensors] type defined in the TensorFlow library also conditionally conforms to `Differentiable`:
 
 ```swift
 extension Float: Differentiable {

--- a/docs/DifferentiableTypes.md
+++ b/docs/DifferentiableTypes.md
@@ -121,7 +121,10 @@ public protocol Differentiable {
 }
 ```
 
-Mathematically, `Differentiable` represents a [differentiable manifold]: this is a technical term for smooth-surfaced objects like spheres and generalizes types that are compatible with differentiation, like `Float`, `Double`, [`Tensor`][https://www.tensorflow.org/guide/tensors], and `SIMD4<Float>`. This definition comes from differential geometry and is quite technical, and not all details are relevant for most use cases.
+Mathematically, `Differentiable` represents a [differentiable manifold]: this is a technical term for smooth-surfaced objects like spheres and generalizes types that are compatible with differentiation, like `Float`, `Double`, [`Tensor`][TensorFlow_Tensor], and `SIMD4<Float>`. This definition comes from differential geometry and is quite technical, and not all details are relevant for most use cases.
+
+... // At bottom of file:
+[TensorFlow_Tensor]: https://www.tensorflow.org/swift/api_docs/Structs/Tensor
 
 <p align="center">
   <img src="https://upload.wikimedia.org/wikipedia/commons/3/37/Pushforward.svg" align=center>

--- a/docs/DifferentiableTypes.md
+++ b/docs/DifferentiableTypes.md
@@ -123,9 +123,6 @@ public protocol Differentiable {
 
 Mathematically, `Differentiable` represents a [differentiable manifold]: this is a technical term for smooth-surfaced objects like spheres and generalizes types that are compatible with differentiation, like `Float`, `Double`, [`Tensor`][TensorFlow_Tensor], and `SIMD4<Float>`. This definition comes from differential geometry and is quite technical, and not all details are relevant for most use cases.
 
-... // At bottom of file:
-[TensorFlow_Tensor]: https://www.tensorflow.org/swift/api_docs/Structs/Tensor
-
 <p align="center">
   <img src="https://upload.wikimedia.org/wikipedia/commons/3/37/Pushforward.svg" align=center>
   <br>
@@ -152,7 +149,7 @@ Here is a detailed explanation of the `Differentiable` protocol:
 * Manifold operations.
   * These currently involve `tangentVector(from:)` and `moved(along:)`. These operations can be useful for implementing manifold-related algorithms, like optimization on manifolds, but are not relevant for simple differentiation use cases.
 
-The standard library defines conformances to the `Differentiable` protocol for `Float`, `Double`, and `Float80`. Conditional conformances will be added to floating-point [SIMD vector types][SIMD]. The [`Tensor`][https://www.tensorflow.org/guide/tensors] type defined in the TensorFlow library also conditionally conforms to `Differentiable`:
+The standard library defines conformances to the `Differentiable` protocol for `Float`, `Double`, and `Float80`. Conditional conformances will be added to floating-point [SIMD vector types][SIMD]. The [`Tensor`][TensorFlow_Tensor] type defined in the TensorFlow library also conditionally conforms to `Differentiable`:
 
 ```swift
 extension Float: Differentiable {
@@ -294,5 +291,5 @@ The authors would like to thank Casey Chu, Dougal Maclaurin, Matthew Johnson, Ro
 [differentiable manifold]: https://en.wikipedia.org/wiki/Differentiable_manifold
 
 [SIMD]: https://github.com/apple/swift-evolution/blob/master/proposals/0229-simd.md
-[TensorFlow_Tensor]: https://tensorflow.devsite.corp.google.com/swift/api_docs/Extensions/Tensor
+[TensorFlow_Tensor]: https://www.tensorflow.org/swift/api_docs/Structs/Tensor
 [parameter-optimization]: https://github.com/tensorflow/swift/blob/master/docs/ParameterOptimization.md#full-fledged-optimizer-using-differentiable


### PR DESCRIPTION
Earlier the links were redirecting the reader to [SSO Sign In webpage](https://login.corp.google.com/request?s=tensorflow.devsite.corp.google.com:443/uberproxy/&d=https://tensorflow.devsite.corp.google.com/swift/api_docs/Extensions/Tensor%3Fupxsrf%3DAKKYJRfems2JqNrY7RvVVo-5SzVUymrw5ZS1BfJqotZTYvjaGA:1552754385107&maxAge=1200&authLevel=2000000&keyIds=X-q,k02) instead of Tensor guide.