### PR TITLE
Fix reference to CSV in prose

### DIFF
--- a/docs/site/tutorials/model_training_walkthrough.ipynb
+++ b/docs/site/tutorials/model_training_walkthrough.ipynb
@@ -1216,7 +1216,7 @@
         "\n",
         "Evaluating the model is similar to training the model. The biggest difference is the examples come from a separate *[test set](https://developers.google.com/machine-learning/crash-course/glossary#test_set)* rather than the training set. To fairly assess a model's effectiveness, the examples used to evaluate a model must be different from the examples used to train the model.\n",
         "\n",
-        "The setup for the test `Dataset` is similar to the setup for training `Dataset`. Download the test set from http://download.tensorflow.org/data/iris_training.csv:"
+        "The setup for the test `Dataset` is similar to the setup for training `Dataset`. Download the test set from http://download.tensorflow.org/data/iris_test.csv:"
       ]
     },
     {


### PR DESCRIPTION
The prose mentions downloading the `iris_training.csv` instead of the `iris_test.csv` referenced in the code