### PR TITLE
Add type Double explanation

### DIFF
--- a/docs/site/tutorials/a_swift_tour.ipynb
+++ b/docs/site/tutorials/a_swift_tour.ipynb
@@ -130,7 +130,7 @@
       "source": [
         "A constant or variable must have the same type as the value you want to assign to it. However, you don’t always have to write the type explicitly. Providing a value when you create a constant or variable lets the compiler infer its type. In the example above, the compiler infers that `myVariable` is an integer because its initial value is an integer.\n",
         "\n",
-        "If the initial value doesn’t provide enough information (or if there is no initial value), specify the type by writing it after the variable, separated by a colon. Note that using type `Double` instead of `Float` for floating point numbers gives you more precision."
+        "If the initial value doesn’t provide enough information (or if there is no initial value), specify the type by writing it after the variable, separated by a colon. Note: using `Double` instead of `Float` for floating point numbers gives you more precision, and is the default floating point type in Swift."
       ]
     },
     {

--- a/docs/site/tutorials/a_swift_tour.ipynb
+++ b/docs/site/tutorials/a_swift_tour.ipynb
@@ -130,7 +130,7 @@
       "source": [
         "A constant or variable must have the same type as the value you want to assign to it. However, you don’t always have to write the type explicitly. Providing a value when you create a constant or variable lets the compiler infer its type. In the example above, the compiler infers that `myVariable` is an integer because its initial value is an integer.\n",
         "\n",
-        "If the initial value doesn’t provide enough information (or if there is no initial value), specify the type by writing it after the variable, separated by a colon."
+        "If the initial value doesn’t provide enough information (or if there is no initial value), specify the type by writing it after the variable, separated by a colon. Note that using type `Double` instead of `Float` for floating point numbers gives you more precision."
       ]
     },
     {


### PR DESCRIPTION
Small suggestion: add a short explanation for why type `Double` was used in a floating point number example. This is because one can use either `Float` or `Double`. Can also emphasize the number of decimal points. Cheers