### PR TITLE
TF-377: Remove gerund titles from the raw TF operators tutorial.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Tutorial | Last Updated |
 [Python Interoperability](https://colab.sandbox.google.com/github/tensorflow/swift/blob/master/docs/site/tutorials/python_interoperability.ipynb) | March 2019
 [Custom Differentiation](https://colab.sandbox.google.com/github/tensorflow/swift/blob/master/docs/site/tutorials/custom_differentiation.ipynb) | March 2019
 [Model Training Walkthrough](https://colab.sandbox.google.com/github/tensorflow/swift/blob/master/docs/site/tutorials/model_training_walkthrough.ipynb) | March 2019
-[Using Raw TensorFlow Operators](https://colab.sandbox.google.com/github/tensorflow/swift/blob/master/docs/site/tutorials/using_raw_tensorflow_operators.ipynb) | March 2019
+[Using Raw TensorFlow Operators](https://colab.sandbox.google.com/github/tensorflow/swift/blob/master/docs/site/tutorials/raw_tensorflow_operators.ipynb) | March 2019
 
 ### Resources
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Tutorial | Last Updated |
 [Python Interoperability](https://colab.sandbox.google.com/github/tensorflow/swift/blob/master/docs/site/tutorials/python_interoperability.ipynb) | March 2019
 [Custom Differentiation](https://colab.sandbox.google.com/github/tensorflow/swift/blob/master/docs/site/tutorials/custom_differentiation.ipynb) | March 2019
 [Model Training Walkthrough](https://colab.sandbox.google.com/github/tensorflow/swift/blob/master/docs/site/tutorials/model_training_walkthrough.ipynb) | March 2019
-[Using Raw TensorFlow Operators](https://colab.sandbox.google.com/github/tensorflow/swift/blob/master/docs/site/tutorials/raw_tensorflow_operators.ipynb) | March 2019
+[Raw TensorFlow Operators](https://colab.sandbox.google.com/github/tensorflow/swift/blob/master/docs/site/tutorials/raw_tensorflow_operators.ipynb) | March 2019
 
 ### Resources
 

--- a/docs/site/_book.yaml
+++ b/docs/site/_book.yaml
@@ -23,7 +23,7 @@ upper_tabs:
       - title: "Custom differentiation"
         path: /swift/tutorials/custom_differentiation
       - title: "Using raw tensorFlow operators"
-        path: /swift/tutorials/using_raw_tensorflow_operators
+        path: /swift/tutorials/raw_tensorflow_operators
     - name: API
       skip_translation: true
       contents:

--- a/docs/site/tutorials/raw_tensorflow_operators.ipynb
+++ b/docs/site/tutorials/raw_tensorflow_operators.ipynb
@@ -3,7 +3,7 @@
   "nbformat_minor": 0,
   "metadata": {
     "colab": {
-      "name": "Using raw TensorFlow operators.ipynb",
+      "name": "Raw TensorFlow operators.ipynb",
       "version": "0.3.2",
       "provenance": [],
       "collapsed_sections": [],
@@ -58,13 +58,13 @@
       "source": [
         "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
         "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/swift/tutorials/using_raw_tensorflow_operators\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/swift/tutorials/raw_tensorflow_operators\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
         "  </td>\n",
         "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/swift/blob/master/docs/site/tutorials/using_raw_tensorflow_operators.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/swift/blob/master/docs/site/tutorials/raw_tensorflow_operators.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
         "  </td>\n",
         "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/swift/blob/master/docs/site/tutorials/using_raw_tensorflow_operators.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/swift/blob/master/docs/site/tutorials/raw_tensorflow_operators.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
         "  </td>\n",
         "</table>"
       ]
@@ -76,7 +76,7 @@
       },
       "cell_type": "markdown",
       "source": [
-        "# Using raw TensorFlow operators\n",
+        "# Raw TensorFlow operators\n",
         "\n",
         "Building on TensorFlow, Swift for TensorFlow takes a fresh approach to API design. APIs are carefully curated from established libraries and combined with new language idioms. This means that not all TensorFlow APIs will be directly available as Swift APIs, and our API curation needs time and dedicated effort to evolve. However, do not worry if your favorite TensorFlow operator is not available in Swift -- the TensorFlow Swift library gives you transparent access to most TensorFlow operators, under the `Raw` namespace.\n"
       ]


### PR DESCRIPTION
https://bugs.swift.org/browse/TF-377