### PR TITLE
release v0.3.1

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -11,12 +11,19 @@ To install Swift for TensorFlow, download one of the packages below and follow t
 | Download | Version | Date | 
 |----------|---------|------|
 | [Xcode 10](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.3/rc1/swift-tensorflow-RELEASE-0.3-osx.pkg) | v0.3 | April 23, 2019 |
-| [Ubuntu 18.04 (CPU Only)](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.3/rc1/swift-tensorflow-RELEASE-0.3-ubuntu18.04.tar.gz) | v0.3 | April 23, 2019 |
-| [Ubuntu 18.04 (CUDA 10.0)](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.3/rc1/swift-tensorflow-RELEASE-0.3-cuda10.0-cudnn7-ubuntu18.04.tar.gz) | v0.3 | April 23, 2019 |
-| [Ubuntu 18.04 (CUDA 9.2)](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.3/rc1/swift-tensorflow-RELEASE-0.3-cuda9.2-cudnn7-ubuntu18.04.tar.gz) | v0.3 | April 23, 2019 |
+| [Ubuntu 18.04 (CPU Only)](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.3.1/rc1/swift-tensorflow-RELEASE-0.3.1-ubuntu18.04.tar.gz) | v0.3.1 | April 30, 2019 |
+| [Ubuntu 18.04 (CUDA 10.0)](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.3.1/rc1/swift-tensorflow-RELEASE-0.3.1-cuda10.0-cudnn7-ubuntu18.04.tar.gz) | v0.3.1 | April 30, 2019 |
+| [Ubuntu 18.04 (CUDA 9.2)](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.3.1/rc1/swift-tensorflow-RELEASE-0.3.1-cuda9.2-cudnn7-ubuntu18.04.tar.gz) | v0.3.1 | April 30, 2019 |
 
 <details>
   <summary>Older Packages</summary>
+
+| Download | Version | Date | 
+|----------|---------|------|
+| [Xcode 10](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.3/rc1/swift-tensorflow-RELEASE-0.3-osx.pkg) | v0.3 | April 23, 2019 |
+| [Ubuntu 18.04 (CPU Only)](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.3/rc1/swift-tensorflow-RELEASE-0.3-ubuntu18.04.tar.gz) | v0.3 | April 23, 2019 |
+| [Ubuntu 18.04 (CUDA 10.0)](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.3/rc1/swift-tensorflow-RELEASE-0.3-cuda10.0-cudnn7-ubuntu18.04.tar.gz) | v0.3 | April 23, 2019 |
+| [Ubuntu 18.04 (CUDA 9.2)](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.3/rc1/swift-tensorflow-RELEASE-0.3-cuda9.2-cudnn7-ubuntu18.04.tar.gz) | v0.3 | April 23, 2019 |
 
 | Download | Version | Date | 
 |----------|---------|------|


### PR DESCRIPTION
Points all the Linux links at v0.3.1 builds. (Built at commit https://github.com/apple/swift/commit/256c9fc69b15042302c890bf77f03a28f8bade7d from the tensorflow-0.3 branch).

MacOS build left at v0.3 until we make it.