### PR TITLE
Add Playground Settings for Legacy Build System build settings

### DIFF
--- a/Usage.md
+++ b/Usage.md
@@ -173,7 +173,7 @@ print(x)
 
 To build an executable with Xcode 10 or 11, you must change some project settings from their default values:
 
- 1. In the menu bar, select `File > Project Settings...`.
+ 1. In the menu bar, select `File > Project Settings` if you are working inside a project or `Playground Settings` if you are using a playground.
 
  2. Then, select `Legacy Build System` for Build Settings and click `Done`.
 


### PR DESCRIPTION
Just a small addition to the Swift for TensorFlow in Xcode usage guide. There are `Project Settings` as well as `Playground Settings` where you can enable `Legacy Build System` build settings. Hope this helps a little.