### PR TITLE
Update more references for Layer API in tutorials 

### DIFF
--- a/docs/site/tutorials/custom_differentiation.ipynb
+++ b/docs/site/tutorials/custom_differentiation.ipynb
@@ -469,7 +469,9 @@
    "source": [
     "## Recomputing activations during backpropagation to save memory (checkpointing)\n",
     "\n",
-    "Checkpointing is a traditional technique in reverse-mode automatic differentiation to save memory when computing derivatives by making large intermediate values in the original computation not be saved in memory for backpropagation, but instead recomputed as needed during backpropagation. This technique has been realized in modern deep learning libraries as well. In Swift, API [`withRecomputationInPullbacks(_:)`](https://www.tensorflow.org/swift/api_docs/Protocols/Differentiable#/s:10TensorFlow14DifferentiablePAAE28withRecomputationInPullbacksyqd__qd__xcAaBRd__lF) enables you to control what to recompute during backpropagation, and it is available on all `Differentiable` types.\n",
+    "Checkpointing is a traditional technique in reverse-mode automatic differentiation for saving memory. Rather than saving large intermediate values in the original computation for computing derivatives, the intermediate values are instead recomputed as needed during backpropagation.\n",
+    "\n",
+    "This technique has been realized in modern deep learning libraries as well. In Swift, API [`withRecomputationInPullbacks(_:)`](https://www.tensorflow.org/swift/api_docs/Protocols/Differentiable#/s:10TensorFlow14DifferentiablePAAE28withRecomputationInPullbacksyqd__qd__xcAaBRd__lF) enables you to control what to recompute during backpropagation, and it is available on all `Differentiable` types.\n",
     "\n",
     "But today, let us learn how to define our own gradient checkpointing APIs from scratch, in just a few lines of code."
    ]
@@ -481,7 +483,7 @@
     "id": "5cZe-JbjwMfZ"
    },
    "source": [
-    "### My gradient checkpointing API"
+    "### Our gradient checkpointing API"
    ]
   },
   {
@@ -507,9 +509,8 @@
    "outputs": [],
    "source": [
     "/// Given a differentiable function, returns the same differentiable function except when\n",
-    "/// derivatives of this function are being computed. In this case, values in the original function \n",
-    "/// that are needed for computing the derivatives will be recomputed, instead of being captured by\n",
-    "/// the differential or pullback.\n",
+    "/// derivatives of this function are being computed. In that case, values in the original function needed\n",
+    "/// for computing the derivatives will be recomputed, instead of being captured by the differential or pullback.\n",
     "///\n",
     "/// - Parameter body: The body of the differentiable function.\n",
     "/// - Returns: The same differentiable function whose derivatives, when computed, will recompute\n",

--- a/docs/site/tutorials/custom_differentiation.ipynb
+++ b/docs/site/tutorials/custom_differentiation.ipynb
@@ -469,7 +469,7 @@
    "source": [
     "## Recomputing activations during backpropagation to save memory (checkpointing)\n",
     "\n",
-    "Checkpointing is a traditional technique in reverse-mode automatic differentiation to save memory when computing derivatives by making large intermediate values in the original computation not be saved in memory for backpropagation, but instead recomputed as needed during backpropagation. This technique has been realized in modern deep learning libraries as well. In Swift, API [`withRecomputationInPullbacks(_:)`](https://www.tensorflow.org/swift/api_docs/Protocols/Differentiable#/s:10TensorFlow14DifferentiablePAAE28withRecomputationInPullbacksyqd__qd__xcAaBRd__lF) makes you able to control what to recompute during backpropagation, and it is available on all `Differentiable` types.\n",
+    "Checkpointing is a traditional technique in reverse-mode automatic differentiation to save memory when computing derivatives by making large intermediate values in the original computation not be saved in memory for backpropagation, but instead recomputed as needed during backpropagation. This technique has been realized in modern deep learning libraries as well. In Swift, API [`withRecomputationInPullbacks(_:)`](https://www.tensorflow.org/swift/api_docs/Protocols/Differentiable#/s:10TensorFlow14DifferentiablePAAE28withRecomputationInPullbacksyqd__qd__xcAaBRd__lF) enables you to control what to recompute during backpropagation, and it is available on all `Differentiable` types.\n",
     "\n",
     "But today, let us learn how to define our own gradient checkpointing APIs from scratch, in just a few lines of code."
    ]
@@ -507,9 +507,9 @@
    "outputs": [],
    "source": [
     "/// Given a differentiable function, returns the same differentiable function except when\n",
-    "/// derivatives of this function is being computed, values in the original function that are needed\n",
-    "/// for computing the derivatives will be recomputed, instead of being captured by the differential\n",
-    "/// or pullback.\n",
+    "/// derivatives of this function are being computed. In this case, values in the original function \n",
+    "/// that are needed for computing the derivatives will be recomputed, instead of being captured by\n",
+    "/// the differential or pullback.\n",
     "///\n",
     "/// - Parameter body: The body of the differentiable function.\n",
     "/// - Returns: The same differentiable function whose derivatives, when computed, will recompute\n",
@@ -596,8 +596,8 @@
     "    var dense = Dense<Float>(inputSize: 36 * 6, outputSize: 10)\n",
     "\n",
     "    @differentiable\n",
-    "    func applied(to input: Tensor<Float>, in context: Context) -> Tensor<Float> {\n",
-    "        return input.sequenced(in: context, through: conv, maxPool, flatten, dense)\n",
+    "    func call(_ input: Tensor<Float>) -> Tensor<Float> {\n",
+    "        return input.sequenced(through: conv, maxPool, flatten, dense)\n",
     "    }\n",
     "}\n",
     "```\n",
@@ -686,7 +686,7 @@
     "id": "HqPXwwuTRjmz"
    },
    "source": [
-    "Finally, we can add a method on all layers that returns the same layer except its activations are discarded during application and recomputeed during backpropagation."
+    "Finally, we can add a method on all layers that returns the same layer except its activations are discarded during application and recomputed during backpropagation."
    ]
   },
   {

--- a/docs/site/tutorials/model_training_walkthrough.ipynb
+++ b/docs/site/tutorials/model_training_walkthrough.ipynb
@@ -601,7 +601,7 @@
         "\n",
         "The [Swift for TensorFlow Deep Learning Library](https://github.com/tensorflow/swift-apis) defines primitive layers and conventions for wiring them together, which makes it easy to build models and experiment.\n",
         "\n",
-        "A model is a `struct` that conforms to [`Layer`](https://www.tensorflow.org/swift/api_docs/Protocols/Layer), which means that it defines an `applied(to:in:)` method that maps input `Tensor`s to output `Tensor`s. The `applied(to:in:)` method often simply sequences the input through sublayers. Let's define an `IrisModel` that sequences the input through three [`Dense`](https://www.tensorflow.org/swift/api_docs/Structs/Dense) sublayers."
+        "A model is a `struct` that conforms to [`Layer`](https://www.tensorflow.org/swift/api_docs/Protocols/Layer), which means that it defines a [`call(_:)`](https://www.tensorflow.org/swift/api_docs/Protocols/Layer#call_:) method that maps input `Tensor`s to output `Tensor`s. The `call(_:)` method often simply sequences the input through sublayers. Let's define an `IrisModel` that sequences the input through three [`Dense`](https://www.tensorflow.org/swift/api_docs/Structs/Dense) sublayers."
       ]
     },
     {


### PR DESCRIPTION
Both the custom differentiation and model training walkthrough tutorials contain references to the old (pre- v0.3) `applied(to:)` on `Layer`. This updates these remaining references to instead use the new `call(_:)` method, reflecting the current docs.