### PR TITLE
Experimental prototype of Swift quasiquotes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,10 +9,10 @@ let package = Package(
             name: "SIL",
             type: .dynamic,
             targets: ["SIL"]),
-      .library(
-        name: "Quote",
-        type: .dynamic,
-        targets: ["Quote"]),
+        .library(
+            name: "Quote",
+            type: .dynamic,
+            targets: ["Quote"]),
     ],
     dependencies: [],
     targets: [
@@ -22,13 +22,13 @@ let package = Package(
         .testTarget(
             name: "SILTests",
             dependencies: ["SIL"],
-            path: "Tests/SILTests")
-    .target(
-      name: "Quote",
-      dependencies: []),
-    .testTarget(
-      name: "QuoteTests",
-      dependencies: ["Quote"],
-      path: "Tests/QuoteTests"),
+            path: "Tests/SILTests"),
+        .target(
+            name: "Quote",
+            dependencies: []),
+        .testTarget(
+            name: "QuoteTests",
+            dependencies: ["Quote"],
+            path: "Tests/QuoteTests"),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -3,12 +3,16 @@
 import PackageDescription
 
 let package = Package(
-    name: "SIL",
+    name: "Metaprogramming",
     products: [
         .library(
             name: "SIL",
             type: .dynamic,
             targets: ["SIL"]),
+      .library(
+        name: "Quote",
+        type: .dynamic,
+        targets: ["Quote"]),
     ],
     dependencies: [],
     targets: [
@@ -19,5 +23,12 @@ let package = Package(
             name: "SILTests",
             dependencies: ["SIL"],
             path: "Tests/SILTests")
+    .target(
+      name: "Quote",
+      dependencies: []),
+    .testTarget(
+      name: "QuoteTests",
+      dependencies: ["Quote"],
+      path: "Tests/QuoteTests"),
     ]
 )

--- a/Sources/Quote/Description.swift
+++ b/Sources/Quote/Description.swift
@@ -290,7 +290,7 @@ class DescriptionPrinter: Printer {
 
   private func printArguments(_ labels: [String?], _ arguments: [Expression]) {
     var needComma = false
-    // TODO(#1): Figure out why this is necessary.
+    // TODO(TF-731): Figure out why this is necessary.
     var fixedLabels: [String?] = labels
     if labels.count == 0 {
       fixedLabels = Array(repeating: nil, count: arguments.count)

--- a/Sources/Quote/Description.swift
+++ b/Sources/Quote/Description.swift
@@ -1,324 +1,324 @@
 extension Tree {
-  /// Returns Swift-like syntax of the tree.
-  /// The printouts may contain occurrences of <?> which stand for `UnknownTree`
-  /// nodes which represent unsupported language constructs.
-  public var description: String {
-    let p = DescriptionPrinter()
-    p.print(self)
-    return p.description
-  }
+    /// Returns Swift-like syntax of the tree.
+    /// The printouts may contain occurrences of <?> which stand for `UnknownTree`
+    /// nodes which represent unsupported language constructs.
+    public var description: String {
+        let p = DescriptionPrinter()
+        p.print(self)
+        return p.description
+    }
 }
 
 extension Quote {
-  /// Returns Swift-like syntax of the underlying tree.
-  public var description: String {
-    return expression.description
-  }
+    /// Returns Swift-like syntax of the underlying tree.
+    public var description: String {
+        return expression.description
+    }
 }
 
 class DescriptionPrinter: Printer {
-  func print(_ tree: Tree) {
-    switch tree {
-    case _ as Differentiable:
-      print("@differentiable")
-    case let x as AndType:
-      print(x.types, " & ") { print($0) }
-    case let x as ArrayType:
-      print("[")
-      print(x.type)
-      print("]")
-    case let x as DictionaryType:
-      print("[")
-      print(x.key)
-      print(": ")
-      print(x.value)
-      print("]")
-    case let x as FunctionType:
-      print(whenEmpty: false, "", x.attributes, " ", " ") { print($0) }
-      print("(", x.parameters, ", ", ")") { print($0) }
-      print(" -> ")
-      print(x.result)
-    case let x as InoutType:
-      print("inout ")
-      print(x.type)
-    case let x as LValueType:
-      print(x.type)
-    case let x as MetaType:
-      // NOTE: We don't have enough context to decide whether we should say .Type or .Protocol here.
-      // However, it's just a prettyprinter - we don't have to emit 100% valid Swift code.
-      print(x.type)
-      print(".Type")
-    case let x as OptionalType:
-      print(x.type)
-      print("?")
-    case let x as SpecializedType:
-      print(x.type)
-      print("[", x.arguments, ", ", "]") { print($0) }
-    case let x as TupleType:
-      print("(", x.types, ", ", ")") { print($0) }
-    case let x as TypeName:
-      print(x.value)
-    case let x as Break:
-      print("break")
-      print(" ", x.label) { print($0) }
-    case let x as Continue:
-      print("continue")
-      print(" ", x.label) { print($0) }
-    case let x as Defer:
-      print("defer")
-      printBody(" {\n", x.body, "}")
-    case let x as Do:
-      print(x.label, ": ") { print($0) }
-      print("do")
-      printBody(" {\n", x.body, "}")
-    case let x as For:
-      print(x.label, ": ") { print($0) }
-      print("for ")
-      print(x.name)
-      print(" in ")
-      print(x.expression)
-      printBody(" {\n", x.body, "}")
-    case let x as Guard:
-      print("guard ")
-      print(x.condition, ", ") { print($0) }
-      printBody(" else {\n", x.body, "}")
-    case let x as If:
-      print(x.label, ": ") { print($0) }
-      print("if ")
-      print(x.condition, ", ") { print($0) }
-      printBody(" {\n", x.thenBranch, "}")
-      guard x.elseBranch.count > 0 else { return }
-      printBody(" else {\n", x.elseBranch, "}")
-    case let x as Repeat:
-      print(x.label, ": ") { print($0) }
-      print("repeat")
-      printBody(" {\n", x.body, "}")
-      print(" while ")
-      print(x.condition)
-    case let x as Return:
-      print("return ")
-      print(x.expression)
-    case let x as Throw:
-      print("throw ")
-      print(x.expression)
-    case let x as While:
-      print(x.label, ": ") { print($0) }
-      print("while ")
-      print(x.condition, ", ") { print($0) }
-      printBody(" {\n", x.body, "}")
-    case let x as ArrayLiteral:
-      print("[", x.expressions, ", ", "]") { print($0) }
-    case let x as As:
-      print("(")
-      print(x.expression)
-      print(" as ")
-      print(x.type)
-      print(")")
-    case let x as Assign:
-      print(x.lhs)
-      print(" = ")
-      print(x.rhs)
-    case let x as Binary:
-      print("(")
-      print(x.lhs)
-      print(" ")
-      print(x.name)
-      print(" ")
-      print(x.rhs)
-      print(")")
-    case let x as BooleanLiteral:
-      print(x.value)
-    case let x as Call:
-      print(x.expression)
-      print("(")
-      printArguments(x.labels, x.arguments)
-      print(")")
-    case let x as Closure:
-      print("{ ")
-      print("(", x.parameters, ", ", ")") {
-        print($0.name)
-        print(": ")
-        print($0.type)
-      }
-      print(" -> ")
-      print(x.result)
-      printBody(" in\n", x.body, "}")
-    case let x as Conversion:
-      print(x.expression)
-    case let x as DictionaryLiteral:
-      print("[")
-      var sep = ""
-      for expr in x.expressions {
-        if sep.count != 0 {
-          print(sep)
+    func print(_ tree: Tree) {
+        switch tree {
+        case _ as Differentiable:
+            print("@differentiable")
+        case let x as AndType:
+            print(x.types, " & ") { print($0) }
+        case let x as ArrayType:
+            print("[")
+            print(x.type)
+            print("]")
+        case let x as DictionaryType:
+            print("[")
+            print(x.key)
+            print(": ")
+            print(x.value)
+            print("]")
+        case let x as FunctionType:
+            print(whenEmpty: false, "", x.attributes, " ", " ") { print($0) }
+            print("(", x.parameters, ", ", ")") { print($0) }
+            print(" -> ")
+            print(x.result)
+        case let x as InoutType:
+            print("inout ")
+            print(x.type)
+        case let x as LValueType:
+            print(x.type)
+        case let x as MetaType:
+            // NOTE: We don't have enough context to decide whether we should say .Type or .Protocol here.
+            // However, it's just a prettyprinter - we don't have to emit 100% valid Swift code.
+            print(x.type)
+            print(".Type")
+        case let x as OptionalType:
+            print(x.type)
+            print("?")
+        case let x as SpecializedType:
+            print(x.type)
+            print("[", x.arguments, ", ", "]") { print($0) }
+        case let x as TupleType:
+            print("(", x.types, ", ", ")") { print($0) }
+        case let x as TypeName:
+            print(x.value)
+        case let x as Break:
+            print("break")
+            print(" ", x.label) { print($0) }
+        case let x as Continue:
+            print("continue")
+            print(" ", x.label) { print($0) }
+        case let x as Defer:
+            print("defer")
+            printBody(" {\n", x.body, "}")
+        case let x as Do:
+            print(x.label, ": ") { print($0) }
+            print("do")
+            printBody(" {\n", x.body, "}")
+        case let x as For:
+            print(x.label, ": ") { print($0) }
+            print("for ")
+            print(x.name)
+            print(" in ")
+            print(x.expression)
+            printBody(" {\n", x.body, "}")
+        case let x as Guard:
+            print("guard ")
+            print(x.condition, ", ") { print($0) }
+            printBody(" else {\n", x.body, "}")
+        case let x as If:
+            print(x.label, ": ") { print($0) }
+            print("if ")
+            print(x.condition, ", ") { print($0) }
+            printBody(" {\n", x.thenBranch, "}")
+            guard x.elseBranch.count > 0 else { return }
+            printBody(" else {\n", x.elseBranch, "}")
+        case let x as Repeat:
+            print(x.label, ": ") { print($0) }
+            print("repeat")
+            printBody(" {\n", x.body, "}")
+            print(" while ")
+            print(x.condition)
+        case let x as Return:
+            print("return ")
+            print(x.expression)
+        case let x as Throw:
+            print("throw ")
+            print(x.expression)
+        case let x as While:
+            print(x.label, ": ") { print($0) }
+            print("while ")
+            print(x.condition, ", ") { print($0) }
+            printBody(" {\n", x.body, "}")
+        case let x as ArrayLiteral:
+            print("[", x.expressions, ", ", "]") { print($0) }
+        case let x as As:
+            print("(")
+            print(x.expression)
+            print(" as ")
+            print(x.type)
+            print(")")
+        case let x as Assign:
+            print(x.lhs)
+            print(" = ")
+            print(x.rhs)
+        case let x as Binary:
+            print("(")
+            print(x.lhs)
+            print(" ")
+            print(x.name)
+            print(" ")
+            print(x.rhs)
+            print(")")
+        case let x as BooleanLiteral:
+            print(x.value)
+        case let x as Call:
+            print(x.expression)
+            print("(")
+            printArguments(x.labels, x.arguments)
+            print(")")
+        case let x as Closure:
+            print("{ ")
+            print("(", x.parameters, ", ", ")") {
+                print($0.name)
+                print(": ")
+                print($0.type)
+            }
+            print(" -> ")
+            print(x.result)
+            printBody(" in\n", x.body, "}")
+        case let x as Conversion:
+            print(x.expression)
+        case let x as DictionaryLiteral:
+            print("[")
+            var sep = ""
+            for expr in x.expressions {
+                if sep.count != 0 {
+                    print(sep)
+                }
+                sep = sep == ": " ? ", " : ": "
+                print(expr)
+            }
+            print("]")
+        case let x as FloatLiteral:
+            print(x.value)
+        case let x as Force:
+            print(x.expression)
+            print("!")
+        case let x as ForceAs:
+            print("(")
+            print(x.expression)
+            print(" as! ")
+            print(x.type)
+            print(")")
+        case let x as ForceTry:
+            print("try! ")
+            print(x.expression)
+        case let x as Inout:
+            print("&")
+            print(x.expression)
+        case let x as IntegerLiteral:
+            print(x.value)
+        case let x as Is:
+            print("(")
+            print(x.expression)
+            print(" is ")
+            print(x.targetType)
+            print(")")
+        case let x as MagicLiteral:
+            print("#")
+            print(x.kind)
+        case let x as Member:
+            print(x.expression)
+            print(".")
+            print(x.value)
+        case let x as Meta:
+            print("#quote(")
+            print(x.expression)
+            print(")")
+        case let x as Name:
+            print(x.value)
+        case _ as NilLiteral:
+            print("nil")
+        case let x as OptionalAs:
+            print("(")
+            print(x.expression)
+            print(" as? ")
+            print(x.targetType)
+            print(")")
+        case let x as OptionalTry:
+            print("try? ")
+            print(x.expression)
+        case let x as Postfix:
+            print("(")
+            print(x.expression)
+            print(x.name)
+            print(")")
+        case let x as PostfixSelf:
+            print(x.tree)
+            print(".self")
+        case let x as Prefix:
+            print("(")
+            print(x.name)
+            print(x.expression)
+            print(")")
+        case _ as StringInterpolation:
+            literal("...")
+        case let x as StringLiteral:
+            literal(x.value)
+        case let x as Subscript:
+            print(x.expression)
+            print("[")
+            printArguments(x.labels, x.arguments)
+            print("]")
+        case _ as Super:
+            print("super")
+        case let x as Ternary:
+            print("(")
+            print(x.condition)
+            print(" ? ")
+            print(x.thenBranch)
+            print(" : ")
+            print(x.elseBranch)
+            print(")")
+        case let x as Try:
+            print("try ")
+            print(x.expression)
+        case let x as Tuple:
+            print("(")
+            printArguments(x.labels, x.arguments)
+            print(")")
+        case let x as TupleElement:
+            print(x.expression)
+            print(".")
+            print(x.field)
+        case let x as Unquote:
+            print("#unquote(")
+            print(x.expression)
+            print(")")
+        case _ as Wildcard:
+            print("_")
+        case let x as Function:
+            print("func ")
+            print(x.name)
+            print("(", x.parameters, ", ", ")") { print($0) }
+            print(" -> ")
+            print(x.result)
+            printBody(" in\n", x.body, "}")
+        case let x as Let:
+            print("let ")
+            print(x.name)
+            print(": ", x.type) { print($0) }
+            print(" = ")
+            print(x.rhs)
+        case let x as Parameter:
+            if let label = x.label {
+                print(label)
+                print(": ")
+            } else {
+                print("_ ")
+            }
+            print(x.name)
+            print(": ")
+            print(x.type)
+        case let x as Var:
+            print("var ")
+            print(x.name)
+            print(": ", x.type) { print($0) }
+            print(" = ")
+            print(x.rhs)
+        default:
+            print("<?>")
         }
-        sep = sep == ": " ? ", " : ": "
-        print(expr)
-      }
-      print("]")
-    case let x as FloatLiteral:
-      print(x.value)
-    case let x as Force:
-      print(x.expression)
-      print("!")
-    case let x as ForceAs:
-      print("(")
-      print(x.expression)
-      print(" as! ")
-      print(x.type)
-      print(")")
-    case let x as ForceTry:
-      print("try! ")
-      print(x.expression)
-    case let x as Inout:
-      print("&")
-      print(x.expression)
-    case let x as IntegerLiteral:
-      print(x.value)
-    case let x as Is:
-      print("(")
-      print(x.expression)
-      print(" is ")
-      print(x.targetType)
-      print(")")
-    case let x as MagicLiteral:
-      print("#")
-      print(x.kind)
-    case let x as Member:
-      print(x.expression)
-      print(".")
-      print(x.value)
-    case let x as Meta:
-      print("#quote(")
-      print(x.expression)
-      print(")")
-    case let x as Name:
-      print(x.value)
-    case _ as NilLiteral:
-      print("nil")
-    case let x as OptionalAs:
-      print("(")
-      print(x.expression)
-      print(" as? ")
-      print(x.targetType)
-      print(")")
-    case let x as OptionalTry:
-      print("try? ")
-      print(x.expression)
-    case let x as Postfix:
-      print("(")
-      print(x.expression)
-      print(x.name)
-      print(")")
-    case let x as PostfixSelf:
-      print(x.tree)
-      print(".self")
-    case let x as Prefix:
-      print("(")
-      print(x.name)
-      print(x.expression)
-      print(")")
-    case _ as StringInterpolation:
-      literal("...")
-    case let x as StringLiteral:
-      literal(x.value)
-    case let x as Subscript:
-      print(x.expression)
-      print("[")
-      printArguments(x.labels, x.arguments)
-      print("]")
-    case _ as Super:
-      print("super")
-    case let x as Ternary:
-      print("(")
-      print(x.condition)
-      print(" ? ")
-      print(x.thenBranch)
-      print(" : ")
-      print(x.elseBranch)
-      print(")")
-    case let x as Try:
-      print("try ")
-      print(x.expression)
-    case let x as Tuple:
-      print("(")
-      printArguments(x.labels, x.arguments)
-      print(")")
-    case let x as TupleElement:
-      print(x.expression)
-      print(".")
-      print(x.field)
-    case let x as Unquote:
-      print("#unquote(")
-      print(x.expression)
-      print(")")
-    case _ as Wildcard:
-      print("_")
-    case let x as Function:
-      print("func ")
-      print(x.name)
-      print("(", x.parameters, ", ", ")") { print($0) }
-      print(" -> ")
-      print(x.result)
-      printBody(" in\n", x.body, "}")
-    case let x as Let:
-      print("let ")
-      print(x.name)
-      print(": ", x.type) { print($0) }
-      print(" = ")
-      print(x.rhs)
-    case let x as Parameter:
-      if let label = x.label {
-        print(label)
-        print(": ")
-      } else {
-        print("_ ")
-      }
-      print(x.name)
-      print(": ")
-      print(x.type)
-    case let x as Var:
-      print("var ")
-      print(x.name)
-      print(": ", x.type) { print($0) }
-      print(" = ")
-      print(x.rhs)
-    default:
-      print("<?>")
     }
-  }
 
-  private func printArguments(_ labels: [String?], _ arguments: [Expression]) {
-    var needComma = false
-    // TODO(TF-731): Figure out why this is necessary.
-    var fixedLabels: [String?] = labels
-    if labels.count == 0 {
-      fixedLabels = Array(repeating: nil, count: arguments.count)
-    }
-    for (label, argument) in zip(fixedLabels, arguments) {
-      if argument is Default {
-        print("")
-      } else {
-        if (needComma) {
-          needComma = false
-          print(", ")
+    private func printArguments(_ labels: [String?], _ arguments: [Expression]) {
+        var needComma = false
+        // TODO(TF-731): Figure out why this is necessary.
+        var fixedLabels: [String?] = labels
+        if labels.count == 0 {
+            fixedLabels = Array(repeating: nil, count: arguments.count)
         }
-        print(label, ": ") { print($0) }
-        if let arguments = argument as? Varargs {
-          print(arguments.expressions, ", ") { print($0) }
-        } else {
-          print(argument)
+        for (label, argument) in zip(fixedLabels, arguments) {
+            if argument is Default {
+                print("")
+            } else {
+                if (needComma) {
+                    needComma = false
+                    print(", ")
+                }
+                print(label, ": ") { print($0) }
+                if let arguments = argument as? Varargs {
+                    print(arguments.expressions, ", ") { print($0) }
+                } else {
+                    print(argument)
+                }
+                needComma = true
+            }
         }
-        needComma = true
-      }
     }
-  }
 
-  private func printBody(_ pre: String, _ body: [Statement], _ suffix: String) {
-    print(pre)
-    indent()
-    print(whenEmpty: false, "", body, "\n", "\n") { print($0) }
-    unindent()
-    print(suffix)
-  }
+    private func printBody(_ pre: String, _ body: [Statement], _ suffix: String) {
+        print(pre)
+        indent()
+        print(whenEmpty: false, "", body, "\n", "\n") { print($0) }
+        unindent()
+        print(suffix)
+    }
 }

--- a/Sources/Quote/Description.swift
+++ b/Sources/Quote/Description.swift
@@ -1,0 +1,324 @@
+extension Tree {
+  /// Returns Swift-like syntax of the tree.
+  /// The printouts may contain occurrences of <?> which stand for `UnknownTree`
+  /// nodes which represent unsupported language constructs.
+  public var description: String {
+    let p = DescriptionPrinter()
+    p.print(self)
+    return p.description
+  }
+}
+
+extension Quote {
+  /// Returns Swift-like syntax of the underlying tree.
+  public var description: String {
+    return expression.description
+  }
+}
+
+class DescriptionPrinter: Printer {
+  func print(_ tree: Tree) {
+    switch tree {
+    case _ as Differentiable:
+      print("@differentiable")
+    case let x as AndType:
+      print(x.types, " & ") { print($0) }
+    case let x as ArrayType:
+      print("[")
+      print(x.type)
+      print("]")
+    case let x as DictionaryType:
+      print("[")
+      print(x.key)
+      print(": ")
+      print(x.value)
+      print("]")
+    case let x as FunctionType:
+      print(whenEmpty: false, "", x.attributes, " ", " ") { print($0) }
+      print("(", x.parameters, ", ", ")") { print($0) }
+      print(" -> ")
+      print(x.result)
+    case let x as InoutType:
+      print("inout ")
+      print(x.type)
+    case let x as LValueType:
+      print(x.type)
+    case let x as MetaType:
+      // NOTE: We don't have enough context to decide whether we should say .Type or .Protocol here.
+      // However, it's just a prettyprinter - we don't have to emit 100% valid Swift code.
+      print(x.type)
+      print(".Type")
+    case let x as OptionalType:
+      print(x.type)
+      print("?")
+    case let x as SpecializedType:
+      print(x.type)
+      print("[", x.arguments, ", ", "]") { print($0) }
+    case let x as TupleType:
+      print("(", x.types, ", ", ")") { print($0) }
+    case let x as TypeName:
+      print(x.value)
+    case let x as Break:
+      print("break")
+      print(" ", x.label) { print($0) }
+    case let x as Continue:
+      print("continue")
+      print(" ", x.label) { print($0) }
+    case let x as Defer:
+      print("defer")
+      printBody(" {\n", x.body, "}")
+    case let x as Do:
+      print(x.label, ": ") { print($0) }
+      print("do")
+      printBody(" {\n", x.body, "}")
+    case let x as For:
+      print(x.label, ": ") { print($0) }
+      print("for ")
+      print(x.name)
+      print(" in ")
+      print(x.expression)
+      printBody(" {\n", x.body, "}")
+    case let x as Guard:
+      print("guard ")
+      print(x.condition, ", ") { print($0) }
+      printBody(" else {\n", x.body, "}")
+    case let x as If:
+      print(x.label, ": ") { print($0) }
+      print("if ")
+      print(x.condition, ", ") { print($0) }
+      printBody(" {\n", x.thenBranch, "}")
+      guard x.elseBranch.count > 0 else { return }
+      printBody(" else {\n", x.elseBranch, "}")
+    case let x as Repeat:
+      print(x.label, ": ") { print($0) }
+      print("repeat")
+      printBody(" {\n", x.body, "}")
+      print(" while ")
+      print(x.condition)
+    case let x as Return:
+      print("return ")
+      print(x.expression)
+    case let x as Throw:
+      print("throw ")
+      print(x.expression)
+    case let x as While:
+      print(x.label, ": ") { print($0) }
+      print("while ")
+      print(x.condition, ", ") { print($0) }
+      printBody(" {\n", x.body, "}")
+    case let x as ArrayLiteral:
+      print("[", x.expressions, ", ", "]") { print($0) }
+    case let x as As:
+      print("(")
+      print(x.expression)
+      print(" as ")
+      print(x.type)
+      print(")")
+    case let x as Assign:
+      print(x.lhs)
+      print(" = ")
+      print(x.rhs)
+    case let x as Binary:
+      print("(")
+      print(x.lhs)
+      print(" ")
+      print(x.name)
+      print(" ")
+      print(x.rhs)
+      print(")")
+    case let x as BooleanLiteral:
+      print(x.value)
+    case let x as Call:
+      print(x.expression)
+      print("(")
+      printArguments(x.labels, x.arguments)
+      print(")")
+    case let x as Closure:
+      print("{ ")
+      print("(", x.parameters, ", ", ")") {
+        print($0.name)
+        print(": ")
+        print($0.type)
+      }
+      print(" -> ")
+      print(x.result)
+      printBody(" in\n", x.body, "}")
+    case let x as Conversion:
+      print(x.expression)
+    case let x as DictionaryLiteral:
+      print("[")
+      var sep = ""
+      for expr in x.expressions {
+        if sep.count != 0 {
+          print(sep)
+        }
+        sep = sep == ": " ? ", " : ": "
+        print(expr)
+      }
+      print("]")
+    case let x as FloatLiteral:
+      print(x.value)
+    case let x as Force:
+      print(x.expression)
+      print("!")
+    case let x as ForceAs:
+      print("(")
+      print(x.expression)
+      print(" as! ")
+      print(x.type)
+      print(")")
+    case let x as ForceTry:
+      print("try! ")
+      print(x.expression)
+    case let x as Inout:
+      print("&")
+      print(x.expression)
+    case let x as IntegerLiteral:
+      print(x.value)
+    case let x as Is:
+      print("(")
+      print(x.expression)
+      print(" is ")
+      print(x.targetType)
+      print(")")
+    case let x as MagicLiteral:
+      print("#")
+      print(x.kind)
+    case let x as Member:
+      print(x.expression)
+      print(".")
+      print(x.value)
+    case let x as Meta:
+      print("#quote(")
+      print(x.expression)
+      print(")")
+    case let x as Name:
+      print(x.value)
+    case _ as NilLiteral:
+      print("nil")
+    case let x as OptionalAs:
+      print("(")
+      print(x.expression)
+      print(" as? ")
+      print(x.targetType)
+      print(")")
+    case let x as OptionalTry:
+      print("try? ")
+      print(x.expression)
+    case let x as Postfix:
+      print("(")
+      print(x.expression)
+      print(x.name)
+      print(")")
+    case let x as PostfixSelf:
+      print(x.tree)
+      print(".self")
+    case let x as Prefix:
+      print("(")
+      print(x.name)
+      print(x.expression)
+      print(")")
+    case _ as StringInterpolation:
+      literal("...")
+    case let x as StringLiteral:
+      literal(x.value)
+    case let x as Subscript:
+      print(x.expression)
+      print("[")
+      printArguments(x.labels, x.arguments)
+      print("]")
+    case _ as Super:
+      print("super")
+    case let x as Ternary:
+      print("(")
+      print(x.condition)
+      print(" ? ")
+      print(x.thenBranch)
+      print(" : ")
+      print(x.elseBranch)
+      print(")")
+    case let x as Try:
+      print("try ")
+      print(x.expression)
+    case let x as Tuple:
+      print("(")
+      printArguments(x.labels, x.arguments)
+      print(")")
+    case let x as TupleElement:
+      print(x.expression)
+      print(".")
+      print(x.field)
+    case let x as Unquote:
+      print("#unquote(")
+      print(x.expression)
+      print(")")
+    case _ as Wildcard:
+      print("_")
+    case let x as Function:
+      print("func ")
+      print(x.name)
+      print("(", x.parameters, ", ", ")") { print($0) }
+      print(" -> ")
+      print(x.result)
+      printBody(" in\n", x.body, "}")
+    case let x as Let:
+      print("let ")
+      print(x.name)
+      print(": ", x.type) { print($0) }
+      print(" = ")
+      print(x.rhs)
+    case let x as Parameter:
+      if let label = x.label {
+        print(label)
+        print(": ")
+      } else {
+        print("_ ")
+      }
+      print(x.name)
+      print(": ")
+      print(x.type)
+    case let x as Var:
+      print("var ")
+      print(x.name)
+      print(": ", x.type) { print($0) }
+      print(" = ")
+      print(x.rhs)
+    default:
+      print("<?>")
+    }
+  }
+
+  private func printArguments(_ labels: [String?], _ arguments: [Expression]) {
+    var needComma = false
+    // TODO(#1): Figure out why this is necessary.
+    var fixedLabels: [String?] = labels
+    if labels.count == 0 {
+      fixedLabels = Array(repeating: nil, count: arguments.count)
+    }
+    for (label, argument) in zip(fixedLabels, arguments) {
+      if argument is Default {
+        print("")
+      } else {
+        if (needComma) {
+          needComma = false
+          print(", ")
+        }
+        print(label, ": ") { print($0) }
+        if let arguments = argument as? Varargs {
+          print(arguments.expressions, ", ") { print($0) }
+        } else {
+          print(argument)
+        }
+        needComma = true
+      }
+    }
+  }
+
+  private func printBody(_ pre: String, _ body: [Statement], _ suffix: String) {
+    print(pre)
+    indent()
+    print(whenEmpty: false, "", body, "\n", "\n") { print($0) }
+    unindent()
+    print(suffix)
+  }
+}

--- a/Sources/Quote/Printer.swift
+++ b/Sources/Quote/Printer.swift
@@ -1,87 +1,87 @@
 class Printer: CustomStringConvertible {
-  var description: String = ""
-  private var indentation: String = ""
-  private var indented: Bool = false
+    var description: String = ""
+    private var indentation: String = ""
+    private var indented: Bool = false
 
-  func indent() {
-    let count = indentation.count + 2
-    indentation = String(repeating: " ", count: count)
-  }
-
-  func unindent() {
-    let count = max(indentation.count - 2, 0)
-    indentation = String(repeating: " ", count: count)
-  }
-
-  func print<T: CustomStringConvertible>(when: Bool = true, _ x: T) {
-    print(when: when, x.description)
-  }
-
-  func print(when: Bool = true, _ s: String) {
-    guard when else { return }
-    let lines = s.split(omittingEmptySubsequences: false) { $0.isNewline }
-    for (i, line) in lines.enumerated() {
-      if !indented && !line.isEmpty {
-        description += indentation
-        indented = true
-      }
-      description += line
-      if i < lines.count - 1 {
-        description += "\n"
-        indented = false
-      }
+    func indent() {
+        let count = indentation.count + 2
+        indentation = String(repeating: " ", count: count)
     }
-  }
 
-  func print<T>(_ x: T?, _ fn: (T) -> Void) {
-    guard let x = x else { return }
-    fn(x)
-  }
-
-  func print<T>(_ pre: String, _ x: T?, _ fn: (T) -> Void) {
-    guard let x = x else { return }
-    print(pre)
-    fn(x)
-  }
-
-  func print<T>(_ x: T?, _ suf: String, _ fn: (T) -> Void) {
-    guard let x = x else { return }
-    fn(x)
-    print(suf)
-  }
-
-  func print<S: Collection>(_ xs: S, _ sep: String, _ fn: (S.Element) -> Void) {
-    var needSep = false
-    for x in xs {
-      if needSep {
-        print(sep)
-      }
-      needSep = true
-      fn(x)
+    func unindent() {
+        let count = max(indentation.count - 2, 0)
+        indentation = String(repeating: " ", count: count)
     }
-  }
 
-  func print<S: Collection>(
-    whenEmpty: Bool = true, _ pre: String, _ xs: S, _ sep: String, _ suf: String,
-    _ fn: (S.Element) -> Void
-  ) {
-    guard !xs.isEmpty || whenEmpty else { return }
-    print(pre)
-    print(xs, sep, fn)
-    print(suf)
-  }
-
-  func literal(_ s: String) {
-    print("\"")
-    print(s)
-    print("\"")
-  }
-
-  func literal(_ s: String?) {
-    if let s = s {
-      literal(s)
-    } else {
-      print("nil")
+    func print<T: CustomStringConvertible>(when: Bool = true, _ x: T) {
+        print(when: when, x.description)
     }
-  }
+
+    func print(when: Bool = true, _ s: String) {
+        guard when else { return }
+        let lines = s.split(omittingEmptySubsequences: false) { $0.isNewline }
+        for (i, line) in lines.enumerated() {
+            if !indented && !line.isEmpty {
+                description += indentation
+                indented = true
+            }
+            description += line
+            if i < lines.count - 1 {
+                description += "\n"
+                indented = false
+            }
+        }
+    }
+
+    func print<T>(_ x: T?, _ fn: (T) -> Void) {
+        guard let x = x else { return }
+        fn(x)
+    }
+
+    func print<T>(_ pre: String, _ x: T?, _ fn: (T) -> Void) {
+        guard let x = x else { return }
+        print(pre)
+        fn(x)
+    }
+
+    func print<T>(_ x: T?, _ suf: String, _ fn: (T) -> Void) {
+        guard let x = x else { return }
+        fn(x)
+        print(suf)
+    }
+
+    func print<S: Collection>(_ xs: S, _ sep: String, _ fn: (S.Element) -> Void) {
+        var needSep = false
+        for x in xs {
+            if needSep {
+                print(sep)
+            }
+            needSep = true
+            fn(x)
+        }
+    }
+
+    func print<S: Collection>(
+        whenEmpty: Bool = true, _ pre: String, _ xs: S, _ sep: String, _ suf: String,
+        _ fn: (S.Element) -> Void
+    ) {
+        guard !xs.isEmpty || whenEmpty else { return }
+        print(pre)
+        print(xs, sep, fn)
+        print(suf)
+    }
+
+    func literal(_ s: String) {
+        print("\"")
+        print(s)
+        print("\"")
+    }
+
+    func literal(_ s: String?) {
+        if let s = s {
+            literal(s)
+        } else {
+            print("nil")
+        }
+    }
 }

--- a/Sources/Quote/Printer.swift
+++ b/Sources/Quote/Printer.swift
@@ -72,7 +72,6 @@ class Printer: CustomStringConvertible {
   }
 
   func literal(_ s: String) {
-    // TODO(#28): Print string literals with control characters in a useful way.
     print("\"")
     print(s)
     print("\"")

--- a/Sources/Quote/Printer.swift
+++ b/Sources/Quote/Printer.swift
@@ -1,0 +1,88 @@
+class Printer: CustomStringConvertible {
+  var description: String = ""
+  private var indentation: String = ""
+  private var indented: Bool = false
+
+  func indent() {
+    let count = indentation.count + 2
+    indentation = String(repeating: " ", count: count)
+  }
+
+  func unindent() {
+    let count = max(indentation.count - 2, 0)
+    indentation = String(repeating: " ", count: count)
+  }
+
+  func print<T: CustomStringConvertible>(when: Bool = true, _ x: T) {
+    print(when: when, x.description)
+  }
+
+  func print(when: Bool = true, _ s: String) {
+    guard when else { return }
+    let lines = s.split(omittingEmptySubsequences: false) { $0.isNewline }
+    for (i, line) in lines.enumerated() {
+      if !indented && !line.isEmpty {
+        description += indentation
+        indented = true
+      }
+      description += line
+      if i < lines.count - 1 {
+        description += "\n"
+        indented = false
+      }
+    }
+  }
+
+  func print<T>(_ x: T?, _ fn: (T) -> Void) {
+    guard let x = x else { return }
+    fn(x)
+  }
+
+  func print<T>(_ pre: String, _ x: T?, _ fn: (T) -> Void) {
+    guard let x = x else { return }
+    print(pre)
+    fn(x)
+  }
+
+  func print<T>(_ x: T?, _ suf: String, _ fn: (T) -> Void) {
+    guard let x = x else { return }
+    fn(x)
+    print(suf)
+  }
+
+  func print<S: Collection>(_ xs: S, _ sep: String, _ fn: (S.Element) -> Void) {
+    var needSep = false
+    for x in xs {
+      if needSep {
+        print(sep)
+      }
+      needSep = true
+      fn(x)
+    }
+  }
+
+  func print<S: Collection>(
+    whenEmpty: Bool = true, _ pre: String, _ xs: S, _ sep: String, _ suf: String,
+    _ fn: (S.Element) -> Void
+  ) {
+    guard !xs.isEmpty || whenEmpty else { return }
+    print(pre)
+    print(xs, sep, fn)
+    print(suf)
+  }
+
+  func literal(_ s: String) {
+    // TODO(#28): Print string literals with control characters in a useful way.
+    print("\"")
+    print(s)
+    print("\"")
+  }
+
+  func literal(_ s: String?) {
+    if let s = s {
+      literal(s)
+    } else {
+      print("nil")
+    }
+  }
+}

--- a/Sources/Quote/Quote.swift
+++ b/Sources/Quote/Quote.swift
@@ -1,12 +1,12 @@
 /// Statically-typed wrapper for an expression.
 /// The phantom type `T` is a compile-type representation of `type`.
 public class Quote<T>: CustomStringConvertible {
-  public let expression: Expression
-  public var type: Type { return expression.type }
+    public let expression: Expression
+    public var type: Type { return expression.type }
 
-  public init(_ expression: Expression) {
-    self.expression = expression
-  }
+    public init(_ expression: Expression) {
+        self.expression = expression
+    }
 }
 
 /// Specialized version of Quote that wraps closures with zero parameters.

--- a/Sources/Quote/Quote.swift
+++ b/Sources/Quote/Quote.swift
@@ -1,0 +1,31 @@
+/// Statically-typed wrapper for an expression.
+/// The phantom type `T` is a compile-type representation of `type`.
+public class Quote<T>: CustomStringConvertible {
+  public let expression: Expression
+  public var type: Type { return expression.type }
+
+  public init(_ expression: Expression) {
+    self.expression = expression
+  }
+}
+
+/// Specialized version of Quote that wraps closures with zero parameters.
+public class FunctionQuote0<R>: Quote<() -> R> {}
+
+/// Specialized version of Quote that wraps closures with one parameter.
+public class FunctionQuote1<T1, R>: Quote<(T1) -> R> {}
+
+/// Specialized version of Quote that wraps closures with two parameters.
+public class FunctionQuote2<T1, T2, R>: Quote<(T1, T2) -> R> {}
+
+/// Specialized version of Quote that wraps closures with three parameters.
+public class FunctionQuote3<T1, T2, T3, R>: Quote<(T1, T2, T3) -> R> {}
+
+/// Specialized version of Quote that wraps closures with four parameters.
+public class FunctionQuote4<T1, T2, T3, T4, R>: Quote<(T1, T2, T3, T4) -> R> {}
+
+/// Specialized version of Quote that wraps closures with five parameters.
+public class FunctionQuote5<T1, T2, T3, T4, T5, R>: Quote<(T1, T2, T3, T4, T5) -> R> {}
+
+/// Specialized version of Quote that wraps closures with six parameters.
+public class FunctionQuote6<T1, T2, T3, T4, T5, T6, R>: Quote<(T1, T2, T3, T4, T5, T6) -> R> {}

--- a/Sources/Quote/Structure.swift
+++ b/Sources/Quote/Structure.swift
@@ -1,0 +1,401 @@
+extension Tree {
+  /// Returns a string that can be copy/pasted into a Swift program or REPL
+  /// and reconstruct the tree.
+  public var structure: String {
+    let p = StructurePrinter()
+    p.print(self)
+    return p.description
+  }
+}
+
+extension Quote {
+  /// Returns a string that can be copy/pasted into a Swift program or REPL
+  /// and reconstruct the underlying tree.
+  public var structure: String {
+    return expression.structure
+  }
+}
+
+class StructurePrinter: Printer {
+  func print(_ tree: Tree) {
+    switch tree {
+    case _ as Differentiable:
+      print("Differentiable()")
+    case let x as AndType:
+      object("AndType") {
+        collection("types", x.types) { print($0) }
+      }
+    case let x as ArrayType:
+      object("ArrayType") {
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as DictionaryType:
+      object("DictionaryType") {
+        scalar("key", x.key) { print($0) }
+        scalar("value", x.value) { print($0) }
+      }
+    case let x as FunctionType:
+      object("FunctionType") {
+        collection("attributes", x.attributes) { print($0) }
+        collection("parameters", x.parameters) { print($0) }
+        scalar("result", x.result) { print($0) }
+      }
+    case let x as InoutType:
+      object("InoutType") {
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as LValueType:
+      object("LValueType") {
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as MetaType:
+      object("MetaType") {
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as OptionalType:
+      object("OptionalType") {
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as SpecializedType:
+      object("SpecializedType") {
+        scalar("type", x.type) { print($0) }
+        collection("arguments", x.arguments) { print($0) }
+      }
+    case let x as TupleType:
+      object("TupleType") {
+        collection("types", x.types) { print($0) }
+      }
+    case let x as TypeName:
+      print("TypeName(")
+      literal(x.value)
+      print(", ")
+      literal(x.symbol)
+      print(")")
+    case let x as Break:
+      object("Break") {
+        scalar("label", x.label) { literal($0) }
+      }
+    case let x as Continue:
+      object("Continue") {
+        scalar("label", x.label) { literal($0) }
+      }
+    case let x as Defer:
+      object("Defer") {
+        collection("body", x.body) { print($0) }
+      }
+    case let x as Do:
+      object("Do") {
+        scalar("label", x.label) { literal($0) }
+        collection("body", x.body) { print($0) }
+      }
+    case let x as For:
+      object("For") {
+        scalar("label", x.label) { literal($0) }
+        scalar("name", x.name) { print($0) }
+        scalar("expression", x.expression) { print($0) }
+        collection("body", x.body) { print($0) }
+      }
+    case let x as Guard:
+      object("Guard") {
+        collection("condition", x.condition) { print($0) }
+        collection("body", x.body) { print($0) }
+      }
+    case let x as If:
+      object("If") {
+        scalar("label", x.label) { literal($0) }
+        collection("condition", x.condition) { print($0) }
+        collection("thenBranch", x.thenBranch) { print($0) }
+        collection("elseBranch", x.elseBranch) { print($0) }
+      }
+    case let x as Repeat:
+      object("Repeat") {
+        scalar("label", x.label) { literal($0) }
+        collection("body", x.body) { print($0) }
+        scalar("condition", x.condition) { print($0) }
+      }
+    case let x as Return:
+      object("Return") {
+        scalar("expression", x.expression) { print($0) }
+      }
+    case let x as Throw:
+      object("Throw") {
+        scalar("expression", x.expression) { print($0) }
+      }
+    case let x as While:
+      object("While") {
+        scalar("label", x.label) { literal($0) }
+        collection("condition", x.condition) { print($0) }
+        collection("body", x.body) { print($0) }
+      }
+    case let x as ArrayLiteral:
+      object("ArrayLiteral") {
+        collection("expressions", x.expressions) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as As:
+      object("As") {
+        scalar("expression", x.expression) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as Assign:
+      object("Assign") {
+        scalar("lhs", x.lhs) { print($0) }
+        scalar("rhs", x.rhs) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as Binary:
+      object("Binary") {
+        scalar("lhs", x.lhs) { print($0) }
+        scalar("name", x.name) { print($0) }
+        scalar("rhs", x.rhs) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as BooleanLiteral:
+      object("BooleanLiteral") {
+        scalar("value", x.value) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as Call:
+      object("Call") {
+        scalar("expression", x.expression) { print($0) }
+        collection("labels", x.labels) { literal($0) }
+        collection("arguments", x.arguments) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as Default:
+      object("Default") {
+        scalar("symbol", x.symbol) { literal($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as DictionaryLiteral:
+      object("DictionaryLiteral") {
+        collection("expressions", x.expressions) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as Closure:
+      object("Closure") {
+        collection("parameters", x.parameters) { print($0) }
+        collection("body", x.body) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as Conversion:
+      object("Conversion") {
+        scalar("expression", x.expression) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as FloatLiteral:
+      object("FloatLiteral") {
+        scalar("value", x.value) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as Force:
+      object("Force") {
+        scalar("expression", x.expression) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as ForceAs:
+      object("ForceAs") {
+        scalar("expression", x.expression) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as ForceTry:
+      object("ForceTry") {
+        scalar("expression", x.expression) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as Inout:
+      object("InOut") {
+        scalar("expression", x.expression) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as IntegerLiteral:
+      object("IntegerLiteral") {
+        scalar("value", x.value) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as Is:
+      object("Is") {
+        scalar("expression", x.expression) { print($0) }
+        scalar("targetType", x.targetType) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as MagicLiteral:
+      object("MagicLiteral") {
+        scalar("kind", x.kind) { literal($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as Member:
+      object("Member") {
+        scalar("expression", x.expression) { print($0) }
+        scalar("value", x.value) { literal($0) }
+        scalar("symbol", x.symbol) { literal($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as Meta:
+      object("Meta") {
+        scalar("expression", x.expression) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as Name:
+      object("Name") {
+        scalar("value", x.value) { literal($0) }
+        scalar("symbol", x.symbol) { literal($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as NilLiteral:
+      object("NilLiteral") {
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as OptionalAs:
+      object("OptionalAs") {
+        scalar("expression", x.expression) { print($0) }
+        scalar("targetType", x.targetType) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as OptionalTry:
+      object("OptionalTry") {
+        scalar("expression", x.expression) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as Postfix:
+      object("Postfix") {
+        scalar("expression", x.expression) { print($0) }
+        scalar("name", x.name) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as PostfixSelf:
+      object("PostfixSelf") {
+        scalar("tree", x.tree) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as Prefix:
+      object("Prefix") {
+        scalar("name", x.name) { print($0) }
+        scalar("expression", x.expression) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as StringInterpolation:
+      object("StringInterpolation") {
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as StringLiteral:
+      object("StringLiteral") {
+        scalar("value", x.value) { literal($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as Subscript:
+      object("Subscript") {
+        scalar("expression", x.expression) { print($0) }
+        scalar("symbol", x.symbol) { literal($0) }
+        collection("labels", x.labels) { literal($0) }
+        collection("arguments", x.arguments) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as Super:
+      object("Super") {
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as Ternary:
+      object("Ternary") {
+        scalar("condition", x.condition) { print($0) }
+        scalar("thenBranch", x.thenBranch) { print($0) }
+        scalar("elseBranch", x.elseBranch) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as Try:
+      object("Try") {
+        scalar("expression", x.expression) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as Tuple:
+      object("Tuple") {
+        collection("labels", x.labels) { literal($0) }
+        collection("arguments", x.arguments) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as TupleElement:
+      object("TupleElement") {
+        scalar("expression", x.expression) { print($0) }
+        scalar("field", x.field) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as Unquote:
+      object("Unquote") {
+        scalar("expression", x.expression) { print($0) }
+        scalar("value", x.value) { print($0().description) }
+        scalar("type", x.type) { print($0) }
+      }
+    case let x as Varargs:
+      object("Varargs") {
+        collection("expressions", x.expressions) { print($0) }
+        scalar("type", x.type) { print($0) }
+      }
+    case _ as Wildcard:
+      print("Wildcard()")
+    case let x as Function:
+      object("Function") {
+        scalar("name", x.name) { print($0) }
+        collection("parameters", x.parameters) { print($0) }
+        collection("body", x.body) { print($0) }
+      }
+    case let x as Let:
+      object("Let") {
+        scalar("name", x.name) { print($0) }
+        scalar("rhs", x.rhs) { print($0) }
+      }
+    case let x as Parameter:
+      object("Parameter") {
+        scalar("label", x.label) { literal($0) }
+        scalar("name", x.name) { print($0) }
+      }
+    case let x as Var:
+      object("Var") {
+        scalar("name", x.name) { print($0) }
+        scalar("rhs", x.rhs) { print($0) }
+      }
+    case _ as UnknownTree:
+      print("UnknownTree()")
+    default:
+      print("<?>")
+    }
+  }
+
+  private func object(_ name: String, _ fn: () -> Void) {
+    print(name)
+    print("(")
+    indent()
+    fn()
+    unindent()
+    print(")")
+  }
+
+  private func scalar<T>(_ name: String, _ value: T, _ fn: (T) -> Void) {
+    let c = description.last!
+    if c == "(" || c == "[" {
+      print("\n")
+      fn(value)
+    } else {
+      print(",\n")
+      fn(value)
+    }
+  }
+
+  private func collection<S: Sequence>(
+    _ name: String,
+    _ value: S,
+    _ fn: (S.Element) -> Void
+  ) {
+    scalar(name, value) {
+      print("[")
+      var needSep = false
+      for el in $0 {
+        if needSep {
+          print(",\n")
+        }
+        needSep = true
+        fn(el)
+      }
+      print("]")
+    }
+  }
+}

--- a/Sources/Quote/Structure.swift
+++ b/Sources/Quote/Structure.swift
@@ -1,401 +1,401 @@
 extension Tree {
-  /// Returns a string that can be copy/pasted into a Swift program or REPL
-  /// and reconstruct the tree.
-  public var structure: String {
-    let p = StructurePrinter()
-    p.print(self)
-    return p.description
-  }
+    /// Returns a string that can be copy/pasted into a Swift program or REPL
+    /// and reconstruct the tree.
+    public var structure: String {
+        let p = StructurePrinter()
+        p.print(self)
+        return p.description
+    }
 }
 
 extension Quote {
-  /// Returns a string that can be copy/pasted into a Swift program or REPL
-  /// and reconstruct the underlying tree.
-  public var structure: String {
-    return expression.structure
-  }
+    /// Returns a string that can be copy/pasted into a Swift program or REPL
+    /// and reconstruct the underlying tree.
+    public var structure: String {
+        return expression.structure
+    }
 }
 
 class StructurePrinter: Printer {
-  func print(_ tree: Tree) {
-    switch tree {
-    case _ as Differentiable:
-      print("Differentiable()")
-    case let x as AndType:
-      object("AndType") {
-        collection("types", x.types) { print($0) }
-      }
-    case let x as ArrayType:
-      object("ArrayType") {
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as DictionaryType:
-      object("DictionaryType") {
-        scalar("key", x.key) { print($0) }
-        scalar("value", x.value) { print($0) }
-      }
-    case let x as FunctionType:
-      object("FunctionType") {
-        collection("attributes", x.attributes) { print($0) }
-        collection("parameters", x.parameters) { print($0) }
-        scalar("result", x.result) { print($0) }
-      }
-    case let x as InoutType:
-      object("InoutType") {
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as LValueType:
-      object("LValueType") {
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as MetaType:
-      object("MetaType") {
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as OptionalType:
-      object("OptionalType") {
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as SpecializedType:
-      object("SpecializedType") {
-        scalar("type", x.type) { print($0) }
-        collection("arguments", x.arguments) { print($0) }
-      }
-    case let x as TupleType:
-      object("TupleType") {
-        collection("types", x.types) { print($0) }
-      }
-    case let x as TypeName:
-      print("TypeName(")
-      literal(x.value)
-      print(", ")
-      literal(x.symbol)
-      print(")")
-    case let x as Break:
-      object("Break") {
-        scalar("label", x.label) { literal($0) }
-      }
-    case let x as Continue:
-      object("Continue") {
-        scalar("label", x.label) { literal($0) }
-      }
-    case let x as Defer:
-      object("Defer") {
-        collection("body", x.body) { print($0) }
-      }
-    case let x as Do:
-      object("Do") {
-        scalar("label", x.label) { literal($0) }
-        collection("body", x.body) { print($0) }
-      }
-    case let x as For:
-      object("For") {
-        scalar("label", x.label) { literal($0) }
-        scalar("name", x.name) { print($0) }
-        scalar("expression", x.expression) { print($0) }
-        collection("body", x.body) { print($0) }
-      }
-    case let x as Guard:
-      object("Guard") {
-        collection("condition", x.condition) { print($0) }
-        collection("body", x.body) { print($0) }
-      }
-    case let x as If:
-      object("If") {
-        scalar("label", x.label) { literal($0) }
-        collection("condition", x.condition) { print($0) }
-        collection("thenBranch", x.thenBranch) { print($0) }
-        collection("elseBranch", x.elseBranch) { print($0) }
-      }
-    case let x as Repeat:
-      object("Repeat") {
-        scalar("label", x.label) { literal($0) }
-        collection("body", x.body) { print($0) }
-        scalar("condition", x.condition) { print($0) }
-      }
-    case let x as Return:
-      object("Return") {
-        scalar("expression", x.expression) { print($0) }
-      }
-    case let x as Throw:
-      object("Throw") {
-        scalar("expression", x.expression) { print($0) }
-      }
-    case let x as While:
-      object("While") {
-        scalar("label", x.label) { literal($0) }
-        collection("condition", x.condition) { print($0) }
-        collection("body", x.body) { print($0) }
-      }
-    case let x as ArrayLiteral:
-      object("ArrayLiteral") {
-        collection("expressions", x.expressions) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as As:
-      object("As") {
-        scalar("expression", x.expression) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as Assign:
-      object("Assign") {
-        scalar("lhs", x.lhs) { print($0) }
-        scalar("rhs", x.rhs) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as Binary:
-      object("Binary") {
-        scalar("lhs", x.lhs) { print($0) }
-        scalar("name", x.name) { print($0) }
-        scalar("rhs", x.rhs) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as BooleanLiteral:
-      object("BooleanLiteral") {
-        scalar("value", x.value) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as Call:
-      object("Call") {
-        scalar("expression", x.expression) { print($0) }
-        collection("labels", x.labels) { literal($0) }
-        collection("arguments", x.arguments) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as Default:
-      object("Default") {
-        scalar("symbol", x.symbol) { literal($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as DictionaryLiteral:
-      object("DictionaryLiteral") {
-        collection("expressions", x.expressions) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as Closure:
-      object("Closure") {
-        collection("parameters", x.parameters) { print($0) }
-        collection("body", x.body) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as Conversion:
-      object("Conversion") {
-        scalar("expression", x.expression) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as FloatLiteral:
-      object("FloatLiteral") {
-        scalar("value", x.value) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as Force:
-      object("Force") {
-        scalar("expression", x.expression) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as ForceAs:
-      object("ForceAs") {
-        scalar("expression", x.expression) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as ForceTry:
-      object("ForceTry") {
-        scalar("expression", x.expression) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as Inout:
-      object("InOut") {
-        scalar("expression", x.expression) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as IntegerLiteral:
-      object("IntegerLiteral") {
-        scalar("value", x.value) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as Is:
-      object("Is") {
-        scalar("expression", x.expression) { print($0) }
-        scalar("targetType", x.targetType) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as MagicLiteral:
-      object("MagicLiteral") {
-        scalar("kind", x.kind) { literal($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as Member:
-      object("Member") {
-        scalar("expression", x.expression) { print($0) }
-        scalar("value", x.value) { literal($0) }
-        scalar("symbol", x.symbol) { literal($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as Meta:
-      object("Meta") {
-        scalar("expression", x.expression) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as Name:
-      object("Name") {
-        scalar("value", x.value) { literal($0) }
-        scalar("symbol", x.symbol) { literal($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as NilLiteral:
-      object("NilLiteral") {
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as OptionalAs:
-      object("OptionalAs") {
-        scalar("expression", x.expression) { print($0) }
-        scalar("targetType", x.targetType) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as OptionalTry:
-      object("OptionalTry") {
-        scalar("expression", x.expression) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as Postfix:
-      object("Postfix") {
-        scalar("expression", x.expression) { print($0) }
-        scalar("name", x.name) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as PostfixSelf:
-      object("PostfixSelf") {
-        scalar("tree", x.tree) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as Prefix:
-      object("Prefix") {
-        scalar("name", x.name) { print($0) }
-        scalar("expression", x.expression) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as StringInterpolation:
-      object("StringInterpolation") {
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as StringLiteral:
-      object("StringLiteral") {
-        scalar("value", x.value) { literal($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as Subscript:
-      object("Subscript") {
-        scalar("expression", x.expression) { print($0) }
-        scalar("symbol", x.symbol) { literal($0) }
-        collection("labels", x.labels) { literal($0) }
-        collection("arguments", x.arguments) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as Super:
-      object("Super") {
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as Ternary:
-      object("Ternary") {
-        scalar("condition", x.condition) { print($0) }
-        scalar("thenBranch", x.thenBranch) { print($0) }
-        scalar("elseBranch", x.elseBranch) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as Try:
-      object("Try") {
-        scalar("expression", x.expression) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as Tuple:
-      object("Tuple") {
-        collection("labels", x.labels) { literal($0) }
-        collection("arguments", x.arguments) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as TupleElement:
-      object("TupleElement") {
-        scalar("expression", x.expression) { print($0) }
-        scalar("field", x.field) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as Unquote:
-      object("Unquote") {
-        scalar("expression", x.expression) { print($0) }
-        scalar("value", x.value) { print($0().description) }
-        scalar("type", x.type) { print($0) }
-      }
-    case let x as Varargs:
-      object("Varargs") {
-        collection("expressions", x.expressions) { print($0) }
-        scalar("type", x.type) { print($0) }
-      }
-    case _ as Wildcard:
-      print("Wildcard()")
-    case let x as Function:
-      object("Function") {
-        scalar("name", x.name) { print($0) }
-        collection("parameters", x.parameters) { print($0) }
-        collection("body", x.body) { print($0) }
-      }
-    case let x as Let:
-      object("Let") {
-        scalar("name", x.name) { print($0) }
-        scalar("rhs", x.rhs) { print($0) }
-      }
-    case let x as Parameter:
-      object("Parameter") {
-        scalar("label", x.label) { literal($0) }
-        scalar("name", x.name) { print($0) }
-      }
-    case let x as Var:
-      object("Var") {
-        scalar("name", x.name) { print($0) }
-        scalar("rhs", x.rhs) { print($0) }
-      }
-    case _ as UnknownTree:
-      print("UnknownTree()")
-    default:
-      print("<?>")
-    }
-  }
-
-  private func object(_ name: String, _ fn: () -> Void) {
-    print(name)
-    print("(")
-    indent()
-    fn()
-    unindent()
-    print(")")
-  }
-
-  private func scalar<T>(_ name: String, _ value: T, _ fn: (T) -> Void) {
-    let c = description.last!
-    if c == "(" || c == "[" {
-      print("\n")
-      fn(value)
-    } else {
-      print(",\n")
-      fn(value)
-    }
-  }
-
-  private func collection<S: Sequence>(
-    _ name: String,
-    _ value: S,
-    _ fn: (S.Element) -> Void
-  ) {
-    scalar(name, value) {
-      print("[")
-      var needSep = false
-      for el in $0 {
-        if needSep {
-          print(",\n")
+    func print(_ tree: Tree) {
+        switch tree {
+        case _ as Differentiable:
+            print("Differentiable()")
+        case let x as AndType:
+            object("AndType") {
+                collection("types", x.types) { print($0) }
+            }
+        case let x as ArrayType:
+            object("ArrayType") {
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as DictionaryType:
+            object("DictionaryType") {
+                scalar("key", x.key) { print($0) }
+                scalar("value", x.value) { print($0) }
+            }
+        case let x as FunctionType:
+            object("FunctionType") {
+                collection("attributes", x.attributes) { print($0) }
+                collection("parameters", x.parameters) { print($0) }
+                scalar("result", x.result) { print($0) }
+            }
+        case let x as InoutType:
+            object("InoutType") {
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as LValueType:
+            object("LValueType") {
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as MetaType:
+            object("MetaType") {
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as OptionalType:
+            object("OptionalType") {
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as SpecializedType:
+            object("SpecializedType") {
+                scalar("type", x.type) { print($0) }
+                collection("arguments", x.arguments) { print($0) }
+            }
+        case let x as TupleType:
+            object("TupleType") {
+                collection("types", x.types) { print($0) }
+            }
+        case let x as TypeName:
+            print("TypeName(")
+            literal(x.value)
+            print(", ")
+            literal(x.symbol)
+            print(")")
+        case let x as Break:
+            object("Break") {
+                scalar("label", x.label) { literal($0) }
+            }
+        case let x as Continue:
+            object("Continue") {
+                scalar("label", x.label) { literal($0) }
+            }
+        case let x as Defer:
+            object("Defer") {
+                collection("body", x.body) { print($0) }
+            }
+        case let x as Do:
+            object("Do") {
+                scalar("label", x.label) { literal($0) }
+                collection("body", x.body) { print($0) }
+            }
+        case let x as For:
+            object("For") {
+                scalar("label", x.label) { literal($0) }
+                scalar("name", x.name) { print($0) }
+                scalar("expression", x.expression) { print($0) }
+                collection("body", x.body) { print($0) }
+            }
+        case let x as Guard:
+            object("Guard") {
+                collection("condition", x.condition) { print($0) }
+                collection("body", x.body) { print($0) }
+            }
+        case let x as If:
+            object("If") {
+                scalar("label", x.label) { literal($0) }
+                collection("condition", x.condition) { print($0) }
+                collection("thenBranch", x.thenBranch) { print($0) }
+                collection("elseBranch", x.elseBranch) { print($0) }
+            }
+        case let x as Repeat:
+            object("Repeat") {
+                scalar("label", x.label) { literal($0) }
+                collection("body", x.body) { print($0) }
+                scalar("condition", x.condition) { print($0) }
+            }
+        case let x as Return:
+            object("Return") {
+                scalar("expression", x.expression) { print($0) }
+            }
+        case let x as Throw:
+            object("Throw") {
+                scalar("expression", x.expression) { print($0) }
+            }
+        case let x as While:
+            object("While") {
+                scalar("label", x.label) { literal($0) }
+                collection("condition", x.condition) { print($0) }
+                collection("body", x.body) { print($0) }
+            }
+        case let x as ArrayLiteral:
+            object("ArrayLiteral") {
+                collection("expressions", x.expressions) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as As:
+            object("As") {
+                scalar("expression", x.expression) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as Assign:
+            object("Assign") {
+                scalar("lhs", x.lhs) { print($0) }
+                scalar("rhs", x.rhs) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as Binary:
+            object("Binary") {
+                scalar("lhs", x.lhs) { print($0) }
+                scalar("name", x.name) { print($0) }
+                scalar("rhs", x.rhs) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as BooleanLiteral:
+            object("BooleanLiteral") {
+                scalar("value", x.value) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as Call:
+            object("Call") {
+                scalar("expression", x.expression) { print($0) }
+                collection("labels", x.labels) { literal($0) }
+                collection("arguments", x.arguments) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as Default:
+            object("Default") {
+                scalar("symbol", x.symbol) { literal($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as DictionaryLiteral:
+            object("DictionaryLiteral") {
+                collection("expressions", x.expressions) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as Closure:
+            object("Closure") {
+                collection("parameters", x.parameters) { print($0) }
+                collection("body", x.body) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as Conversion:
+            object("Conversion") {
+                scalar("expression", x.expression) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as FloatLiteral:
+            object("FloatLiteral") {
+                scalar("value", x.value) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as Force:
+            object("Force") {
+                scalar("expression", x.expression) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as ForceAs:
+            object("ForceAs") {
+                scalar("expression", x.expression) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as ForceTry:
+            object("ForceTry") {
+                scalar("expression", x.expression) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as Inout:
+            object("InOut") {
+                scalar("expression", x.expression) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as IntegerLiteral:
+            object("IntegerLiteral") {
+                scalar("value", x.value) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as Is:
+            object("Is") {
+                scalar("expression", x.expression) { print($0) }
+                scalar("targetType", x.targetType) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as MagicLiteral:
+            object("MagicLiteral") {
+                scalar("kind", x.kind) { literal($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as Member:
+            object("Member") {
+                scalar("expression", x.expression) { print($0) }
+                scalar("value", x.value) { literal($0) }
+                scalar("symbol", x.symbol) { literal($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as Meta:
+            object("Meta") {
+                scalar("expression", x.expression) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as Name:
+            object("Name") {
+                scalar("value", x.value) { literal($0) }
+                scalar("symbol", x.symbol) { literal($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as NilLiteral:
+            object("NilLiteral") {
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as OptionalAs:
+            object("OptionalAs") {
+                scalar("expression", x.expression) { print($0) }
+                scalar("targetType", x.targetType) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as OptionalTry:
+            object("OptionalTry") {
+                scalar("expression", x.expression) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as Postfix:
+            object("Postfix") {
+                scalar("expression", x.expression) { print($0) }
+                scalar("name", x.name) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as PostfixSelf:
+            object("PostfixSelf") {
+                scalar("tree", x.tree) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as Prefix:
+            object("Prefix") {
+                scalar("name", x.name) { print($0) }
+                scalar("expression", x.expression) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as StringInterpolation:
+            object("StringInterpolation") {
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as StringLiteral:
+            object("StringLiteral") {
+                scalar("value", x.value) { literal($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as Subscript:
+            object("Subscript") {
+                scalar("expression", x.expression) { print($0) }
+                scalar("symbol", x.symbol) { literal($0) }
+                collection("labels", x.labels) { literal($0) }
+                collection("arguments", x.arguments) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as Super:
+            object("Super") {
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as Ternary:
+            object("Ternary") {
+                scalar("condition", x.condition) { print($0) }
+                scalar("thenBranch", x.thenBranch) { print($0) }
+                scalar("elseBranch", x.elseBranch) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as Try:
+            object("Try") {
+                scalar("expression", x.expression) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as Tuple:
+            object("Tuple") {
+                collection("labels", x.labels) { literal($0) }
+                collection("arguments", x.arguments) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as TupleElement:
+            object("TupleElement") {
+                scalar("expression", x.expression) { print($0) }
+                scalar("field", x.field) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as Unquote:
+            object("Unquote") {
+                scalar("expression", x.expression) { print($0) }
+                scalar("value", x.value) { print($0().description) }
+                scalar("type", x.type) { print($0) }
+            }
+        case let x as Varargs:
+            object("Varargs") {
+                collection("expressions", x.expressions) { print($0) }
+                scalar("type", x.type) { print($0) }
+            }
+        case _ as Wildcard:
+            print("Wildcard()")
+        case let x as Function:
+            object("Function") {
+                scalar("name", x.name) { print($0) }
+                collection("parameters", x.parameters) { print($0) }
+                collection("body", x.body) { print($0) }
+            }
+        case let x as Let:
+            object("Let") {
+                scalar("name", x.name) { print($0) }
+                scalar("rhs", x.rhs) { print($0) }
+            }
+        case let x as Parameter:
+            object("Parameter") {
+                scalar("label", x.label) { literal($0) }
+                scalar("name", x.name) { print($0) }
+            }
+        case let x as Var:
+            object("Var") {
+                scalar("name", x.name) { print($0) }
+                scalar("rhs", x.rhs) { print($0) }
+            }
+        case _ as UnknownTree:
+            print("UnknownTree()")
+        default:
+            print("<?>")
         }
-        needSep = true
-        fn(el)
-      }
-      print("]")
     }
-  }
+
+    private func object(_ name: String, _ fn: () -> Void) {
+        print(name)
+        print("(")
+        indent()
+        fn()
+        unindent()
+        print(")")
+    }
+
+    private func scalar<T>(_ name: String, _ value: T, _ fn: (T) -> Void) {
+        let c = description.last!
+        if c == "(" || c == "[" {
+            print("\n")
+            fn(value)
+        } else {
+            print(",\n")
+            fn(value)
+        }
+    }
+
+    private func collection<S: Sequence>(
+        _ name: String,
+        _ value: S,
+        _ fn: (S.Element) -> Void
+    ) {
+        scalar(name, value) {
+            print("[")
+            var needSep = false
+            for el in $0 {
+                if needSep {
+                    print(",\n")
+                }
+                needSep = true
+                fn(el)
+            }
+            print("]")
+        }
+    }
 }

--- a/Sources/Quote/Trees.swift
+++ b/Sources/Quote/Trees.swift
@@ -1425,7 +1425,7 @@ public class Prefix: Expression {
 }
 
 /// Tree that provides an incomplete representation of a string interpolation expression.
-/// TODO(#2): Finish the implementation.
+/// TODO(TF-723): Finish the implementation.
 ///
 ///     > let x = 42
 ///     > let q = #quote("x = \(x)")

--- a/Sources/Quote/Trees.swift
+++ b/Sources/Quote/Trees.swift
@@ -1,0 +1,1857 @@
+/// `Tree` models abstract syntax trees that represent the supported subset of Swift
+/// At the moment, this subset isn't particularly rich, but we are planning to extend it over
+/// time until it eventually covers the entire language.
+///
+/// Trees can be constructed either manually or via #quote(...). When applicable, the latter may be
+/// preferable because it's much more concise. (In the examples below, we'll be using a REPL-like
+/// notation where lines that start with > indicate Swift code and other lines stand for program
+/// output):
+///
+///     > let fourtyTwo: Quote<Int> = #quote(42)
+///     > print(fourtyTwo.expression)
+///     42
+///
+///     > let fourtyTwoAgain = IntegerLiteral(42, TypeName("Int", ...))
+///     > print(fourtyTwoAgain)
+///     42
+///
+/// Trees can deconstructed via downcasting. In Swift, only enums support ML-like pattern matching.
+/// However, enums come with certain limitations, so our trees are not enums and therefore don't
+/// enjoy the full benefits of pattern matching. In the future, we may consider extending Swift
+/// pattern matching to support protocols, classes and structures, but that's a long shot.
+///
+///     > if let lit = fourtyTwo.expression as? IntegerLiteral {
+///     >   print(lit.value)
+///     > }
+///     42
+///
+///     > switch fourtyTwo.expression {
+///     >   case let lit as IntegerLiteral:
+///     >     print(lit.value)
+///     >   default:
+///     >     print("not a literal")
+///     > }
+///     42
+///
+/// At the moment, we don't have documentation for which language feature correspond to which
+/// tree structures (#25), so the only way to figure that out is to experiment with quoting
+/// the code that you're curious about and inspecting its structure via `Tree.structure`.
+///
+/// Our trees carry semantic information, including symbols and types, which means that they
+/// don't fully correspond to parse trees. There are some details in original syntax that are
+/// not present in our trees (e.g. comments, whitespace, presence or absense of type annotations,
+/// among others). There are also some details in our trees that are not present in original syntax
+/// (e.g. inferred types, vararg / default arguments, among others).
+///
+/// Symbols, available in trees that create or reference declarations, are string-based identifiers
+/// for declarations. The idea is that these identifiers are unique across globally visible
+/// declarations, and are unique across local declarations within the same file. For that purpose,
+/// we're using unified symbol resolutions (USRs) available in the Swift compiler.
+///
+///     > let def = 42
+///     > let ref = #quote(def)
+///     > if let name = ref.expression as? Name {
+///     >   print(name.symbol)
+///     > }
+///     s:4main3defSivp
+///
+/// At the moment, we don't have docs for which definition have which symbols (#26).
+/// In order to figure that out you may: 1) quote the corresponding code and manually inspecting
+/// symbols, or 2) ask `sourcekitd-test` to obtain a USR at a given position in a given file:
+///
+///     $ cat test.swift
+///     let x: Int = 42
+///
+///     $ sourcekitd-test -print-raw-response -req=cursor -pos=1:10 $(pwd)/test.swift -- $(pwd)/test.swift
+///     {
+///       key.request: source.request.cursorinfo,
+///       key.compilerargs: [
+///         "/Users/burmako/scratchpad/test.swift"
+///       ],
+///       key.offset: 9,
+///       key.sourcefile: "/Users/burmako/scratchpad/test.swift"
+///     }
+///     {
+///       key.kind: source.lang.swift.ref.struct,
+///       key.name: "Int",
+///       key.usr: "s:Si",
+///       ...
+///     }
+///
+/// Quotes are an early work in progress, so it is expected that there are lots of bugs and missing
+/// features. At https://bugs.swift.org/browse/TF, you can find the list of known issues. Please
+/// consider reporting issues as you encounter them.
+public protocol Tree: CustomStringConvertible {
+}
+
+/// Tree that represents an unsupported language construct.
+/// At the moment, our trees only represent a modest subset of Swift, so this tree may be a
+/// frequent guest in quotes. In the future, we are planning to extend the supported subset of
+/// the language until it eventually covers everything.
+public class UnknownTree: Attribute, Type, Condition, Statement, Expression, Declaration {
+  public var type: Type {
+    return UnknownTree()
+  }
+
+  public init() {
+  }
+}
+
+// MARK: Attributes
+
+/// Tree that represents a Swift attribute.
+public protocol Attribute: Tree {
+}
+
+/// Tree that represents a @differentiable attribute.
+///
+///     > let foo: @differentiable (Float) -> Float = { x in x }
+///     > let q = #quote(foo)
+///     > print(q.type.structure)
+///     FunctionType(
+///       [Differentiable()],
+///       [TypeName("Float", "s:Sf")],
+///       TypeName("Float", "s:Sf"))
+public class Differentiable: Attribute {
+  public init() {
+  }
+}
+
+// MARK: Types
+
+/// Tree that represents a Swift type - either explicitly written down by the programmers or
+/// inferred by the compiler.
+public protocol Type: Tree {
+}
+
+/// Tree that represents a protocol composition type.
+/// It looks like the Swift compiler represents `Any` with `AnyType([])`.
+///
+///     > protocol A {}
+///     > protocol B {}
+///     > func f() -> A & B { fatalError("implement me"); }
+///     > let q = #quote(f())
+///     > print(q.type.structure)
+///     AndType(
+///       [TypeName("A", "s:4main1AP"),
+///       TypeName("B", "s:4main1BP")])
+public class AndType: Type {
+  public let types: [Type]
+
+  public init(_ types: [Type]) {
+    self.types = types
+  }
+}
+
+/// Tree that represents an array type [T].
+///
+///     > let x = [1, 2, 3]
+///     > let q = #quote(x)
+///     > print(q.type.structure)
+///     ArrayType(
+///       TypeName("Int", "s:Si"))
+public class ArrayType: Type {
+  public let type: Type
+
+  public init(_ type: Type) {
+    self.type = type
+  }
+}
+
+/// Tree that represents a dictionary type [T: U].
+///
+///     > let x = [40: 2]
+///     > let q = #quote(x)
+///     > print(q.type.structure)
+///     DictionaryType(
+///       TypeName("Int", "s:Si"),
+///       TypeName("Int", "s:Si"))
+public class DictionaryType: Type {
+  public let key: Type
+  public let value: Type
+
+  public init(_ key: Type, _ value: Type) {
+    self.key = key
+    self.value = value
+  }
+}
+
+/// Tree that represents a function type (T1, ..., Tn) -> R.
+///
+///     > let x = { (x: Int) in x }
+///     > let q = #quote(x)
+///     > print(q.type.structure)
+///     FunctionType(
+///       [],
+///       [TypeName("Int", "s:Si")],
+///       TypeName("Int", "s:Si"))
+public class FunctionType: Type {
+  public let attributes: [Attribute]
+  public let parameters: [Type]
+  public let result: Type
+
+  public init(_ attributes: [Attribute], _ parameters: [Type], _ result: Type) {
+    self.attributes = attributes
+    self.parameters = parameters
+    self.result = result
+  }
+}
+
+/// Tree that represents a type of an inout parameter.
+///
+///     > let q = #quote { (x: inout Int) in x }
+///     > print(q.type.structure)
+///     FunctionType(
+///       [],
+///       [InoutType(
+///         TypeName("Int", "s:Si"))],
+///       TypeName("Int", "s:Si"))
+public class InoutType: Type {
+  public let type: Type
+
+  public init(_ type: Type) {
+    self.type = type
+  }
+}
+
+/// Tree that represents a type of a reference to an in-out parameter.
+///
+///     > func foo(_ x: inout Int) {
+///     >   let q = #quote { let y = x }
+///     >   print(q.type.structure)
+///     > }
+///     > var x = 2
+///     > foo(&x)
+///     Closure(
+///       [],
+///       [Let(
+///         Name(
+///           "y",
+///           "s:4main3fooyySizFyycfU_1yL_Sivp",
+///           TypeName("Int", "s:Si")),
+///         Conversion(
+///           Name(
+///             "x",
+///             "s:4main3fooyySizF1xL_Sivp",
+///             LValueType(
+///               TypeName("Int", "s:Si")))))],
+///       FunctionType(
+///         [],
+///         [],
+///         TupleType(
+///           [])))
+public class LValueType: Type {
+  public let type: Type
+
+  public init(_ type: Type) {
+    self.type = type
+  }
+}
+
+/// Tree that represents a metatype T.Type or T.Protocol.
+///
+///     > let x = Int.self
+///     > let q = #quote(x)
+///     > print(q.type.structure)
+///     MetaType(
+///       TypeName("Int", "s:Si"))
+public class MetaType: Type {
+  public let type: Type
+
+  public init(_ type: Type) {
+    self.type = type
+  }
+}
+
+/// Tree that represents an optional type T?.
+///
+///     > let x: Int? = 42
+///     > let q = #quote(x)
+///     > print(q.type.structure)
+///     OptionalType(
+///       TypeName("Int", "s:Si"))
+public class OptionalType: Type {
+  public let type: Type
+
+  public init(_ type: Type) {
+    self.type = type
+  }
+}
+
+/// Tree that represents a specialized type, i.e. a generic type with generic arguments.
+///
+///     > let x: ClosedRange<Int> = 1...10
+///     > let q = #quote(x)
+///     > print(q.type.structure)
+///     SpecializedType(
+///       TypeName("ClosedRange", "s:SN"),
+///       [TypeName("Int", "s:Si")])
+public class SpecializedType: Type {
+  public let type: Type
+  public let arguments: [Type]
+
+  public init(_ type: Type, _ arguments: [Type]) {
+    self.type = type
+    self.arguments = arguments
+  }
+}
+
+/// Tree that represents a tuple type (T1, ..., Tn)
+///
+///     > let x = (1, "2", 3)
+///     > let q = #quote(x)
+///     > print(q.type.structure)
+///     TupleType(
+///       [TypeName("Int", "s:Si"),
+///       TypeName("String", "s:SS"),
+///       TypeName("Int", "s:Si")])
+public class TupleType: Type {
+  public let types: [Type]
+
+  public init(_ types: [Type]) {
+    self.types = types
+  }
+}
+
+/// Tree that represents a reference to a class, struct, protocol, etc.
+///
+///    > let x = 42
+///    > let q = #quote(x)
+///    > print(q.type.structure)
+///    TypeName("Int", "s:Si")
+public class TypeName: Type {
+  public let value: String
+  public let symbol: String
+
+  public init(_ value: String, _ symbol: String) {
+    self.value = value
+    self.symbol = symbol
+  }
+}
+
+// MARK: Conditions
+
+/// Tree that represents a condition of if, while, repeat, etc.
+public protocol Condition: Tree {
+}
+
+// MARK: Statements
+
+/// Tree that represents a Swift statement.
+public protocol Statement: Tree {
+}
+
+/// Tree that represents a break statement.
+///
+///     > let q = #quote {
+///     >   while true {
+///     >     break
+///     >   }
+///     > }
+///     > print(q.structure)
+///     Closure(
+///       [],
+///       [While(
+///         nil,
+///         [BooleanLiteral(
+///           true,
+///           TypeName("Bool", "s:Sb"))],
+///         [Break(
+///            nil)])],
+///       FunctionType(
+///         [],
+///         [],
+///         TupleType(
+///           [])))
+public class Break: Statement {
+  public let label: String?
+
+  public init(_ label: String?) {
+    self.label = label
+  }
+}
+
+/// Tree that represents a continue statement.
+///
+///     > let q = #quote {
+///     >   while true {
+///     >     continue
+///     >   }
+///     > }
+///     > print(q.structure)
+///     Closure(
+///       [],
+///       [While(
+///         nil,
+///         [BooleanLiteral(
+///           true,
+///           TypeName("Bool", "s:Sb"))],
+///         [Continue(
+///            nil)])],
+///       FunctionType(
+///         [],
+///         [],
+///         TupleType(
+///           [])))
+public class Continue: Statement {
+  public let label: String?
+
+  public init(_ label: String?) {
+    self.label = label
+  }
+}
+
+/// Tree that represents a defer statement.
+///
+///     > let q = #quote {
+///     >   defer {}
+///     >   return
+///     > }
+///     > print(q.structure)
+///     Closure(
+///       [],
+///       [Defer(
+///         []),
+///       Return(
+///         Tuple(
+///           [],
+///           [],
+///           TupleType(
+///             [])))],
+///       FunctionType(
+///         [],
+///         [],
+///         TupleType(
+///           [])))
+public class Defer: Statement {
+  public let body: [Statement]
+
+  public init(_ body: [Statement]) {
+    self.body = body
+  }
+}
+
+/// Tree that represents a do statement.
+///
+///     > let q = #quote {
+///     >   do {}
+///     > }
+///     > print(q.structure)
+///     Closure(
+///       [],
+///       [Do(
+///         [])],
+///       FunctionType(
+///         [],
+///         [],
+///         TupleType(
+///           [])))
+public class Do: Statement {
+  public let label: String?
+  public let body: [Statement]
+
+  public init(_ label: String?, _ body: [Statement]) {
+    self.label = label
+    self.body = body
+  }
+}
+
+/// Tree that represents a for-in loop.
+///
+///     > let range = 1...10
+///     > let q = #quote {
+///     >   for i in range {}
+///     > }
+///     > print(q.structure)
+///     Closure(
+///       [],
+///       [For(
+///         nil,
+///         Name(
+///           "i",
+///           "s:4mainyycfU_1iL_Sivp",
+///           TypeName("Int", "s:Si")),
+///         Name(
+///           "range",
+///           "s:4main5rangeSNySiGvp",
+///           SpecializedType(
+///             TypeName("ClosedRange", "s:SN"),
+///             [TypeName("Int", "s:Si")])),
+///         [])],
+///       FunctionType(
+///         [],
+///         [],
+///         TupleType(
+///           [])))
+public class For: Statement {
+  public let label: String?
+  public let name: Name
+  public let expression: Expression
+  public let body: [Statement]
+
+  public init(_ label: String?, _ name: Name, _ expression: Expression, _ body: [Statement]) {
+    self.label = label
+    self.name = name
+    self.expression = expression
+    self.body = body
+  }
+}
+
+/// Tree that represents a guard statement.
+///
+///     > let q = #quote {
+///     >   guard true else {}
+///     > }
+///     > print(q.structure)
+///     Closure(
+///       [],
+///       [Guard(
+///         [BooleanLiteral(
+///           true,
+///           TypeName("Bool", "s:Sb"))],
+///         [])],
+///       FunctionType(
+///         [],
+///         [],
+///         TupleType(
+///           [])))
+public class Guard: Statement {
+  public let condition: [Condition]
+  public let body: [Statement]
+
+  public init(_ condition: [Condition], _ body: [Statement]) {
+    self.condition = condition
+    self.body = body
+  }
+}
+
+/// Tree that represents an if statement.
+///
+///     > let q = #quote {
+///     >   if true {} else if false {} else {}
+///     > }
+///     > print(q.structure)
+///     Closure(
+///       [],
+///       [If(
+///         nil,
+///         [BooleanLiteral(
+///           true,
+///           TypeName("Bool", "s:Sb"))],
+///         [],
+///         [If(
+///           nil,
+///           [BooleanLiteral(
+///             false,
+///             TypeName("Bool", "s:Sb"))],
+///           [],
+///           [])])],
+///       FunctionType(
+///         [],
+///         [],
+///         TupleType(
+///           [])))
+public class If: Statement {
+  public let label: String?
+  public let condition: [Condition]
+  public let thenBranch: [Statement]
+  public let elseBranch: [Statement]
+
+  public init(
+    _ label: String?, _ condition: [Condition], _ thenBranch: [Statement], _ elseBranch: [Statement]
+  ) {
+    self.label = label
+    self.condition = condition
+    self.thenBranch = thenBranch
+    self.elseBranch = elseBranch
+  }
+}
+
+/// Tree that represents a repeat-while loop.
+///
+///     > let q = #quote {
+///     >   repeat {} while true
+///     > }
+///     > print(q.structure)
+///     Closure(
+///       [],
+///       [Repeat(
+///         nil,
+///         [],
+///         BooleanLiteral(
+///           true,
+///           TypeName("Bool", "s:Sb")))],
+///       FunctionType(
+///         [],
+///         [],
+///         TupleType(
+///           [])))
+public class Repeat: Statement {
+  public let label: String?
+  public let body: [Statement]
+  public let condition: Expression
+
+  public init(_ label: String?, _ body: [Statement], _ condition: Expression) {
+    self.label = label
+    self.body = body
+    self.condition = condition
+  }
+}
+
+/// Tree that represents a return statement.
+///
+///     > let q = #quote { () in return }
+///     > print(q.structure)
+///     Closure(
+///       [],
+///       [Return(
+///         Tuple(
+///           [],
+///           [],
+///           TupleType(
+///             [])))],
+///       FunctionType(
+///         [],
+///         [],
+///         TupleType(
+///           [])))
+public class Return: Statement {
+  public let expression: Expression
+
+  public init(_ expression: Expression) {
+    self.expression = expression
+  }
+}
+
+/// Tree that represents a throw statement.
+///
+///     > class X: Error {}
+///     > let q = #quote {
+///     >   throw X()
+///     > }
+///     > print(q.structure)
+///     Closure(
+///       [],
+///       [Throw(
+///         Conversion(
+///           Call(
+///             Name(
+///               "E",
+///               "s:4main1ECXCycfc",
+///               FunctionType(
+///                 [],
+///                 [],
+///                 TypeName("X", "s:4main1XC"))),
+///             [],
+///             [],
+///             TypeName("X", "s:4main1XC")),
+///           TypeName("Error", "s:s5ErrorP")))],
+///       FunctionType(
+///         [],
+///         [],
+///         TupleType(
+///           [])))
+public class Throw: Statement {
+  public let expression: Expression
+
+  public init(_ expression: Expression) {
+    self.expression = expression
+  }
+}
+
+/// Tree that represents a while loop.
+///
+///     > let q = #quote {
+///     >   while true {}
+///     > }
+///     > print(q.structure)
+///     Closure(
+///       [],
+///       [While(
+///         nil,
+///         [BooleanLiteral(
+///           true,
+///           TypeName("Bool", "s:Sb"))],
+///         [])],
+///       FunctionType(
+///         [],
+///         [],
+///         TupleType(
+///           [])))
+public class While: Statement {
+  public let label: String?
+  public let condition: [Condition]
+  public let body: [Statement]
+
+  public init(_ label: String?, _ condition: [Condition], _ body: [Statement]) {
+    self.label = label
+    self.condition = condition
+    self.body = body
+  }
+}
+
+// MARK: Expressions
+
+/// Tree that represents a Swift expression.
+/// Always has an associated type computed for this expression by the typechecker.
+public protocol Expression: Statement, Condition {
+  var type: Type { get }
+}
+
+/// Tree that represents an array literal [...].
+///
+///     > let q = #quote([40, 2])
+///     > print(q.structure)
+///     ArrayLiteral(
+///       [IntegerLiteral(
+///         40,
+///         TypeName("Int", "s:Si")),
+///       IntegerLiteral(
+///         2,
+///         TypeName("Int", "s:Si"))],
+///       ArrayType(
+///         TypeName("Int", "s:Si")))
+public class ArrayLiteral: Expression {
+  public let expressions: [Expression]
+  public let type: Type
+
+  public init(_ expressions: [Expression], _ type: Type) {
+    self.expressions = expressions
+    self.type = type
+  }
+}
+
+/// Tree that represents an as expression.
+///
+///     > let q = #quote(42 as Int)
+///     > print(q.structure)
+///     As(
+///       IntegerLiteral(
+///         42,
+///         TypeName("Int", "s:Si")))
+public class As: Expression {
+  public let expression: Expression
+  public let type: Type
+
+  public init(_ expression: Expression, _ type: Type) {
+    self.expression = expression
+    self.type = type
+  }
+}
+
+/// Tree that represents an assignment expression.
+///
+///     > var x = 0
+///     > let q = #quote(x = 42)
+///     > print(q.structure)
+///     Assign(
+///       Name(
+///         "x",
+///         "s:4main1xSivp",
+///          LValueType(
+///            TypeName("Int", "s:Si"))),
+///       IntegerLiteral(
+///         42,
+///         TypeName("Int", "s:Si")),
+///       TupleType(
+///         []))
+public class Assign: Expression {
+  public let lhs: Expression
+  public let rhs: Expression
+  public let type: Type
+
+  public init(_ lhs: Expression, _ rhs: Expression, _ type: Type) {
+    self.lhs = lhs
+    self.rhs = rhs
+    self.type = type
+  }
+}
+
+/// Tree that represents a binary operator expression.
+///
+///     > let q = #quote(40 + 2)
+///     > print(q.structure)
+///     Binary(
+///       IntegerLiteral(
+///         40,
+///         TypeName("Int", "s:Si")),
+///       Name(
+///         "+",
+///         "s:Si1poiyS2i_SitFZ",
+///         FunctionType(
+///           [],
+///           [TypeName("Int", "s:Si"),
+///           TypeName("Int", "s:Si")],
+///           TypeName("Int", "s:Si"))),
+///       IntegerLiteral(
+///         2,
+///         TypeName("Int", "s:Si")),
+///       TypeName("Int", "s:Si"))
+public class Binary: Expression {
+  public let lhs: Expression
+  public let name: Name
+  public let rhs: Expression
+  public let type: Type
+
+  public init(_ lhs: Expression, _ name: Name, _ rhs: Expression, _ type: Type) {
+    self.lhs = lhs
+    self.name = name
+    self.rhs = rhs
+    self.type = type
+  }
+}
+
+/// Tree that represents a boolean literal.
+///
+///     > let q = #quote(true)
+///     > print(q.structure)
+///     BooleanLiteral(
+///       true,
+///       TypeName("Bool", "s:Sb"))
+public class BooleanLiteral: Expression {
+  public let value: Bool
+  public let type: Type
+
+  public init(_ value: Bool, _ type: Type) {
+    self.value = value
+    self.type = type
+  }
+}
+
+/// Tree that represents a call expression.
+/// This can include a function call, an init call, etc.
+/// It is also a known issue that symbols of default arguments are empty (#27).
+///
+///     > let q = #quote(print(42))
+///     > print(q.structure)
+///     Call(
+///       Name(
+///         "print",
+///         "s:s5print_9separator10terminatoryypd_S2StF",
+///         FunctionType(
+///           [],
+///           [AndType(
+///             []),
+///           TypeName("String", "s:SS"),
+///           TypeName("String", "s:SS")],
+///           TupleType(
+///             []))),
+///       [nil],
+///       [Varargs(
+///         [IntegerLiteral(
+///           42,
+///           TypeName("Int", "s:Si"))],
+///         ArrayType(
+///           AndType(
+///             []))),
+///       Default(
+///         "",
+///         TypeName("String", "s:SS")),
+///       Default(
+///         "",
+///         TypeName("String", "s:SS"))],
+///       TupleType(
+///         []))
+public class Call: Expression {
+  public let expression: Expression
+  public let labels: [String?]
+  public let arguments: [Expression]
+  public let type: Type
+
+  public init(
+    _ expression: Expression,
+    _ labels: [String?],
+    _ arguments: [Expression],
+    _ type: Type
+  ) {
+    self.expression = expression
+    self.labels = labels
+    self.arguments = arguments
+    self.type = type
+  }
+}
+
+/// Tree that represents a closure expression.
+/// Note that the result type is not stored as a field but computed from the type of the expression.
+///
+///     > let q = #quote { (x: Int) in x }
+///     > print(q.structure)
+///     Closure(
+///       [Parameter(
+///         nil,
+///         Name(
+///           "x",
+///           "s:4mainS2icfU_1xL_Sivp",
+///           TypeName("Int", "s:Si")))],
+///       [Return(
+///         Name(
+///           "x",
+///           "s:4mainS2icfU_1xL_Sivp",
+///           TypeName("Int", "s:Si")))],
+///       FunctionType(
+///         [],
+///         [TypeName("Int", "s:Si")],
+///         TypeName("Int", "s:Si")))
+///
+///     > func f(_ fn: @autoclosure () -> Int) {}
+///     > let q = #quote(f(42))
+///     > print(q.structure)
+///     Call(
+///       Name(
+///         "f",
+///         "s:4main1fyySiyXKF",
+///         FunctionType(
+///           [],
+///           [FunctionType(
+///             [],
+///             [],
+///             TypeName("Int", "s:Si"))],
+///           TupleType(
+///             []))),
+///       [nil],
+///       [Closure(
+///         [],
+///         [Return(
+///           IntegerLiteral(
+///             42,
+///             TypeName("Int", "s:Si")))],
+///         FunctionType(
+///           [],
+///           [],
+///           TypeName("Int", "s:Si")))],
+///       TupleType(
+///         []))
+public class Closure: Expression {
+  public let parameters: [Parameter]
+
+  public var result: Type {
+    switch type {
+    case let type as FunctionType:
+      return type.result
+    default:
+      return UnknownTree()
+    }
+  }
+
+  public let body: [Statement]
+  public let type: Type
+
+  public init(
+    _ parameters: [Parameter],
+    _ body: [Statement],
+    _ type: Type
+  ) {
+    self.parameters = parameters
+    self.body = body
+    self.type = type
+  }
+}
+
+/// Tree that represents one of the variety of implicit conversions applied by the Swift compiler.
+///
+/// For the comprehensive list, see ExprNodes.def in the sources of the compiler:
+/// https://github.com/apple/swift/blob/master/include/swift/AST/ExprNodes.def#L146-L174
+///
+/// See `LValueType` for an example.
+public class Conversion: Expression {
+  public let expression: Expression
+  public let type: Type
+
+  public init(_ expression: Expression, _ type: Type) {
+    self.expression = expression
+    self.type = type
+  }
+}
+
+/// Tree that represents a synthetic argument inserted into a call with a default parameter.
+/// See `Call` for an example.
+public class Default: Expression {
+  public let symbol: String
+  public let type: Type
+
+  public init(_ symbol: String, _ type: Type) {
+    self.symbol = symbol
+    self.type = type
+  }
+}
+
+/// Tree that represents a dictionary literal [...: ..., ...].
+///
+///     > let q = #quote([40: 40, 2: 2])
+///     > print(q.structure)
+///     DictionaryLiteral(
+///       [IntegerLiteral(
+///         40,
+///         TypeName("Int", "s:Si")),
+///       IntegerLiteral(
+///         40,
+///         TypeName("Int", "s:Si")),
+///       IntegerLiteral(
+///         2,
+///         TypeName("Int", "s:Si")),
+///       IntegerLiteral(
+///         2,
+///         TypeName("Int", "s:Si"))],
+///       DictionaryType(
+///         TypeName("Int", "s:Si"),
+///         TypeName("Int", "s:Si")))
+public class DictionaryLiteral: Expression {
+  public let expressions: [Expression]
+  public let type: Type
+
+  public init(_ expressions: [Expression], _ type: Type) {
+    self.expressions = expressions
+    self.type = type
+  }
+}
+
+/// Tree that represents a floating-point literal.
+///
+///     > let q = #quote(42.0)
+///     > print(q.structure)
+///     FloatLiteral(
+///       42.0,
+///       TypeName("Double", "s:Sd"))
+public class FloatLiteral: Expression {
+  public let value: Float
+  public let type: Type
+
+  public init(_ value: Float, _ type: Type) {
+    self.value = value
+    self.type = type
+  }
+}
+
+/// Tree that represents a ! expression.
+///
+///     > let x: Int? = 42
+///     > let q = #quote(x!)
+///     > print(q.structure)
+///     Force(
+///       Name(
+///         "x",
+///         "s:4main1xypvp",
+///         AndType(
+///           [])),
+///       TypeName("Int", "s:Si"))
+public class Force: Expression {
+  public let expression: Expression
+  public let type: Type
+
+  public init(_ expression: Expression, _ type: Type) {
+    self.expression = expression
+    self.type = type
+  }
+}
+
+/// Tree that represents an as! expression.
+///
+///     > let x: Any = 42
+///     > let q = #quote(x as! Int)
+///     > print(q.structure)
+///     ForceAs(
+///       Name(
+///         "x",
+///         "s:4main1xypvp",
+///         AndType(
+///           [])),
+///       TypeName("Int", "s:Si"))
+public class ForceAs: Expression {
+  public let expression: Expression
+  public let type: Type
+
+  public init(_ expression: Expression, _ type: Type) {
+    self.expression = expression
+    self.type = type
+  }
+}
+
+/// Tree that represents a try! expression.
+///
+///     > let q = #quote(try! 42)
+///     > print(q.structure)
+///     ForceTry(
+///       IntegerLiteral(
+///         42,
+///         TypeName("Int", "s:Si")))
+public class ForceTry: Expression {
+  public let expression: Expression
+  public let type: Type
+
+  public init(_ expression: Expression, _ type: Type) {
+    self.expression = expression
+    self.type = type
+  }
+}
+
+/// Tree that represents an in-out expression.
+///
+///     > func foo(_ x: inout Int) {}
+///     > var x = 42
+///     > let q = #quote(foo(&x))
+///     > print(q.structure)
+///     Call(
+///       Name(
+///         "foo",
+///         "s:4main3fooyySizF",
+///         FunctionType(
+///           [],
+///           [InoutType(
+///             TypeName("Int", "s:Si"))],
+///           TupleType(
+///             []))),
+///       [nil],
+///       [Inout(
+///         Name(
+///           "x",
+///           "s:4main1xSivp",
+///           LValueType(
+///             TypeName("Int", "s:Si"))))],
+///       TupleType(
+///         []))
+public class Inout: Expression {
+  public let expression: Expression
+  public let type: Type
+
+  public init(_ expression: Expression, _ type: Type) {
+    self.expression = expression
+    self.type = type
+  }
+}
+
+/// Tree that represents an integer literal.
+///
+///     > let q = #quote(42)
+///     > print(q.structure)
+///     IntegerLiteral(
+///       42,
+///       TypeName("Int", "s:Si"))
+public class IntegerLiteral: Expression {
+  public let value: Int
+  public let type: Type
+
+  public init(_ value: Int, _ type: Type) {
+    self.value = value
+    self.type = type
+  }
+}
+
+/// Tree that represents an as expression.
+///
+///     > let x: Any = 42
+///     > let q = #quote(x is Int)
+///     > print(q.structure)
+///     Is(
+///       Name(
+///         "x",
+///         "s:4main1xypvp",
+///         AndType(
+///           [])),
+///       TypeName("Int", "s:Si"),
+///       TypeName("Bool", "s:Sb"))
+public class Is: Expression {
+  public let expression: Expression
+  public let targetType: Type
+  public let type: Type
+
+  public init(_ expression: Expression, _ targetType: Type, _ type: Type) {
+    self.expression = expression
+    self.targetType = targetType
+    self.type = type
+  }
+}
+
+/// Tree that represents a magic literal, i.e. #file, #line, #column, #function or #dsohandle.
+///
+///     > let q = #quote(#file)
+///     > print(q.structure)
+///     MagicLiteral(
+///       "file",
+///       TypeName("String", "s:SS"))
+public class MagicLiteral: Expression {
+  public let kind: String
+  public let type: Type
+
+  public init(_ kind: String, _ type: Type) {
+    self.kind = kind
+    self.type = type
+  }
+}
+
+/// Tree that represents member selection.
+/// This can include a field selection, a method selection, etc.
+/// However, subscript selections are their own thing because they don't have names.
+///
+///     > let x = [1, 2, 3]
+///     > let q = #quote(x.count)
+///     > print(q.structure)
+///     Member(
+///       Name(
+///         "x",
+///         "s:4main1xSaySiGvp",
+///         ArrayType(
+///           TypeName("Int", "s:Si"))),
+///       "count",
+///       "s:Sa5countSivp",
+///       TypeName("Int", "s:Si"))
+///
+/// Static members are represented as selections from type exprs in the Swift compiler,
+/// but in our trees they are represented as names to avoid getting into the rabbit hole of
+/// exposing type exprs, metatypes, etc for this supposedly simple use case.
+///
+///     > class Context { static let local = Context() }
+///     > let q = #quote(Context.local)
+///     > print(q.structure)
+///     Name(
+///       "local",
+///       "s:4main7ContextC5localACvpZ",
+///       TypeName("Context", "s:4main7ContextC"))
+///
+///     > enum E { case a }
+///     > let q = #quote(E.a)
+///     > print(q.structure)
+///     Name(
+///       "a",
+///       "s:4main1EO1ayA2CmF",
+///       TypeName("E", "s:4main1EO"))
+///
+/// When a selection doesn't actually need the actual value of expression to be evaluated,
+/// we also represent the selection as a name.
+///
+///     func g() {}
+///     let q = #quote(main.g())
+///     print(q.structure)
+///     Call(
+///       Name(
+///         "f",
+///         "s:4main1gyyF",
+///         FunctionType(
+///           [],
+///           [],
+///           TupleType(
+///             []))),
+///       [],
+///       [],
+///       TupleType(
+///         []))
+///
+/// Selection from a tuple is modelled as `TupleElement`.
+public class Member: Expression {
+  public let expression: Expression
+  public let value: String
+  public let symbol: String
+  public let type: Type
+
+  public init(_ expression: Expression, _ value: String, _ symbol: String, _ type: Type) {
+    self.expression = expression
+    self.value = value
+    self.symbol = symbol
+    self.type = type
+  }
+}
+
+/// Tree that represents a #quote(...) expression.
+///
+///     > let q = #quote(#quote(42))
+///     > print(q.structure)
+///     Meta(
+///       IntegerLiteral(
+///         42,
+///         TypeName("Int", "s:Si")),
+///       SpecializedType(
+///         TypeName("Quote", "s:5QuoteAAC"),
+///         [TypeName("Int", "s:Si")]))
+public class Meta: Expression {
+  public let expression: Expression
+  public let type: Type
+
+  public init(_ expression: Expression, _ type: Type) {
+    self.expression = expression
+    self.type = type
+  }
+}
+
+/// Tree that represents a reference to a value, func, etc.
+///
+///     > let x = 42
+///     > let q = #quote(x)
+///     > print(q.structure)
+///     Name(
+///       "x",
+///       "s:4main1xSivp",
+///       TypeName("Int", "s:Si"))
+public class Name: Expression {
+  public let value: String
+  public let symbol: String
+  public let type: Type
+
+  public init(_ value: String, _ symbol: String, _ type: Type) {
+    self.value = value
+    self.symbol = symbol
+    self.type = type
+  }
+}
+
+/// Tree that represents a nil literal.
+///
+///     > let q = #quote(nil as Int?)
+///     > print(q.structure)
+///     As(
+///       NilLiteral(
+///         OptionalType(
+///           TypeName("Int", "s:Si"))),
+///       OptionalType(
+///         TypeName("Int", "s:Si")))
+public class NilLiteral: Expression {
+  public let type: Type
+
+  public init(_ type: Type) {
+    self.type = type
+  }
+}
+
+/// Tree that represents an as? expression.
+///
+///     > let x: Any = 42
+///     > let q = #quote(x as? Int)
+///     > print(q.structure)
+///     OptionalAs(
+///       Name(
+///         "x",
+///         "s:4main1xypvp",
+///         AndType(
+///           [])),
+///       TypeName("Int", "s:Si"),
+///       OptionalType(
+///         TypeName("Int", "s:Si")))
+public class OptionalAs: Expression {
+  public let expression: Expression
+  public let targetType: Type
+  public let type: Type
+
+  public init(_ expression: Expression, _ targetType: Type, _ type: Type) {
+    self.expression = expression
+    self.targetType = targetType
+    self.type = type
+  }
+}
+
+/// Tree that represents a try? expression.
+///
+///     > let q = #quote(try? 42)
+///     > print(q.structure)
+///     OptionalTry(
+///       Conversion(
+///         IntegerLiteral(
+///           42,
+///           TypeName("Int", "s:Si")),
+///         OptionalType(
+///           TypeName("Int", "s:Si"))))
+public class OptionalTry: Expression {
+  public let expression: Expression
+  public let type: Type
+
+  public init(_ expression: Expression, _ type: Type) {
+    self.expression = expression
+    self.type = type
+  }
+}
+
+/// Tree that represents a postfix operator expression.
+public class Postfix: Expression {
+  public let expression: Expression
+  public let name: Name
+  public let type: Type
+
+  public init(_ expression: Expression, _ name: Name, _ type: Type) {
+    self.expression = expression
+    self.name = name
+    self.type = type
+  }
+}
+
+/// Tree that represents a postfix self expression expr.self or T.self.
+///
+///     > let q = #quote(42.self)
+///     > print(q.structure)
+///     PostfixSelf(
+///       IntegerLiteral(
+///         42,
+///         TypeName("Int", "s:Si")),
+///       TypeName("Int", "s:Si"))
+///
+///     > let q = #quote(Int.self)
+///     > print(q.structure)
+///     PostfixSelf(
+///       TypeName("Int", "s:Si"),
+///       MetaType(
+///         TypeName("Int", "s:Si")))
+public class PostfixSelf: Expression {
+  public let tree: Tree
+  public let type: Type
+
+  public init(_ tree: Tree, _ type: Type) {
+    self.tree = tree
+    self.type = type
+  }
+}
+
+/// Tree that represents a prefix operator expression.
+///
+///     > let q = #quote(+42)
+///     > print(q.structure)
+///     Prefix(
+///       Name(
+///         "+",
+///         "s:s18AdditiveArithmeticPsE1popyxxFZ",
+///         FunctionType(
+///           [],
+///           [TypeName("Int", "s:Si")],
+///           TypeName("Int", "s:Si"))),
+///       IntegerLiteral(
+///         42,
+///         TypeName("Int", "s:Si")),
+///       TypeName("Int", "s:Si"))
+public class Prefix: Expression {
+  public let name: Name
+  public let expression: Expression
+  public let type: Type
+
+  public init(_ name: Name, _ expression: Expression, _ type: Type) {
+    self.name = name
+    self.expression = expression
+    self.type = type
+  }
+}
+
+/// Tree that provides an incomplete representation of a string interpolation expression.
+/// TODO(#2): Finish the implementation.
+///
+///     > let x = 42
+///     > let q = #quote("x = \(x)")
+///     > print(q.structure)
+///     StringInterpolation(
+///       TypeName("String", "s:SS"))
+public class StringInterpolation: Expression {
+  public let type: Type
+
+  public init(_ type: Type) {
+    self.type = type
+  }
+}
+
+/// Tree that represents a string literal.
+///
+///     > let q = #quote("42")
+///     > print(q.structure)
+///     StringLiteral(
+///       "42",
+///       TypeName("Int", "s:SS"))
+public class StringLiteral: Expression {
+  public let value: String
+  public let type: Type
+
+  public init(_ value: String, _ type: Type) {
+    self.value = value
+    self.type = type
+  }
+}
+
+/// Tree that represents a subscript expression.
+///
+///     > let x = [1, 2, 3]
+///     > let q = #quote(x[0])
+///     > print(q.structure)
+///     Subscript(
+///       Name(
+///         "x",
+///         "s:4main1xSaySiGvp",
+///         ArrayType(
+///           TypeName("Int", "s:Si"))),
+///       "s:SayxSicip",
+///       [nil],
+///       [IntegerLiteral(
+///         0,
+///         TypeName("Int", "s:Si"))],
+///       TypeName("Int", "s:Si"))
+public class Subscript: Expression {
+  public let expression: Expression
+  public let symbol: String
+  public let labels: [String?]
+  public let arguments: [Expression]
+  public let type: Type
+
+  public init(
+    _ expression: Expression,
+    _ symbol: String,
+    _ labels: [String?],
+    _ arguments: [Expression],
+    _ type: Type
+  ) {
+    self.expression = expression
+    self.symbol = symbol
+    self.labels = labels
+    self.arguments = arguments
+    self.type = type
+  }
+}
+
+/// Tree that represents a super expression.
+///
+///     > class C {
+///     >   func p() {}
+///     > }
+///     > class D: C {
+///     >   func q() {
+///     >     let q = #quote(super.p())
+///     >     print(q.structure)
+///     >   }
+///     > }
+///     > D().q()
+///     Call(
+///       Member(
+///         Super(
+///           TypeName("C", "s:4main1CC")),
+///         "p",
+///         "s:4main1CC1pyyF",
+///         FunctionType(
+///           [],
+///           [],
+///           TupleType(
+///             []))),
+///       [],
+///       [],
+///       TupleType(
+///         []))
+public class Super: Expression {
+  public let type: Type
+
+  public init(_ type: Type) {
+    self.type = type
+  }
+}
+
+/// Tree that represents a ternary operator expression.
+///
+///     > let q = #quote(true ? 40 : 2)
+///     > print(q.structure)
+///     Ternary(
+///       BooleanLiteral(
+///         true,
+///         TypeName("Bool", "s:Sb")),
+///       IntegerLiteral(
+///         40,
+///         TypeName("Int", "s:Si")),
+///       IntegerLiteral(
+///         2,
+///         TypeName("Int", "s:Si")),
+///       TypeName("Int", "s:Si"))
+public class Ternary: Expression {
+  public let condition: Expression
+  public let thenBranch: Expression
+  public let elseBranch: Expression
+  public let type: Type
+
+  public init(
+    _ condition: Expression,
+    _ thenBranch: Expression,
+    _ elseBranch: Expression,
+    _ type: Type
+  ) {
+    self.condition = condition
+    self.thenBranch = thenBranch
+    self.elseBranch = elseBranch
+    self.type = type
+  }
+}
+
+/// Tree that represents a try expression.
+///
+///     > let q = #quote(try 42)
+///     > print(q.structure)
+///     Try(
+///       IntegerLiteral(
+///         42,
+///         TypeName("Int", "s:Si")))
+public class Try: Expression {
+  public let expression: Expression
+  public let type: Type
+
+  public init(_ expression: Expression, _ type: Type) {
+    self.expression = expression
+    self.type = type
+  }
+}
+
+/// Tree that represents a tuple expression.
+///
+///     > let q = #quote((1, "2", 3))
+///     > print(q.structure)
+///     Tuple(
+///       [],
+///       [IntegerLiteral(
+///         1,
+///         TypeName("Int", "s:Si")),
+///       StringLiteral(
+///         "2",
+///         TypeName("String", "s:SS")),
+///       IntegerLiteral(
+///         3,
+///         TypeName("Int", "s:Si"))],
+///       TupleType(
+///         [TypeName("Int", "s:Si"),
+///         TypeName("String", "s:SS"),
+///         TypeName("Int", "s:Si")]))
+public class Tuple: Expression {
+  public let labels: [String?]
+  public let arguments: [Expression]
+  public let type: Type
+
+  public init(
+    _ labels: [String?],
+    _ arguments: [Expression],
+    _ type: Type
+  ) {
+    self.labels = labels
+    self.arguments = arguments
+    self.type = type
+  }
+}
+
+/// Tree that represents selection of a tuple element.
+/// It is a known issue that sometimes the type of the associate Tuple is unknown (#1).
+///
+///     > let q = #quote((1, 2).1)
+///     > print(q.structure)
+///     TupleElement(
+///       Tuple(
+///         [],
+///         [IntegerLiteral(
+///           1,
+///           TypeName("Int", "s:Si")),
+///         IntegerLiteral(
+///           2,
+///           TypeName("Int", "s:Si"))],
+///         UnknownTree()),
+///       1,
+///       TypeName("Int", "s:Si"))
+public class TupleElement: Expression {
+  public let expression: Expression
+  public let field: Int
+  public let type: Type
+
+  public init(_ expression: Expression, _ field: Int, _ type: Type) {
+    self.expression = expression
+    self.field = field
+    self.type = type
+  }
+}
+
+/// Tree that represents the #unquote(...) expression.
+/// Note how it contains both the AST representation of the unquoted expression and the actual value
+/// of that expression. The actual value is wrapped in a no-parameter closure to allow for mutually
+/// recursive quotes.
+///
+///     > let x = #quote(40)
+///     > let q = #quote(#unquote(x) + 2)
+///     > print(q.structure)
+///     Binary(
+///       Unquote(
+///         Name(
+///           "x",
+///           "s:4main1x5QuoteACCySiGvp",
+///           SpecializedType(
+///             TypeName("Quote", "s:5QuoteAAC"),
+///             [TypeName("Int", "s:Si")])),
+///         40,
+///         TypeName("Int", "s:Si")),
+///       Name(
+///         "+",
+///         "s:Si1poiyS2i_SitFZ",
+///         FunctionType(
+///           [],
+///           [TypeName("Int", "s:Si"),
+///           TypeName("Int", "s:Si")],
+///           TypeName("Int", "s:Si"))),
+///       IntegerLiteral(
+///         2,
+///         TypeName("Int", "s:Si")),
+///       TypeName("Int", "s:Si"))
+public class Unquote: Expression {
+  public let expression: Expression
+  public let value: () -> Tree
+  public let type: Type
+
+  public init(
+    _ expression: Expression,
+    _ value: @autoclosure @escaping () -> Tree,
+    _ type: Type
+  ) {
+    self.expression = expression
+    self.value = value
+    self.type = type
+  }
+}
+
+/// Tree that represents a synthetic argument inserted into a call with a vararg parameter.
+/// See `Call` for an example.
+public class Varargs: Expression {
+  public let expressions: [Expression]
+  public let type: Type
+
+  public init(_ expressions: [Expression], _ type: Type) {
+    self.expressions = expressions
+    self.type = type
+  }
+}
+
+/// Tree that represents a wildcard, i.e. `_`.
+///
+///     > let q = #quote(_ = 42)
+///     > print(q.structure)
+///     Assign(
+///       Wildcard(),
+///       IntegerLiteral(
+///         42,
+///         TypeName("Int", "s:Si")),
+///       TupleType(
+///         []))
+public class Wildcard: Expression {
+  public var type: Type {
+    return UnknownTree()
+  }
+
+  public init() {
+  }
+}
+
+// MARK: Declarations
+
+/// Tree that represents a Swift declaration.
+public protocol Declaration: Statement {
+}
+
+/// Tree that represents a `func` declaration.
+/// Note that the result type is not stored as a field but computed from the type of name.
+/// It is a known issue that local functions cannot be quoted (#5).
+///
+///     > @quoted
+///     > func foo(_ x: Int) -> Int {
+///     >   return x
+///     > }
+///     > print(#quote(foo).structure)
+///     Unquote(
+///       Name(
+///         "foo",
+///         "s:4main3fooyS2iF",
+///         FunctionType(
+///           [],
+///           [TypeName("Int", "s:Si")],
+///           TypeName("Int", "s:Si"))),
+///       func foo(_ x: Int) -> Int in
+///       return x
+///     }  ,
+///       SpecializedType(
+///         TypeName("FunctionQuote1", "s:5Quote14FunctionQuote1C"),
+///         [TypeName("Int", "s:Si"),
+///         TypeName("Int", "s:Si")]))
+public class Function: Declaration {
+  public let name: Name
+  public let parameters: [Parameter]
+
+  public var result: Type {
+    switch name.type {
+    case let type as FunctionType:
+      return type.result
+    default:
+      return UnknownTree()
+    }
+  }
+
+  public let body: [Statement]
+
+  public init(
+    _ name: Name,
+    _ parameters: [Parameter],
+    _ body: [Statement]
+  ) {
+    self.name = name
+    self.parameters = parameters
+    self.body = body
+  }
+}
+
+/// Tree that represents a `let` declaration.
+/// Note that the result type is not stored as a field but computed from the type of name.
+///
+///     > let q = #quote { let x = 42 };
+///     > print(q.structure);
+///     Closure(
+///       [],
+///       [Let(
+///         Name(
+///           "x",
+///           "s:4mainyycfU_1xL_Sivp",
+///           TypeName("Int", "s:Si")),
+///         IntegerLiteral(
+///           42,
+///           TypeName("Int", "s:Si")))],
+///       FunctionType(
+///         [],
+///         [],
+///         TupleType(
+///           [])))
+public class Let: Declaration {
+  public let name: Name
+  public var type: Type { return name.type }
+  public let rhs: Expression
+
+  public init(_ name: Name, _ rhs: Expression) {
+    self.name = name
+    self.rhs = rhs
+  }
+}
+
+/// Tree that represents a parameter declaration.
+/// See `Closure` for an example.
+public class Parameter: Tree {
+  public let label: String?
+  public let name: Name
+  public var type: Type { return name.type }
+
+  public init(_ label: String?, _ name: Name) {
+    self.label = label
+    self.name = name
+  }
+}
+
+/// Tree that represents a `var` declaration.
+/// Note that the result type is not stored as a field but computed from the type of name.
+///
+///     > let q = #quote { var x = 42 };
+///     > print(q.structure);
+///     Closure(
+///       [],
+///       [Var(
+///         Name(
+///           "x",
+///           "s:4mainyycfU_1xL_Sivp",
+///           TypeName("Int", "s:Si")),
+///         IntegerLiteral(
+///           42,
+///           TypeName("Int", "s:Si")))],
+///       FunctionType(
+///         []
+///         [],
+///         TupleType(
+///           [])))
+public class Var: Declaration {
+  public let name: Name
+  public var type: Type { return name.type }
+  public let rhs: Expression
+
+  public init(_ name: Name, _ rhs: Expression) {
+    self.name = name
+    self.rhs = rhs
+  }
+}

--- a/Sources/Quote/Trees.swift
+++ b/Sources/Quote/Trees.swift
@@ -89,12 +89,12 @@ public protocol Tree: CustomStringConvertible {
 /// frequent guest in quotes. In the future, we are planning to extend the supported subset of
 /// the language until it eventually covers everything.
 public class UnknownTree: Attribute, Type, Condition, Statement, Expression, Declaration {
-  public var type: Type {
-    return UnknownTree()
-  }
+    public var type: Type {
+        return UnknownTree()
+    }
 
-  public init() {
-  }
+    public init() {
+    }
 }
 
 // MARK: Attributes
@@ -113,8 +113,8 @@ public protocol Attribute: Tree {
 ///       [TypeName("Float", "s:Sf")],
 ///       TypeName("Float", "s:Sf"))
 public class Differentiable: Attribute {
-  public init() {
-  }
+    public init() {
+    }
 }
 
 // MARK: Types
@@ -136,11 +136,11 @@ public protocol Type: Tree {
 ///       [TypeName("A", "s:4main1AP"),
 ///       TypeName("B", "s:4main1BP")])
 public class AndType: Type {
-  public let types: [Type]
+    public let types: [Type]
 
-  public init(_ types: [Type]) {
-    self.types = types
-  }
+    public init(_ types: [Type]) {
+        self.types = types
+    }
 }
 
 /// Tree that represents an array type [T].
@@ -151,11 +151,11 @@ public class AndType: Type {
 ///     ArrayType(
 ///       TypeName("Int", "s:Si"))
 public class ArrayType: Type {
-  public let type: Type
+    public let type: Type
 
-  public init(_ type: Type) {
-    self.type = type
-  }
+    public init(_ type: Type) {
+        self.type = type
+    }
 }
 
 /// Tree that represents a dictionary type [T: U].
@@ -167,13 +167,13 @@ public class ArrayType: Type {
 ///       TypeName("Int", "s:Si"),
 ///       TypeName("Int", "s:Si"))
 public class DictionaryType: Type {
-  public let key: Type
-  public let value: Type
+    public let key: Type
+    public let value: Type
 
-  public init(_ key: Type, _ value: Type) {
-    self.key = key
-    self.value = value
-  }
+    public init(_ key: Type, _ value: Type) {
+        self.key = key
+        self.value = value
+    }
 }
 
 /// Tree that represents a function type (T1, ..., Tn) -> R.
@@ -186,15 +186,15 @@ public class DictionaryType: Type {
 ///       [TypeName("Int", "s:Si")],
 ///       TypeName("Int", "s:Si"))
 public class FunctionType: Type {
-  public let attributes: [Attribute]
-  public let parameters: [Type]
-  public let result: Type
+    public let attributes: [Attribute]
+    public let parameters: [Type]
+    public let result: Type
 
-  public init(_ attributes: [Attribute], _ parameters: [Type], _ result: Type) {
-    self.attributes = attributes
-    self.parameters = parameters
-    self.result = result
-  }
+    public init(_ attributes: [Attribute], _ parameters: [Type], _ result: Type) {
+        self.attributes = attributes
+        self.parameters = parameters
+        self.result = result
+    }
 }
 
 /// Tree that represents a type of an inout parameter.
@@ -207,11 +207,11 @@ public class FunctionType: Type {
 ///         TypeName("Int", "s:Si"))],
 ///       TypeName("Int", "s:Si"))
 public class InoutType: Type {
-  public let type: Type
+    public let type: Type
 
-  public init(_ type: Type) {
-    self.type = type
-  }
+    public init(_ type: Type) {
+        self.type = type
+    }
 }
 
 /// Tree that represents a type of a reference to an in-out parameter.
@@ -241,11 +241,11 @@ public class InoutType: Type {
 ///         TupleType(
 ///           [])))
 public class LValueType: Type {
-  public let type: Type
+    public let type: Type
 
-  public init(_ type: Type) {
-    self.type = type
-  }
+    public init(_ type: Type) {
+        self.type = type
+    }
 }
 
 /// Tree that represents a metatype T.Type or T.Protocol.
@@ -256,11 +256,11 @@ public class LValueType: Type {
 ///     MetaType(
 ///       TypeName("Int", "s:Si"))
 public class MetaType: Type {
-  public let type: Type
+    public let type: Type
 
-  public init(_ type: Type) {
-    self.type = type
-  }
+    public init(_ type: Type) {
+        self.type = type
+    }
 }
 
 /// Tree that represents an optional type T?.
@@ -271,11 +271,11 @@ public class MetaType: Type {
 ///     OptionalType(
 ///       TypeName("Int", "s:Si"))
 public class OptionalType: Type {
-  public let type: Type
+    public let type: Type
 
-  public init(_ type: Type) {
-    self.type = type
-  }
+    public init(_ type: Type) {
+        self.type = type
+    }
 }
 
 /// Tree that represents a specialized type, i.e. a generic type with generic arguments.
@@ -287,13 +287,13 @@ public class OptionalType: Type {
 ///       TypeName("ClosedRange", "s:SN"),
 ///       [TypeName("Int", "s:Si")])
 public class SpecializedType: Type {
-  public let type: Type
-  public let arguments: [Type]
+    public let type: Type
+    public let arguments: [Type]
 
-  public init(_ type: Type, _ arguments: [Type]) {
-    self.type = type
-    self.arguments = arguments
-  }
+    public init(_ type: Type, _ arguments: [Type]) {
+        self.type = type
+        self.arguments = arguments
+    }
 }
 
 /// Tree that represents a tuple type (T1, ..., Tn)
@@ -306,11 +306,11 @@ public class SpecializedType: Type {
 ///       TypeName("String", "s:SS"),
 ///       TypeName("Int", "s:Si")])
 public class TupleType: Type {
-  public let types: [Type]
+    public let types: [Type]
 
-  public init(_ types: [Type]) {
-    self.types = types
-  }
+    public init(_ types: [Type]) {
+        self.types = types
+    }
 }
 
 /// Tree that represents a reference to a class, struct, protocol, etc.
@@ -320,13 +320,13 @@ public class TupleType: Type {
 ///    > print(q.type.structure)
 ///    TypeName("Int", "s:Si")
 public class TypeName: Type {
-  public let value: String
-  public let symbol: String
+    public let value: String
+    public let symbol: String
 
-  public init(_ value: String, _ symbol: String) {
-    self.value = value
-    self.symbol = symbol
-  }
+    public init(_ value: String, _ symbol: String) {
+        self.value = value
+        self.symbol = symbol
+    }
 }
 
 // MARK: Conditions
@@ -364,11 +364,11 @@ public protocol Statement: Tree {
 ///         TupleType(
 ///           [])))
 public class Break: Statement {
-  public let label: String?
+    public let label: String?
 
-  public init(_ label: String?) {
-    self.label = label
-  }
+    public init(_ label: String?) {
+        self.label = label
+    }
 }
 
 /// Tree that represents a continue statement.
@@ -394,11 +394,11 @@ public class Break: Statement {
 ///         TupleType(
 ///           [])))
 public class Continue: Statement {
-  public let label: String?
+    public let label: String?
 
-  public init(_ label: String?) {
-    self.label = label
-  }
+    public init(_ label: String?) {
+        self.label = label
+    }
 }
 
 /// Tree that represents a defer statement.
@@ -424,11 +424,11 @@ public class Continue: Statement {
 ///         TupleType(
 ///           [])))
 public class Defer: Statement {
-  public let body: [Statement]
+    public let body: [Statement]
 
-  public init(_ body: [Statement]) {
-    self.body = body
-  }
+    public init(_ body: [Statement]) {
+        self.body = body
+    }
 }
 
 /// Tree that represents a do statement.
@@ -447,13 +447,13 @@ public class Defer: Statement {
 ///         TupleType(
 ///           [])))
 public class Do: Statement {
-  public let label: String?
-  public let body: [Statement]
+    public let label: String?
+    public let body: [Statement]
 
-  public init(_ label: String?, _ body: [Statement]) {
-    self.label = label
-    self.body = body
-  }
+    public init(_ label: String?, _ body: [Statement]) {
+        self.label = label
+        self.body = body
+    }
 }
 
 /// Tree that represents a for-in loop.
@@ -484,17 +484,17 @@ public class Do: Statement {
 ///         TupleType(
 ///           [])))
 public class For: Statement {
-  public let label: String?
-  public let name: Name
-  public let expression: Expression
-  public let body: [Statement]
+    public let label: String?
+    public let name: Name
+    public let expression: Expression
+    public let body: [Statement]
 
-  public init(_ label: String?, _ name: Name, _ expression: Expression, _ body: [Statement]) {
-    self.label = label
-    self.name = name
-    self.expression = expression
-    self.body = body
-  }
+    public init(_ label: String?, _ name: Name, _ expression: Expression, _ body: [Statement]) {
+        self.label = label
+        self.name = name
+        self.expression = expression
+        self.body = body
+    }
 }
 
 /// Tree that represents a guard statement.
@@ -516,13 +516,13 @@ public class For: Statement {
 ///         TupleType(
 ///           [])))
 public class Guard: Statement {
-  public let condition: [Condition]
-  public let body: [Statement]
+    public let condition: [Condition]
+    public let body: [Statement]
 
-  public init(_ condition: [Condition], _ body: [Statement]) {
-    self.condition = condition
-    self.body = body
-  }
+    public init(_ condition: [Condition], _ body: [Statement]) {
+        self.condition = condition
+        self.body = body
+    }
 }
 
 /// Tree that represents an if statement.
@@ -552,19 +552,20 @@ public class Guard: Statement {
 ///         TupleType(
 ///           [])))
 public class If: Statement {
-  public let label: String?
-  public let condition: [Condition]
-  public let thenBranch: [Statement]
-  public let elseBranch: [Statement]
+    public let label: String?
+    public let condition: [Condition]
+    public let thenBranch: [Statement]
+    public let elseBranch: [Statement]
 
-  public init(
-    _ label: String?, _ condition: [Condition], _ thenBranch: [Statement], _ elseBranch: [Statement]
-  ) {
-    self.label = label
-    self.condition = condition
-    self.thenBranch = thenBranch
-    self.elseBranch = elseBranch
-  }
+    public init(
+        _ label: String?, _ condition: [Condition], _ thenBranch: [Statement],
+        _ elseBranch: [Statement]
+    ) {
+        self.label = label
+        self.condition = condition
+        self.thenBranch = thenBranch
+        self.elseBranch = elseBranch
+    }
 }
 
 /// Tree that represents a repeat-while loop.
@@ -587,15 +588,15 @@ public class If: Statement {
 ///         TupleType(
 ///           [])))
 public class Repeat: Statement {
-  public let label: String?
-  public let body: [Statement]
-  public let condition: Expression
+    public let label: String?
+    public let body: [Statement]
+    public let condition: Expression
 
-  public init(_ label: String?, _ body: [Statement], _ condition: Expression) {
-    self.label = label
-    self.body = body
-    self.condition = condition
-  }
+    public init(_ label: String?, _ body: [Statement], _ condition: Expression) {
+        self.label = label
+        self.body = body
+        self.condition = condition
+    }
 }
 
 /// Tree that represents a return statement.
@@ -616,11 +617,11 @@ public class Repeat: Statement {
 ///         TupleType(
 ///           [])))
 public class Return: Statement {
-  public let expression: Expression
+    public let expression: Expression
 
-  public init(_ expression: Expression) {
-    self.expression = expression
-  }
+    public init(_ expression: Expression) {
+        self.expression = expression
+    }
 }
 
 /// Tree that represents a throw statement.
@@ -652,11 +653,11 @@ public class Return: Statement {
 ///         TupleType(
 ///           [])))
 public class Throw: Statement {
-  public let expression: Expression
+    public let expression: Expression
 
-  public init(_ expression: Expression) {
-    self.expression = expression
-  }
+    public init(_ expression: Expression) {
+        self.expression = expression
+    }
 }
 
 /// Tree that represents a while loop.
@@ -679,15 +680,15 @@ public class Throw: Statement {
 ///         TupleType(
 ///           [])))
 public class While: Statement {
-  public let label: String?
-  public let condition: [Condition]
-  public let body: [Statement]
+    public let label: String?
+    public let condition: [Condition]
+    public let body: [Statement]
 
-  public init(_ label: String?, _ condition: [Condition], _ body: [Statement]) {
-    self.label = label
-    self.condition = condition
-    self.body = body
-  }
+    public init(_ label: String?, _ condition: [Condition], _ body: [Statement]) {
+        self.label = label
+        self.condition = condition
+        self.body = body
+    }
 }
 
 // MARK: Expressions
@@ -695,7 +696,7 @@ public class While: Statement {
 /// Tree that represents a Swift expression.
 /// Always has an associated type computed for this expression by the typechecker.
 public protocol Expression: Statement, Condition {
-  var type: Type { get }
+    var type: Type { get }
 }
 
 /// Tree that represents an array literal [...].
@@ -712,13 +713,13 @@ public protocol Expression: Statement, Condition {
 ///       ArrayType(
 ///         TypeName("Int", "s:Si")))
 public class ArrayLiteral: Expression {
-  public let expressions: [Expression]
-  public let type: Type
+    public let expressions: [Expression]
+    public let type: Type
 
-  public init(_ expressions: [Expression], _ type: Type) {
-    self.expressions = expressions
-    self.type = type
-  }
+    public init(_ expressions: [Expression], _ type: Type) {
+        self.expressions = expressions
+        self.type = type
+    }
 }
 
 /// Tree that represents an as expression.
@@ -730,13 +731,13 @@ public class ArrayLiteral: Expression {
 ///         42,
 ///         TypeName("Int", "s:Si")))
 public class As: Expression {
-  public let expression: Expression
-  public let type: Type
+    public let expression: Expression
+    public let type: Type
 
-  public init(_ expression: Expression, _ type: Type) {
-    self.expression = expression
-    self.type = type
-  }
+    public init(_ expression: Expression, _ type: Type) {
+        self.expression = expression
+        self.type = type
+    }
 }
 
 /// Tree that represents an assignment expression.
@@ -756,15 +757,15 @@ public class As: Expression {
 ///       TupleType(
 ///         []))
 public class Assign: Expression {
-  public let lhs: Expression
-  public let rhs: Expression
-  public let type: Type
+    public let lhs: Expression
+    public let rhs: Expression
+    public let type: Type
 
-  public init(_ lhs: Expression, _ rhs: Expression, _ type: Type) {
-    self.lhs = lhs
-    self.rhs = rhs
-    self.type = type
-  }
+    public init(_ lhs: Expression, _ rhs: Expression, _ type: Type) {
+        self.lhs = lhs
+        self.rhs = rhs
+        self.type = type
+    }
 }
 
 /// Tree that represents a binary operator expression.
@@ -788,17 +789,17 @@ public class Assign: Expression {
 ///         TypeName("Int", "s:Si")),
 ///       TypeName("Int", "s:Si"))
 public class Binary: Expression {
-  public let lhs: Expression
-  public let name: Name
-  public let rhs: Expression
-  public let type: Type
+    public let lhs: Expression
+    public let name: Name
+    public let rhs: Expression
+    public let type: Type
 
-  public init(_ lhs: Expression, _ name: Name, _ rhs: Expression, _ type: Type) {
-    self.lhs = lhs
-    self.name = name
-    self.rhs = rhs
-    self.type = type
-  }
+    public init(_ lhs: Expression, _ name: Name, _ rhs: Expression, _ type: Type) {
+        self.lhs = lhs
+        self.name = name
+        self.rhs = rhs
+        self.type = type
+    }
 }
 
 /// Tree that represents a boolean literal.
@@ -809,13 +810,13 @@ public class Binary: Expression {
 ///       true,
 ///       TypeName("Bool", "s:Sb"))
 public class BooleanLiteral: Expression {
-  public let value: Bool
-  public let type: Type
+    public let value: Bool
+    public let type: Type
 
-  public init(_ value: Bool, _ type: Type) {
-    self.value = value
-    self.type = type
-  }
+    public init(_ value: Bool, _ type: Type) {
+        self.value = value
+        self.type = type
+    }
 }
 
 /// Tree that represents a call expression.
@@ -853,22 +854,22 @@ public class BooleanLiteral: Expression {
 ///       TupleType(
 ///         []))
 public class Call: Expression {
-  public let expression: Expression
-  public let labels: [String?]
-  public let arguments: [Expression]
-  public let type: Type
+    public let expression: Expression
+    public let labels: [String?]
+    public let arguments: [Expression]
+    public let type: Type
 
-  public init(
-    _ expression: Expression,
-    _ labels: [String?],
-    _ arguments: [Expression],
-    _ type: Type
-  ) {
-    self.expression = expression
-    self.labels = labels
-    self.arguments = arguments
-    self.type = type
-  }
+    public init(
+        _ expression: Expression,
+        _ labels: [String?],
+        _ arguments: [Expression],
+        _ type: Type
+    ) {
+        self.expression = expression
+        self.labels = labels
+        self.arguments = arguments
+        self.type = type
+    }
 }
 
 /// Tree that represents a closure expression.
@@ -922,29 +923,29 @@ public class Call: Expression {
 ///       TupleType(
 ///         []))
 public class Closure: Expression {
-  public let parameters: [Parameter]
+    public let parameters: [Parameter]
 
-  public var result: Type {
-    switch type {
-    case let type as FunctionType:
-      return type.result
-    default:
-      return UnknownTree()
+    public var result: Type {
+        switch type {
+        case let type as FunctionType:
+            return type.result
+        default:
+            return UnknownTree()
+        }
     }
-  }
 
-  public let body: [Statement]
-  public let type: Type
+    public let body: [Statement]
+    public let type: Type
 
-  public init(
-    _ parameters: [Parameter],
-    _ body: [Statement],
-    _ type: Type
-  ) {
-    self.parameters = parameters
-    self.body = body
-    self.type = type
-  }
+    public init(
+        _ parameters: [Parameter],
+        _ body: [Statement],
+        _ type: Type
+    ) {
+        self.parameters = parameters
+        self.body = body
+        self.type = type
+    }
 }
 
 /// Tree that represents one of the variety of implicit conversions applied by the Swift compiler.
@@ -954,25 +955,25 @@ public class Closure: Expression {
 ///
 /// See `LValueType` for an example.
 public class Conversion: Expression {
-  public let expression: Expression
-  public let type: Type
+    public let expression: Expression
+    public let type: Type
 
-  public init(_ expression: Expression, _ type: Type) {
-    self.expression = expression
-    self.type = type
-  }
+    public init(_ expression: Expression, _ type: Type) {
+        self.expression = expression
+        self.type = type
+    }
 }
 
 /// Tree that represents a synthetic argument inserted into a call with a default parameter.
 /// See `Call` for an example.
 public class Default: Expression {
-  public let symbol: String
-  public let type: Type
+    public let symbol: String
+    public let type: Type
 
-  public init(_ symbol: String, _ type: Type) {
-    self.symbol = symbol
-    self.type = type
-  }
+    public init(_ symbol: String, _ type: Type) {
+        self.symbol = symbol
+        self.type = type
+    }
 }
 
 /// Tree that represents a dictionary literal [...: ..., ...].
@@ -996,13 +997,13 @@ public class Default: Expression {
 ///         TypeName("Int", "s:Si"),
 ///         TypeName("Int", "s:Si")))
 public class DictionaryLiteral: Expression {
-  public let expressions: [Expression]
-  public let type: Type
+    public let expressions: [Expression]
+    public let type: Type
 
-  public init(_ expressions: [Expression], _ type: Type) {
-    self.expressions = expressions
-    self.type = type
-  }
+    public init(_ expressions: [Expression], _ type: Type) {
+        self.expressions = expressions
+        self.type = type
+    }
 }
 
 /// Tree that represents a floating-point literal.
@@ -1013,13 +1014,13 @@ public class DictionaryLiteral: Expression {
 ///       42.0,
 ///       TypeName("Double", "s:Sd"))
 public class FloatLiteral: Expression {
-  public let value: Float
-  public let type: Type
+    public let value: Float
+    public let type: Type
 
-  public init(_ value: Float, _ type: Type) {
-    self.value = value
-    self.type = type
-  }
+    public init(_ value: Float, _ type: Type) {
+        self.value = value
+        self.type = type
+    }
 }
 
 /// Tree that represents a ! expression.
@@ -1035,13 +1036,13 @@ public class FloatLiteral: Expression {
 ///           [])),
 ///       TypeName("Int", "s:Si"))
 public class Force: Expression {
-  public let expression: Expression
-  public let type: Type
+    public let expression: Expression
+    public let type: Type
 
-  public init(_ expression: Expression, _ type: Type) {
-    self.expression = expression
-    self.type = type
-  }
+    public init(_ expression: Expression, _ type: Type) {
+        self.expression = expression
+        self.type = type
+    }
 }
 
 /// Tree that represents an as! expression.
@@ -1057,13 +1058,13 @@ public class Force: Expression {
 ///           [])),
 ///       TypeName("Int", "s:Si"))
 public class ForceAs: Expression {
-  public let expression: Expression
-  public let type: Type
+    public let expression: Expression
+    public let type: Type
 
-  public init(_ expression: Expression, _ type: Type) {
-    self.expression = expression
-    self.type = type
-  }
+    public init(_ expression: Expression, _ type: Type) {
+        self.expression = expression
+        self.type = type
+    }
 }
 
 /// Tree that represents a try! expression.
@@ -1075,13 +1076,13 @@ public class ForceAs: Expression {
 ///         42,
 ///         TypeName("Int", "s:Si")))
 public class ForceTry: Expression {
-  public let expression: Expression
-  public let type: Type
+    public let expression: Expression
+    public let type: Type
 
-  public init(_ expression: Expression, _ type: Type) {
-    self.expression = expression
-    self.type = type
-  }
+    public init(_ expression: Expression, _ type: Type) {
+        self.expression = expression
+        self.type = type
+    }
 }
 
 /// Tree that represents an in-out expression.
@@ -1110,13 +1111,13 @@ public class ForceTry: Expression {
 ///       TupleType(
 ///         []))
 public class Inout: Expression {
-  public let expression: Expression
-  public let type: Type
+    public let expression: Expression
+    public let type: Type
 
-  public init(_ expression: Expression, _ type: Type) {
-    self.expression = expression
-    self.type = type
-  }
+    public init(_ expression: Expression, _ type: Type) {
+        self.expression = expression
+        self.type = type
+    }
 }
 
 /// Tree that represents an integer literal.
@@ -1127,13 +1128,13 @@ public class Inout: Expression {
 ///       42,
 ///       TypeName("Int", "s:Si"))
 public class IntegerLiteral: Expression {
-  public let value: Int
-  public let type: Type
+    public let value: Int
+    public let type: Type
 
-  public init(_ value: Int, _ type: Type) {
-    self.value = value
-    self.type = type
-  }
+    public init(_ value: Int, _ type: Type) {
+        self.value = value
+        self.type = type
+    }
 }
 
 /// Tree that represents an as expression.
@@ -1150,15 +1151,15 @@ public class IntegerLiteral: Expression {
 ///       TypeName("Int", "s:Si"),
 ///       TypeName("Bool", "s:Sb"))
 public class Is: Expression {
-  public let expression: Expression
-  public let targetType: Type
-  public let type: Type
+    public let expression: Expression
+    public let targetType: Type
+    public let type: Type
 
-  public init(_ expression: Expression, _ targetType: Type, _ type: Type) {
-    self.expression = expression
-    self.targetType = targetType
-    self.type = type
-  }
+    public init(_ expression: Expression, _ targetType: Type, _ type: Type) {
+        self.expression = expression
+        self.targetType = targetType
+        self.type = type
+    }
 }
 
 /// Tree that represents a magic literal, i.e. #file, #line, #column, #function or #dsohandle.
@@ -1169,13 +1170,13 @@ public class Is: Expression {
 ///       "file",
 ///       TypeName("String", "s:SS"))
 public class MagicLiteral: Expression {
-  public let kind: String
-  public let type: Type
+    public let kind: String
+    public let type: Type
 
-  public init(_ kind: String, _ type: Type) {
-    self.kind = kind
-    self.type = type
-  }
+    public init(_ kind: String, _ type: Type) {
+        self.kind = kind
+        self.type = type
+    }
 }
 
 /// Tree that represents member selection.
@@ -1237,17 +1238,17 @@ public class MagicLiteral: Expression {
 ///
 /// Selection from a tuple is modelled as `TupleElement`.
 public class Member: Expression {
-  public let expression: Expression
-  public let value: String
-  public let symbol: String
-  public let type: Type
+    public let expression: Expression
+    public let value: String
+    public let symbol: String
+    public let type: Type
 
-  public init(_ expression: Expression, _ value: String, _ symbol: String, _ type: Type) {
-    self.expression = expression
-    self.value = value
-    self.symbol = symbol
-    self.type = type
-  }
+    public init(_ expression: Expression, _ value: String, _ symbol: String, _ type: Type) {
+        self.expression = expression
+        self.value = value
+        self.symbol = symbol
+        self.type = type
+    }
 }
 
 /// Tree that represents a #quote(...) expression.
@@ -1262,13 +1263,13 @@ public class Member: Expression {
 ///         TypeName("Quote", "s:5QuoteAAC"),
 ///         [TypeName("Int", "s:Si")]))
 public class Meta: Expression {
-  public let expression: Expression
-  public let type: Type
+    public let expression: Expression
+    public let type: Type
 
-  public init(_ expression: Expression, _ type: Type) {
-    self.expression = expression
-    self.type = type
-  }
+    public init(_ expression: Expression, _ type: Type) {
+        self.expression = expression
+        self.type = type
+    }
 }
 
 /// Tree that represents a reference to a value, func, etc.
@@ -1281,15 +1282,15 @@ public class Meta: Expression {
 ///       "s:4main1xSivp",
 ///       TypeName("Int", "s:Si"))
 public class Name: Expression {
-  public let value: String
-  public let symbol: String
-  public let type: Type
+    public let value: String
+    public let symbol: String
+    public let type: Type
 
-  public init(_ value: String, _ symbol: String, _ type: Type) {
-    self.value = value
-    self.symbol = symbol
-    self.type = type
-  }
+    public init(_ value: String, _ symbol: String, _ type: Type) {
+        self.value = value
+        self.symbol = symbol
+        self.type = type
+    }
 }
 
 /// Tree that represents a nil literal.
@@ -1303,11 +1304,11 @@ public class Name: Expression {
 ///       OptionalType(
 ///         TypeName("Int", "s:Si")))
 public class NilLiteral: Expression {
-  public let type: Type
+    public let type: Type
 
-  public init(_ type: Type) {
-    self.type = type
-  }
+    public init(_ type: Type) {
+        self.type = type
+    }
 }
 
 /// Tree that represents an as? expression.
@@ -1325,15 +1326,15 @@ public class NilLiteral: Expression {
 ///       OptionalType(
 ///         TypeName("Int", "s:Si")))
 public class OptionalAs: Expression {
-  public let expression: Expression
-  public let targetType: Type
-  public let type: Type
+    public let expression: Expression
+    public let targetType: Type
+    public let type: Type
 
-  public init(_ expression: Expression, _ targetType: Type, _ type: Type) {
-    self.expression = expression
-    self.targetType = targetType
-    self.type = type
-  }
+    public init(_ expression: Expression, _ targetType: Type, _ type: Type) {
+        self.expression = expression
+        self.targetType = targetType
+        self.type = type
+    }
 }
 
 /// Tree that represents a try? expression.
@@ -1348,26 +1349,26 @@ public class OptionalAs: Expression {
 ///         OptionalType(
 ///           TypeName("Int", "s:Si"))))
 public class OptionalTry: Expression {
-  public let expression: Expression
-  public let type: Type
+    public let expression: Expression
+    public let type: Type
 
-  public init(_ expression: Expression, _ type: Type) {
-    self.expression = expression
-    self.type = type
-  }
+    public init(_ expression: Expression, _ type: Type) {
+        self.expression = expression
+        self.type = type
+    }
 }
 
 /// Tree that represents a postfix operator expression.
 public class Postfix: Expression {
-  public let expression: Expression
-  public let name: Name
-  public let type: Type
+    public let expression: Expression
+    public let name: Name
+    public let type: Type
 
-  public init(_ expression: Expression, _ name: Name, _ type: Type) {
-    self.expression = expression
-    self.name = name
-    self.type = type
-  }
+    public init(_ expression: Expression, _ name: Name, _ type: Type) {
+        self.expression = expression
+        self.name = name
+        self.type = type
+    }
 }
 
 /// Tree that represents a postfix self expression expr.self or T.self.
@@ -1387,13 +1388,13 @@ public class Postfix: Expression {
 ///       MetaType(
 ///         TypeName("Int", "s:Si")))
 public class PostfixSelf: Expression {
-  public let tree: Tree
-  public let type: Type
+    public let tree: Tree
+    public let type: Type
 
-  public init(_ tree: Tree, _ type: Type) {
-    self.tree = tree
-    self.type = type
-  }
+    public init(_ tree: Tree, _ type: Type) {
+        self.tree = tree
+        self.type = type
+    }
 }
 
 /// Tree that represents a prefix operator expression.
@@ -1413,15 +1414,15 @@ public class PostfixSelf: Expression {
 ///         TypeName("Int", "s:Si")),
 ///       TypeName("Int", "s:Si"))
 public class Prefix: Expression {
-  public let name: Name
-  public let expression: Expression
-  public let type: Type
+    public let name: Name
+    public let expression: Expression
+    public let type: Type
 
-  public init(_ name: Name, _ expression: Expression, _ type: Type) {
-    self.name = name
-    self.expression = expression
-    self.type = type
-  }
+    public init(_ name: Name, _ expression: Expression, _ type: Type) {
+        self.name = name
+        self.expression = expression
+        self.type = type
+    }
 }
 
 /// Tree that provides an incomplete representation of a string interpolation expression.
@@ -1433,11 +1434,11 @@ public class Prefix: Expression {
 ///     StringInterpolation(
 ///       TypeName("String", "s:SS"))
 public class StringInterpolation: Expression {
-  public let type: Type
+    public let type: Type
 
-  public init(_ type: Type) {
-    self.type = type
-  }
+    public init(_ type: Type) {
+        self.type = type
+    }
 }
 
 /// Tree that represents a string literal.
@@ -1448,13 +1449,13 @@ public class StringInterpolation: Expression {
 ///       "42",
 ///       TypeName("Int", "s:SS"))
 public class StringLiteral: Expression {
-  public let value: String
-  public let type: Type
+    public let value: String
+    public let type: Type
 
-  public init(_ value: String, _ type: Type) {
-    self.value = value
-    self.type = type
-  }
+    public init(_ value: String, _ type: Type) {
+        self.value = value
+        self.type = type
+    }
 }
 
 /// Tree that represents a subscript expression.
@@ -1475,25 +1476,25 @@ public class StringLiteral: Expression {
 ///         TypeName("Int", "s:Si"))],
 ///       TypeName("Int", "s:Si"))
 public class Subscript: Expression {
-  public let expression: Expression
-  public let symbol: String
-  public let labels: [String?]
-  public let arguments: [Expression]
-  public let type: Type
+    public let expression: Expression
+    public let symbol: String
+    public let labels: [String?]
+    public let arguments: [Expression]
+    public let type: Type
 
-  public init(
-    _ expression: Expression,
-    _ symbol: String,
-    _ labels: [String?],
-    _ arguments: [Expression],
-    _ type: Type
-  ) {
-    self.expression = expression
-    self.symbol = symbol
-    self.labels = labels
-    self.arguments = arguments
-    self.type = type
-  }
+    public init(
+        _ expression: Expression,
+        _ symbol: String,
+        _ labels: [String?],
+        _ arguments: [Expression],
+        _ type: Type
+    ) {
+        self.expression = expression
+        self.symbol = symbol
+        self.labels = labels
+        self.arguments = arguments
+        self.type = type
+    }
 }
 
 /// Tree that represents a super expression.
@@ -1524,11 +1525,11 @@ public class Subscript: Expression {
 ///       TupleType(
 ///         []))
 public class Super: Expression {
-  public let type: Type
+    public let type: Type
 
-  public init(_ type: Type) {
-    self.type = type
-  }
+    public init(_ type: Type) {
+        self.type = type
+    }
 }
 
 /// Tree that represents a ternary operator expression.
@@ -1547,22 +1548,22 @@ public class Super: Expression {
 ///         TypeName("Int", "s:Si")),
 ///       TypeName("Int", "s:Si"))
 public class Ternary: Expression {
-  public let condition: Expression
-  public let thenBranch: Expression
-  public let elseBranch: Expression
-  public let type: Type
+    public let condition: Expression
+    public let thenBranch: Expression
+    public let elseBranch: Expression
+    public let type: Type
 
-  public init(
-    _ condition: Expression,
-    _ thenBranch: Expression,
-    _ elseBranch: Expression,
-    _ type: Type
-  ) {
-    self.condition = condition
-    self.thenBranch = thenBranch
-    self.elseBranch = elseBranch
-    self.type = type
-  }
+    public init(
+        _ condition: Expression,
+        _ thenBranch: Expression,
+        _ elseBranch: Expression,
+        _ type: Type
+    ) {
+        self.condition = condition
+        self.thenBranch = thenBranch
+        self.elseBranch = elseBranch
+        self.type = type
+    }
 }
 
 /// Tree that represents a try expression.
@@ -1574,13 +1575,13 @@ public class Ternary: Expression {
 ///         42,
 ///         TypeName("Int", "s:Si")))
 public class Try: Expression {
-  public let expression: Expression
-  public let type: Type
+    public let expression: Expression
+    public let type: Type
 
-  public init(_ expression: Expression, _ type: Type) {
-    self.expression = expression
-    self.type = type
-  }
+    public init(_ expression: Expression, _ type: Type) {
+        self.expression = expression
+        self.type = type
+    }
 }
 
 /// Tree that represents a tuple expression.
@@ -1603,19 +1604,19 @@ public class Try: Expression {
 ///         TypeName("String", "s:SS"),
 ///         TypeName("Int", "s:Si")]))
 public class Tuple: Expression {
-  public let labels: [String?]
-  public let arguments: [Expression]
-  public let type: Type
+    public let labels: [String?]
+    public let arguments: [Expression]
+    public let type: Type
 
-  public init(
-    _ labels: [String?],
-    _ arguments: [Expression],
-    _ type: Type
-  ) {
-    self.labels = labels
-    self.arguments = arguments
-    self.type = type
-  }
+    public init(
+        _ labels: [String?],
+        _ arguments: [Expression],
+        _ type: Type
+    ) {
+        self.labels = labels
+        self.arguments = arguments
+        self.type = type
+    }
 }
 
 /// Tree that represents selection of a tuple element.
@@ -1636,15 +1637,15 @@ public class Tuple: Expression {
 ///       1,
 ///       TypeName("Int", "s:Si"))
 public class TupleElement: Expression {
-  public let expression: Expression
-  public let field: Int
-  public let type: Type
+    public let expression: Expression
+    public let field: Int
+    public let type: Type
 
-  public init(_ expression: Expression, _ field: Int, _ type: Type) {
-    self.expression = expression
-    self.field = field
-    self.type = type
-  }
+    public init(_ expression: Expression, _ field: Int, _ type: Type) {
+        self.expression = expression
+        self.field = field
+        self.type = type
+    }
 }
 
 /// Tree that represents the #unquote(...) expression.
@@ -1678,31 +1679,31 @@ public class TupleElement: Expression {
 ///         TypeName("Int", "s:Si")),
 ///       TypeName("Int", "s:Si"))
 public class Unquote: Expression {
-  public let expression: Expression
-  public let value: () -> Tree
-  public let type: Type
+    public let expression: Expression
+    public let value: () -> Tree
+    public let type: Type
 
-  public init(
-    _ expression: Expression,
-    _ value: @autoclosure @escaping () -> Tree,
-    _ type: Type
-  ) {
-    self.expression = expression
-    self.value = value
-    self.type = type
-  }
+    public init(
+        _ expression: Expression,
+        _ value: @autoclosure @escaping () -> Tree,
+        _ type: Type
+    ) {
+        self.expression = expression
+        self.value = value
+        self.type = type
+    }
 }
 
 /// Tree that represents a synthetic argument inserted into a call with a vararg parameter.
 /// See `Call` for an example.
 public class Varargs: Expression {
-  public let expressions: [Expression]
-  public let type: Type
+    public let expressions: [Expression]
+    public let type: Type
 
-  public init(_ expressions: [Expression], _ type: Type) {
-    self.expressions = expressions
-    self.type = type
-  }
+    public init(_ expressions: [Expression], _ type: Type) {
+        self.expressions = expressions
+        self.type = type
+    }
 }
 
 /// Tree that represents a wildcard, i.e. `_`.
@@ -1717,12 +1718,12 @@ public class Varargs: Expression {
 ///       TupleType(
 ///         []))
 public class Wildcard: Expression {
-  public var type: Type {
-    return UnknownTree()
-  }
+    public var type: Type {
+        return UnknownTree()
+    }
 
-  public init() {
-  }
+    public init() {
+    }
 }
 
 // MARK: Declarations
@@ -1756,29 +1757,29 @@ public protocol Declaration: Statement {
 ///         [TypeName("Int", "s:Si"),
 ///         TypeName("Int", "s:Si")]))
 public class Function: Declaration {
-  public let name: Name
-  public let parameters: [Parameter]
+    public let name: Name
+    public let parameters: [Parameter]
 
-  public var result: Type {
-    switch name.type {
-    case let type as FunctionType:
-      return type.result
-    default:
-      return UnknownTree()
+    public var result: Type {
+        switch name.type {
+        case let type as FunctionType:
+            return type.result
+        default:
+            return UnknownTree()
+        }
     }
-  }
 
-  public let body: [Statement]
+    public let body: [Statement]
 
-  public init(
-    _ name: Name,
-    _ parameters: [Parameter],
-    _ body: [Statement]
-  ) {
-    self.name = name
-    self.parameters = parameters
-    self.body = body
-  }
+    public init(
+        _ name: Name,
+        _ parameters: [Parameter],
+        _ body: [Statement]
+    ) {
+        self.name = name
+        self.parameters = parameters
+        self.body = body
+    }
 }
 
 /// Tree that represents a `let` declaration.
@@ -1802,27 +1803,27 @@ public class Function: Declaration {
 ///         TupleType(
 ///           [])))
 public class Let: Declaration {
-  public let name: Name
-  public var type: Type { return name.type }
-  public let rhs: Expression
+    public let name: Name
+    public var type: Type { return name.type }
+    public let rhs: Expression
 
-  public init(_ name: Name, _ rhs: Expression) {
-    self.name = name
-    self.rhs = rhs
-  }
+    public init(_ name: Name, _ rhs: Expression) {
+        self.name = name
+        self.rhs = rhs
+    }
 }
 
 /// Tree that represents a parameter declaration.
 /// See `Closure` for an example.
 public class Parameter: Tree {
-  public let label: String?
-  public let name: Name
-  public var type: Type { return name.type }
+    public let label: String?
+    public let name: Name
+    public var type: Type { return name.type }
 
-  public init(_ label: String?, _ name: Name) {
-    self.label = label
-    self.name = name
-  }
+    public init(_ label: String?, _ name: Name) {
+        self.label = label
+        self.name = name
+    }
 }
 
 /// Tree that represents a `var` declaration.
@@ -1846,12 +1847,12 @@ public class Parameter: Tree {
 ///         TupleType(
 ///           [])))
 public class Var: Declaration {
-  public let name: Name
-  public var type: Type { return name.type }
-  public let rhs: Expression
+    public let name: Name
+    public var type: Type { return name.type }
+    public let rhs: Expression
 
-  public init(_ name: Name, _ rhs: Expression) {
-    self.name = name
-    self.rhs = rhs
-  }
+    public init(_ name: Name, _ rhs: Expression) {
+        self.name = name
+        self.rhs = rhs
+    }
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,8 +2,8 @@ import QuoteTests
 import XCTest
 
 let tests = [
-  testCase(DescriptionTests.allTests),
-  testCase(QuoteTests.allTests),
-  testCase(StructureTests.allTests),
+    testCase(DescriptionTests.allTests),
+    testCase(QuoteTests.allTests),
+    testCase(StructureTests.allTests),
 ]
 XCTMain(tests)

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,9 @@
+import QuoteTests
+import XCTest
+
+let tests = [
+  testCase(DescriptionTests.allTests),
+  testCase(QuoteTests.allTests),
+  testCase(StructureTests.allTests),
+]
+XCTMain(tests)

--- a/Tests/QuoteTests/Assertions.swift
+++ b/Tests/QuoteTests/Assertions.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Quote
+import XCTest
+
+func assertDescription(
+  _ tree: Tree, _ expected: String, file: StaticString = #file, line: UInt = #line
+) {
+  XCTAssertEqual(tree.description, expected, file: file, line: line)
+}
+
+func assertDescription<T>(
+  _ quote: Quote<T>, _ expected: String, file: StaticString = #file, line: UInt = #line
+) {
+  XCTAssertEqual(quote.description, expected, file: file, line: line)
+}
+
+func assertStructure(
+  _ tree: Tree, _ expected: String, file: StaticString = #file, line: UInt = #line
+) {
+  XCTAssertEqual(stripUnstableUSRs(tree.structure), expected, file: file, line: line)
+}
+
+func assertStructure<T>(
+  _ quote: Quote<T>, _ expected: String, file: StaticString = #file, line: UInt = #line
+) {
+  XCTAssertEqual(stripUnstableUSRs(quote.structure), expected, file: file, line: line)
+}
+
+private func stripUnstableUSRs(_ s: String) -> String {
+  let range = NSRange(location: 0, length: s.count)
+  let regex = try! NSRegularExpression(pattern: "\"s:10QuoteTests.*?\"", options: .caseInsensitive)
+  let template = "\"<unstable USR>\""
+  return regex.stringByReplacingMatches(in: s, options: [], range: range, withTemplate: template)
+}

--- a/Tests/QuoteTests/Assertions.swift
+++ b/Tests/QuoteTests/Assertions.swift
@@ -3,32 +3,33 @@ import Quote
 import XCTest
 
 func assertDescription(
-  _ tree: Tree, _ expected: String, file: StaticString = #file, line: UInt = #line
+    _ tree: Tree, _ expected: String, file: StaticString = #file, line: UInt = #line
 ) {
-  XCTAssertEqual(tree.description, expected, file: file, line: line)
+    XCTAssertEqual(tree.description, expected, file: file, line: line)
 }
 
 func assertDescription<T>(
-  _ quote: Quote<T>, _ expected: String, file: StaticString = #file, line: UInt = #line
+    _ quote: Quote<T>, _ expected: String, file: StaticString = #file, line: UInt = #line
 ) {
-  XCTAssertEqual(quote.description, expected, file: file, line: line)
+    XCTAssertEqual(quote.description, expected, file: file, line: line)
 }
 
 func assertStructure(
-  _ tree: Tree, _ expected: String, file: StaticString = #file, line: UInt = #line
+    _ tree: Tree, _ expected: String, file: StaticString = #file, line: UInt = #line
 ) {
-  XCTAssertEqual(stripUnstableUSRs(tree.structure), expected, file: file, line: line)
+    XCTAssertEqual(stripUnstableUSRs(tree.structure), expected, file: file, line: line)
 }
 
 func assertStructure<T>(
-  _ quote: Quote<T>, _ expected: String, file: StaticString = #file, line: UInt = #line
+    _ quote: Quote<T>, _ expected: String, file: StaticString = #file, line: UInt = #line
 ) {
-  XCTAssertEqual(stripUnstableUSRs(quote.structure), expected, file: file, line: line)
+    XCTAssertEqual(stripUnstableUSRs(quote.structure), expected, file: file, line: line)
 }
 
 private func stripUnstableUSRs(_ s: String) -> String {
-  let range = NSRange(location: 0, length: s.count)
-  let regex = try! NSRegularExpression(pattern: "\"s:10QuoteTests.*?\"", options: .caseInsensitive)
-  let template = "\"<unstable USR>\""
-  return regex.stringByReplacingMatches(in: s, options: [], range: range, withTemplate: template)
+    let range = NSRange(location: 0, length: s.count)
+    let regex = try! NSRegularExpression(
+        pattern: "\"s:10QuoteTests.*?\"", options: .caseInsensitive)
+    let template = "\"<unstable USR>\""
+    return regex.stringByReplacingMatches(in: s, options: [], range: range, withTemplate: template)
 }

--- a/Tests/QuoteTests/Declarations.swift
+++ b/Tests/QuoteTests/Declarations.swift
@@ -1,0 +1,65 @@
+import Quote
+
+protocol A {
+}
+
+protocol B {
+}
+
+class Context {
+  public init() {}
+  static let local = Context()
+}
+
+enum E {
+  case a
+}
+
+func f() -> P {
+  fatalError("")
+}
+
+public func g() {
+}
+
+protocol P {
+  func m()
+}
+
+class X: Error {
+}
+
+extension FunctionQuote0 {
+  @discardableResult
+  public func callAsFunction() -> R {
+    fatalError("implement me")
+  }
+}
+
+extension FunctionQuote1 {
+  @discardableResult
+  public func callAsFunction(_ t1: T1) -> R {
+    fatalError("implement me")
+  }
+}
+
+extension FunctionQuote2 {
+  @discardableResult
+  public func callAsFunction(_ t1: T1, _ t2: T2) -> R {
+    fatalError("implement me")
+  }
+}
+
+extension FunctionQuote3 {
+  @discardableResult
+  public func callAsFunction(_ t1: T1, _ t2: T2, _ t3: T3) -> R {
+    fatalError("implement me")
+  }
+}
+
+extension FunctionQuote4 {
+  @discardableResult
+  public func callAsFunction(_ t1: T1, _ t2: T2, _ t3: T3, _ t4: T4) -> R {
+    fatalError("implement me")
+  }
+}

--- a/Tests/QuoteTests/Declarations.swift
+++ b/Tests/QuoteTests/Declarations.swift
@@ -7,59 +7,59 @@ protocol B {
 }
 
 class Context {
-  public init() {}
-  static let local = Context()
+    public init() {}
+    static let local = Context()
 }
 
 enum E {
-  case a
+    case a
 }
 
 func f() -> P {
-  fatalError("")
+    fatalError("")
 }
 
 public func g() {
 }
 
 protocol P {
-  func m()
+    func m()
 }
 
 class X: Error {
 }
 
 extension FunctionQuote0 {
-  @discardableResult
-  public func callAsFunction() -> R {
-    fatalError("implement me")
-  }
+    @discardableResult
+    public func callAsFunction() -> R {
+        fatalError("implement me")
+    }
 }
 
 extension FunctionQuote1 {
-  @discardableResult
-  public func callAsFunction(_ t1: T1) -> R {
-    fatalError("implement me")
-  }
+    @discardableResult
+    public func callAsFunction(_ t1: T1) -> R {
+        fatalError("implement me")
+    }
 }
 
 extension FunctionQuote2 {
-  @discardableResult
-  public func callAsFunction(_ t1: T1, _ t2: T2) -> R {
-    fatalError("implement me")
-  }
+    @discardableResult
+    public func callAsFunction(_ t1: T1, _ t2: T2) -> R {
+        fatalError("implement me")
+    }
 }
 
 extension FunctionQuote3 {
-  @discardableResult
-  public func callAsFunction(_ t1: T1, _ t2: T2, _ t3: T3) -> R {
-    fatalError("implement me")
-  }
+    @discardableResult
+    public func callAsFunction(_ t1: T1, _ t2: T2, _ t3: T3) -> R {
+        fatalError("implement me")
+    }
 }
 
 extension FunctionQuote4 {
-  @discardableResult
-  public func callAsFunction(_ t1: T1, _ t2: T2, _ t3: T3, _ t4: T4) -> R {
-    fatalError("implement me")
-  }
+    @discardableResult
+    public func callAsFunction(_ t1: T1, _ t2: T2, _ t3: T3, _ t4: T4) -> R {
+        fatalError("implement me")
+    }
 }

--- a/Tests/QuoteTests/DescriptionTests.swift
+++ b/Tests/QuoteTests/DescriptionTests.swift
@@ -2,192 +2,194 @@ import Quote
 import XCTest
 
 public final class DescriptionTests: XCTestCase {
-  public func testDifferentiable() {
-    // NOTE: At the moment, this leads to a runtime crash.
-    // let fn: @differentiable (Float) -> Float = { x in x }
-    // blackHole(fn)
-    // let q = #quote(fn)
-    func fn() -> @differentiable (Float) -> Float { fatalError("") }
-    let q = #quote(fn())
-    assertDescription(q.type, "@differentiable (Float) -> Float")
-  }
-
-  public func testAndType() {
-    func f() -> A & B { fatalError("implement me"); }
-    let q = #quote(f())
-    assertDescription(q.type, "A & B")
-  }
-
-  public func testArrayType() {
-    let x = [1, 2, 3]
-    blackHole(x)
-    let q = #quote(x)
-    assertDescription(q.type, "[Int]")
-  }
-
-  public func testDictionaryType() {
-    let x = [40: 2]
-    blackHole(x)
-    let q = #quote(x)
-    assertDescription(q.type, "[Int: Int]")
-  }
-
-  public func testFunctionType() {
-    let x = { (x: Int) in
-      x
+    public func testDifferentiable() {
+        // NOTE: At the moment, this leads to a runtime crash.
+        // let fn: @differentiable (Float) -> Float = { x in x }
+        // blackHole(fn)
+        // let q = #quote(fn)
+        func fn() -> @differentiable (Float) -> Float { fatalError("") }
+        let q = #quote(fn())
+        assertDescription(q.type, "@differentiable (Float) -> Float")
     }
-    blackHole(x)
-    let q = #quote(x)
-    assertDescription(q.type, "(Int) -> Int")
-  }
 
-  public func testInOutType() {
-    let q = #quote{ (x: inout Int) in
-      x
+    public func testAndType() {
+        func f() -> A & B { fatalError("implement me"); }
+        let q = #quote(f())
+        assertDescription(q.type, "A & B")
     }
-    assertDescription(q.type, "(inout Int) -> Int")
-  }
 
-  public func testLValueType() {
-    // TODO(TF-729): Find out how to conveniently test this.
-  }
-
-  public func testMetaType() {
-    let x = Int.self
-    blackHole(x)
-    let q = #quote(x)
-    assertDescription(q.type, "Int.Type")
-  }
-
-  public func testOptionalType() {
-    let x: Int? = 42
-    blackHole(x ?? 42)
-    let q = #quote(x)
-    assertDescription(q.type, "Int?")
-  }
-
-  public func testSpecializedType() {
-    let x: ClosedRange<Int> = 1...10
-    blackHole(x)
-    let q = #quote(x)
-    assertDescription(q.type, "ClosedRange[Int]")
-  }
-
-  public func testTupleType() {
-    let x = (1, "2", 3)
-    blackHole(x)
-    let q = #quote(x)
-    assertDescription(q.type, "(Int, String, Int)")
-  }
-
-  public func testTypeName() {
-    let x = 42
-    blackHole(x)
-    let q = #quote(x)
-    assertDescription(q.type, "Int")
-  }
-
-  public func testBreak() {
-    let q = #quote{
-      while true {
-        break
-      }
+    public func testArrayType() {
+        let x = [1, 2, 3]
+        blackHole(x)
+        let q = #quote(x)
+        assertDescription(q.type, "[Int]")
     }
-    assertDescription(
-      q,
-      """
+
+    public func testDictionaryType() {
+        let x = [40: 2]
+        blackHole(x)
+        let q = #quote(x)
+        assertDescription(q.type, "[Int: Int]")
+    }
+
+    public func testFunctionType() {
+        let x = { (x: Int) in
+            x
+        }
+        blackHole(x)
+        let q = #quote(x)
+        assertDescription(q.type, "(Int) -> Int")
+    }
+
+    public func testInOutType() {
+        let q = #quote{ (x: inout Int) in
+            x
+        }
+        assertDescription(q.type, "(inout Int) -> Int")
+    }
+
+    public func testLValueType() {
+        // TODO(TF-729): Find out how to conveniently test this.
+    }
+
+    public func testMetaType() {
+        let x = Int.self
+        blackHole(x)
+        let q = #quote(x)
+        assertDescription(q.type, "Int.Type")
+    }
+
+    public func testOptionalType() {
+        let x: Int? = 42
+        blackHole(x ?? 42)
+        let q = #quote(x)
+        assertDescription(q.type, "Int?")
+    }
+
+    public func testSpecializedType() {
+        let x: ClosedRange<Int> = 1...10
+        blackHole(x)
+        let q = #quote(x)
+        assertDescription(q.type, "ClosedRange[Int]")
+    }
+
+    public func testTupleType() {
+        let x = (1, "2", 3)
+        blackHole(x)
+        let q = #quote(x)
+        assertDescription(q.type, "(Int, String, Int)")
+    }
+
+    public func testTypeName() {
+        let x = 42
+        blackHole(x)
+        let q = #quote(x)
+        assertDescription(q.type, "Int")
+    }
+
+    public func testBreak() {
+        let q = #quote{
+            while true {
+                break
+            }
+        }
+        assertDescription(
+            q,
+            """
       { () -> () in
         while true {
           break
         }
       }
-      """)
-  }
-
-  public func testContinue() {
-    let q = #quote{
-      while true {
-        continue
-      }
-    }
-    assertDescription(
-      q,
       """
+        )
+    }
+
+    public func testContinue() {
+        let q = #quote{
+            while true {
+                continue
+            }
+        }
+        assertDescription(
+            q,
+            """
       { () -> () in
         while true {
           continue
         }
       }
-      """)
-  }
-
-  public func testDefer() {
-    let q = #quote{
-      defer {}
-      return
-    }
-    assertDescription(
-      q,
       """
+        )
+    }
+
+    public func testDefer() {
+        let q = #quote{
+            defer {}
+            return
+        }
+        assertDescription(
+            q,
+            """
       { () -> () in
         defer {
         }
         return ()
       }
       """)
-  }
-
-  public func testDo() {
-    let q = #quote{
-      do {}
     }
-    assertDescription(
-      q,
-      """
+
+    public func testDo() {
+        let q = #quote{
+            do {}
+        }
+        assertDescription(
+            q,
+            """
       { () -> () in
         do {
         }
       }
       """)
-  }
-
-  public func testFor() {
-    let range = 1...10
-    blackHole(range)
-    let q = #quote{
-      for i in range {}
     }
-    assertDescription(
-      q,
-      """
+
+    public func testFor() {
+        let range = 1...10
+        blackHole(range)
+        let q = #quote{
+            for i in range {}
+        }
+        assertDescription(
+            q,
+            """
       { () -> () in
         for i in range {
         }
       }
       """)
-  }
-
-  public func testGuard() {
-    let q = #quote{
-      guard true else {}
     }
-    assertDescription(
-      q,
-      """
+
+    public func testGuard() {
+        let q = #quote{
+            guard true else {}
+        }
+        assertDescription(
+            q,
+            """
       { () -> () in
         guard true else {
         }
       }
       """)
-  }
-
-  public func testIf() {
-    let q = #quote{
-      if true {} else if false {} else {}
     }
-    assertDescription(
-      q,
-      """
+
+    public func testIf() {
+        let q = #quote{
+            if true {} else if false {} else {}
+        }
+        assertDescription(
+            q,
+            """
       { () -> () in
         if true {
         } else {
@@ -196,441 +198,441 @@ public final class DescriptionTests: XCTestCase {
         }
       }
       """
-    )
-  }
-
-  public func testRepeat() {
-    let q = #quote{
-      repeat {} while true
+        )
     }
-    assertDescription(
-      q,
-      """
+
+    public func testRepeat() {
+        let q = #quote{
+            repeat {} while true
+        }
+        assertDescription(
+            q,
+            """
       { () -> () in
         repeat {
         } while true
       }
       """)
-  }
-
-  public func testReturn() {
-    let q = #quote{ () in
-      return
     }
-    assertDescription(
-      q,
-      """
+
+    public func testReturn() {
+        let q = #quote{ () in
+            return
+        }
+        assertDescription(
+            q,
+            """
       { () -> () in
         return ()
       }
       """)
-  }
-
-  public func testThrow() {
-    let q = #quote{
-      throw X()
     }
-    assertDescription(
-      q,
-      """
+
+    public func testThrow() {
+        let q = #quote{
+            throw X()
+        }
+        assertDescription(
+            q,
+            """
       { () -> () in
         throw X()
       }
       """)
-  }
-
-  public func testWhile() {
-    let q = #quote{
-      while true {}
     }
-    assertDescription(
-      q,
-      """
+
+    public func testWhile() {
+        let q = #quote{
+            while true {}
+        }
+        assertDescription(
+            q,
+            """
       { () -> () in
         while true {
         }
       }
       """)
-  }
-
-  public func testArrayLiteral() {
-    let q = #quote([40, 2])
-    assertDescription(q, "[40, 2]")
-  }
-
-  public func testAs() {
-    let q = #quote(42 as Int)
-    assertDescription(q, "(42 as Int)")
-  }
-
-  public func testAssign() {
-    var x = 0
-    x = 42  // TODO(TF-728): Get rid of this assignment.
-    blackHole(x)
-    let q = #quote(x = 42)
-    assertDescription(q, "x = 42")
-  }
-
-  public func testBinary() {
-    let q = #quote(40 + 2)
-    assertDescription(q, "(40 + 2)")
-  }
-
-  public func testBooleanLiteral() {
-    let q = #quote(true)
-    assertDescription(q, "true")
-  }
-
-  public func testCall1() {
-    let q = #quote(print(42))
-    assertDescription(q, "print(42)")
-  }
-
-  public func testCall2() {
-    let q = #quote(f().m())
-    assertDescription(q, "f().m()")
-  }
-
-  public func testClosure() {
-    let q = #quote{ (x: Int) in
-      x
     }
-    assertDescription(
-      q,
-      """
+
+    public func testArrayLiteral() {
+        let q = #quote([40, 2])
+        assertDescription(q, "[40, 2]")
+    }
+
+    public func testAs() {
+        let q = #quote(42 as Int)
+        assertDescription(q, "(42 as Int)")
+    }
+
+    public func testAssign() {
+        var x = 0
+        x = 42  // TODO(TF-728): Get rid of this assignment.
+        blackHole(x)
+        let q = #quote(x = 42)
+        assertDescription(q, "x = 42")
+    }
+
+    public func testBinary() {
+        let q = #quote(40 + 2)
+        assertDescription(q, "(40 + 2)")
+    }
+
+    public func testBooleanLiteral() {
+        let q = #quote(true)
+        assertDescription(q, "true")
+    }
+
+    public func testCall1() {
+        let q = #quote(print(42))
+        assertDescription(q, "print(42)")
+    }
+
+    public func testCall2() {
+        let q = #quote(f().m())
+        assertDescription(q, "f().m()")
+    }
+
+    public func testClosure() {
+        let q = #quote{ (x: Int) in
+            x
+        }
+        assertDescription(
+            q,
+            """
       { (x: Int) -> Int in
         return x
       }
       """)
-  }
-
-  public func testConversion() {
-    testLValueType()
-  }
-
-  public func testDefault() {
-    testCall1()
-  }
-
-  public func testDictionaryLiteral() {
-    let q = #quote([40: 40, 2: 2])
-    assertDescription(q, "[40: 40, 2: 2]")
-  }
-
-  public func testFloatLiteral() {
-    let q = #quote(42.0)
-    assertDescription(q, "42.0")
-  }
-
-  public func testForce() {
-    let x: Int? = 42
-    blackHole(x ?? 42)
-    let q = #quote(x!)
-    assertDescription(q, "x!")
-  }
-
-  public func testForceAs() {
-    let x: Any = 42
-    blackHole(x)
-    let q = #quote(x as! Int)
-    assertDescription(q, "(x as! Int)")
-  }
-
-  public func testForceTry() {
-    let q = #quote(try! 42)
-    assertDescription(q, "try! 42")
-  }
-
-  public func testInout() {
-    func foo(_ x: inout Int) {}
-    var x = 0
-    blackHole(x)
-    x = 42  // TODO(TF-728): Get rid of this assignment.
-    let q = #quote(foo(&x))
-    assertDescription(q, "foo(&x)")
-  }
-
-  public func testIntegerLiteral() {
-    let q = #quote(42)
-    assertDescription(q, "42")
-  }
-
-  public func testIs() {
-    let x: Any = 42
-    blackHole(x)
-    let q = #quote(x is Int)
-    assertDescription(q, "(x is Int)")
-  }
-
-  public func testMagicLiteral() {
-    let q1 = #quote(#file)
-    assertDescription(q1, "#file")
-    let q2 = #quote(#line)
-    assertDescription(q2, "#line")
-    let q3 = #quote(#column)
-    assertDescription(q3, "#column")
-    let q4 = #quote(#function)
-    assertDescription(q4, "#function")
-    let q5 = #quote(#dsohandle)
-    assertDescription(q5, "#dsohandle")
-  }
-
-  public func testMember1() {
-    let x = [1, 2, 3]
-    blackHole(x)
-    let q = #quote(x.count)
-    assertDescription(q, "x.count")
-  }
-
-  public func testMember2() {
-    let q = #quote(Context.local)
-    assertDescription(q, "local")
-  }
-
-  public func testMember3() {
-    let q = #quote(E.a)
-    assertDescription(q, "a")
-  }
-
-  public func testMember4() {
-    let q = #quote(g())
-    assertDescription(q, "g()")
-  }
-
-  public func testMeta() {
-    let q = #quote(#quote(42))
-    assertDescription(q, "#quote(42)")
-  }
-
-  public func testName() {
-    let x = 42
-    blackHole(x)
-    let q = #quote(x)
-    assertDescription(q, "x")
-  }
-
-  public func testNilLiteral() {
-    let q = #quote(nil as Int?)
-    assertDescription(q, "(nil as Int?)")
-  }
-
-  public func testOptionalAs() {
-    let x: Any = 42
-    blackHole(x)
-    let q = #quote(x as? Int)
-    assertDescription(q, "(x as? Int)")
-  }
-
-  public func testOptionalTry() {
-    let q = #quote(try? 42)
-    assertDescription(q, "try? 42")
-  }
-
-  public func testPostfix() {
-    // TODO(TF-729): Find out how to conveniently test this.
-  }
-
-  public func testPostfixSelf1() {
-    let q = #quote(42.self)
-    assertDescription(q, "42.self")
-  }
-
-  public func testPostfixSelf2() {
-    let q = #quote(Int.self)
-    assertDescription(q, "Int.self")
-  }
-
-  public func testPrefix() {
-    let q = #quote(+42)
-    assertDescription(q, "(+42)")
-  }
-
-  public func testStringInterpolation() {
-    let x = 42
-    blackHole(x)
-    let q = #quote("x = \(x)")
-    assertDescription(q, "\"...\"")
-  }
-
-  public func testStringLiteral() {
-    let q = #quote("42")
-    assertDescription(q, "\"42\"")
-  }
-
-  public func testSubscript() {
-    let x = [1, 2, 3]
-    blackHole(x)
-    let q = #quote(x[0])
-    assertDescription(q, "x[0]")
-  }
-
-  public func testSuper() {
-    class C {
-      func p() {}
     }
-    class D: C {
-      func q() {
-        let q = #quote(super.p())
-        assertDescription(q, "super.p()")
-      }
+
+    public func testConversion() {
+        testLValueType()
     }
-    D().q()
-  }
 
-  public func testTernary() {
-    let q = #quote(true ? 40 : 2)
-    assertDescription(q, "(true ? 40 : 2)")
-  }
+    public func testDefault() {
+        testCall1()
+    }
 
-  public func testTry() {
-    let q = #quote(try 42)
-    assertDescription(q, "try 42")
-  }
+    public func testDictionaryLiteral() {
+        let q = #quote([40: 40, 2: 2])
+        assertDescription(q, "[40: 40, 2: 2]")
+    }
 
-  public func testTuple() {
-    let q = #quote((1, "2", 3))
-    assertDescription(q, "(1, \"2\", 3)")
-  }
+    public func testFloatLiteral() {
+        let q = #quote(42.0)
+        assertDescription(q, "42.0")
+    }
 
-  public func testTupleElement() {
-    let q = #quote((1, 2).1)
-    assertDescription(q, "(1, 2).1")
-  }
+    public func testForce() {
+        let x: Int? = 42
+        blackHole(x ?? 42)
+        let q = #quote(x!)
+        assertDescription(q, "x!")
+    }
 
-  public func testUnquote() {
-    let x = #quote(40)
-    let q = #quote(#unquote(x)+2)
-    assertDescription(q, "(#unquote(x) + 2)")
-  }
+    public func testForceAs() {
+        let x: Any = 42
+        blackHole(x)
+        let q = #quote(x as! Int)
+        assertDescription(q, "(x as! Int)")
+    }
 
-  public func testVarargs() {
-    testCall1()
-  }
+    public func testForceTry() {
+        let q = #quote(try! 42)
+        assertDescription(q, "try! 42")
+    }
 
-  public func testWildcard() {
-    let q = #quote(_ = 42)
-    assertDescription(q, "_ = 42")
-  }
+    public func testInout() {
+        func foo(_ x: inout Int) {}
+        var x = 0
+        blackHole(x)
+        x = 42  // TODO(TF-728): Get rid of this assignment.
+        let q = #quote(foo(&x))
+        assertDescription(q, "foo(&x)")
+    }
 
-  public func testFunction() {
-    // TODO(TF-724): Find out how to conveniently test this.
-  }
+    public func testIntegerLiteral() {
+        let q = #quote(42)
+        assertDescription(q, "42")
+    }
 
-  public func testLet() {
-    let q = #quote{ let x = 42 }
-    assertDescription(
-      q,
-      """
+    public func testIs() {
+        let x: Any = 42
+        blackHole(x)
+        let q = #quote(x is Int)
+        assertDescription(q, "(x is Int)")
+    }
+
+    public func testMagicLiteral() {
+        let q1 = #quote(#file)
+        assertDescription(q1, "#file")
+        let q2 = #quote(#line)
+        assertDescription(q2, "#line")
+        let q3 = #quote(#column)
+        assertDescription(q3, "#column")
+        let q4 = #quote(#function)
+        assertDescription(q4, "#function")
+        let q5 = #quote(#dsohandle)
+        assertDescription(q5, "#dsohandle")
+    }
+
+    public func testMember1() {
+        let x = [1, 2, 3]
+        blackHole(x)
+        let q = #quote(x.count)
+        assertDescription(q, "x.count")
+    }
+
+    public func testMember2() {
+        let q = #quote(Context.local)
+        assertDescription(q, "local")
+    }
+
+    public func testMember3() {
+        let q = #quote(E.a)
+        assertDescription(q, "a")
+    }
+
+    public func testMember4() {
+        let q = #quote(g())
+        assertDescription(q, "g()")
+    }
+
+    public func testMeta() {
+        let q = #quote(#quote(42))
+        assertDescription(q, "#quote(42)")
+    }
+
+    public func testName() {
+        let x = 42
+        blackHole(x)
+        let q = #quote(x)
+        assertDescription(q, "x")
+    }
+
+    public func testNilLiteral() {
+        let q = #quote(nil as Int?)
+        assertDescription(q, "(nil as Int?)")
+    }
+
+    public func testOptionalAs() {
+        let x: Any = 42
+        blackHole(x)
+        let q = #quote(x as? Int)
+        assertDescription(q, "(x as? Int)")
+    }
+
+    public func testOptionalTry() {
+        let q = #quote(try? 42)
+        assertDescription(q, "try? 42")
+    }
+
+    public func testPostfix() {
+        // TODO(TF-729): Find out how to conveniently test this.
+    }
+
+    public func testPostfixSelf1() {
+        let q = #quote(42.self)
+        assertDescription(q, "42.self")
+    }
+
+    public func testPostfixSelf2() {
+        let q = #quote(Int.self)
+        assertDescription(q, "Int.self")
+    }
+
+    public func testPrefix() {
+        let q = #quote(+42)
+        assertDescription(q, "(+42)")
+    }
+
+    public func testStringInterpolation() {
+        let x = 42
+        blackHole(x)
+        let q = #quote("x = \(x)")
+        assertDescription(q, "\"...\"")
+    }
+
+    public func testStringLiteral() {
+        let q = #quote("42")
+        assertDescription(q, "\"42\"")
+    }
+
+    public func testSubscript() {
+        let x = [1, 2, 3]
+        blackHole(x)
+        let q = #quote(x[0])
+        assertDescription(q, "x[0]")
+    }
+
+    public func testSuper() {
+        class C {
+            func p() {}
+        }
+        class D: C {
+            func q() {
+                let q = #quote(super.p())
+                assertDescription(q, "super.p()")
+            }
+        }
+        D().q()
+    }
+
+    public func testTernary() {
+        let q = #quote(true ? 40 : 2)
+        assertDescription(q, "(true ? 40 : 2)")
+    }
+
+    public func testTry() {
+        let q = #quote(try 42)
+        assertDescription(q, "try 42")
+    }
+
+    public func testTuple() {
+        let q = #quote((1, "2", 3))
+        assertDescription(q, "(1, \"2\", 3)")
+    }
+
+    public func testTupleElement() {
+        let q = #quote((1, 2).1)
+        assertDescription(q, "(1, 2).1")
+    }
+
+    public func testUnquote() {
+        let x = #quote(40)
+        let q = #quote(#unquote(x)+2)
+        assertDescription(q, "(#unquote(x) + 2)")
+    }
+
+    public func testVarargs() {
+        testCall1()
+    }
+
+    public func testWildcard() {
+        let q = #quote(_ = 42)
+        assertDescription(q, "_ = 42")
+    }
+
+    public func testFunction() {
+        // TODO(TF-724): Find out how to conveniently test this.
+    }
+
+    public func testLet() {
+        let q = #quote{ let x = 42 }
+        assertDescription(
+            q,
+            """
       { () -> () in
         let x: Int = 42
       }
       """)
-  }
+    }
 
-  public func testParameter() {
-    testClosure()
-  }
+    public func testParameter() {
+        testClosure()
+    }
 
-  public func testVar() {
-    let q = #quote{ var x = 42 }
-    assertDescription(
-      q,
-      """
+    public func testVar() {
+        let q = #quote{ var x = 42 }
+        assertDescription(
+            q,
+            """
       { () -> () in
         var x: Int = 42
       }
       """)
-  }
+    }
 
-  public func test29() {
-    let q = #quote(1...10)
-    assertDescription(q, "(1 ... 10)")
-  }
+    public func test29() {
+        let q = #quote(1...10)
+        assertDescription(q, "(1 ... 10)")
+    }
 
-  public func test30() {
-    let x = 42
-    blackHole(x)
-    let q = #quote(Float(x))
-    assertDescription(q, "Float(x)")
-  }
+    public func test30() {
+        let x = 42
+        blackHole(x)
+        let q = #quote(Float(x))
+        assertDescription(q, "Float(x)")
+    }
 
-  private func blackHole(_ x: Any) {
-    // This method exists to silence unused variable warnings.
-    // TODO(TF-728): Get rid of this method.
-  }
+    private func blackHole(_ x: Any) {
+        // This method exists to silence unused variable warnings.
+        // TODO(TF-728): Get rid of this method.
+    }
 
-  public static let allTests = [
-    ("testDifferentiable", testDifferentiable),
-    ("testAndType", testAndType),
-    ("testArrayType", testArrayType),
-    ("testDictionaryType", testDictionaryType),
-    ("testFunctionType", testFunctionType),
-    ("testInOutType", testInOutType),
-    ("testLValueType", testLValueType),
-    ("testMetaType", testMetaType),
-    ("testOptionalType", testOptionalType),
-    ("testSpecializedType", testSpecializedType),
-    ("testTupleType", testTupleType),
-    ("testTypeName", testTypeName),
-    ("testBreak", testBreak),
-    ("testContinue", testContinue),
-    ("testDefer", testDefer),
-    ("testDo", testDo),
-    ("testFor", testFor),
-    ("testGuard", testGuard),
-    ("testIf", testIf),
-    ("testRepeat", testRepeat),
-    ("testReturn", testReturn),
-    ("testThrow", testThrow),
-    ("testWhile", testWhile),
-    ("testArrayLiteral", testArrayLiteral),
-    ("testAs", testAs),
-    ("testAssign", testAssign),
-    ("testBinary", testBinary),
-    ("testBooleanLiteral", testBooleanLiteral),
-    ("testCall1", testCall1),
-    ("testCall2", testCall2),
-    ("testClosure", testClosure),
-    ("testConversion", testConversion),
-    ("testDefault", testDefault),
-    ("testDictionaryLiteral", testDictionaryLiteral),
-    ("testFloatLiteral", testFloatLiteral),
-    ("testForce", testForce),
-    ("testForceAs", testForceAs),
-    ("testForceTry", testForceTry),
-    ("testInout", testInout),
-    ("testIntegerLiteral", testIntegerLiteral),
-    ("testIs", testIs),
-    ("testMagicLiteral", testMagicLiteral),
-    ("testMember1", testMember1),
-    ("testMember2", testMember2),
-    ("testMember3", testMember3),
-    ("testMember4", testMember4),
-    ("testMeta", testMeta),
-    ("testName", testName),
-    ("testNilLiteral", testNilLiteral),
-    ("testOptionalAs", testOptionalAs),
-    ("testOptionalTry", testOptionalTry),
-    ("testPostfix", testPostfix),
-    ("testPostfixSelf1", testPostfixSelf1),
-    ("testPostfixSelf2", testPostfixSelf2),
-    ("testPrefix", testPrefix),
-    ("testStringInterpolation", testStringInterpolation),
-    ("testStringLiteral", testStringLiteral),
-    ("testSubscript", testSubscript),
-    ("testSuper", testSuper),
-    ("testTernary", testTernary),
-    ("testTry", testTry),
-    ("testTuple", testTuple),
-    ("testTupleElement", testTupleElement),
-    ("testUnquote", testUnquote),
-    ("testVarargs", testVarargs),
-    ("testWildcard", testWildcard),
-    ("testFunction", testFunction),
-    ("testLet", testLet),
-    ("testParameter", testParameter),
-    ("testVar", testVar),
-    ("test29", test29),
-    ("test30", test30),
-  ]
+    public static let allTests = [
+        ("testDifferentiable", testDifferentiable),
+        ("testAndType", testAndType),
+        ("testArrayType", testArrayType),
+        ("testDictionaryType", testDictionaryType),
+        ("testFunctionType", testFunctionType),
+        ("testInOutType", testInOutType),
+        ("testLValueType", testLValueType),
+        ("testMetaType", testMetaType),
+        ("testOptionalType", testOptionalType),
+        ("testSpecializedType", testSpecializedType),
+        ("testTupleType", testTupleType),
+        ("testTypeName", testTypeName),
+        ("testBreak", testBreak),
+        ("testContinue", testContinue),
+        ("testDefer", testDefer),
+        ("testDo", testDo),
+        ("testFor", testFor),
+        ("testGuard", testGuard),
+        ("testIf", testIf),
+        ("testRepeat", testRepeat),
+        ("testReturn", testReturn),
+        ("testThrow", testThrow),
+        ("testWhile", testWhile),
+        ("testArrayLiteral", testArrayLiteral),
+        ("testAs", testAs),
+        ("testAssign", testAssign),
+        ("testBinary", testBinary),
+        ("testBooleanLiteral", testBooleanLiteral),
+        ("testCall1", testCall1),
+        ("testCall2", testCall2),
+        ("testClosure", testClosure),
+        ("testConversion", testConversion),
+        ("testDefault", testDefault),
+        ("testDictionaryLiteral", testDictionaryLiteral),
+        ("testFloatLiteral", testFloatLiteral),
+        ("testForce", testForce),
+        ("testForceAs", testForceAs),
+        ("testForceTry", testForceTry),
+        ("testInout", testInout),
+        ("testIntegerLiteral", testIntegerLiteral),
+        ("testIs", testIs),
+        ("testMagicLiteral", testMagicLiteral),
+        ("testMember1", testMember1),
+        ("testMember2", testMember2),
+        ("testMember3", testMember3),
+        ("testMember4", testMember4),
+        ("testMeta", testMeta),
+        ("testName", testName),
+        ("testNilLiteral", testNilLiteral),
+        ("testOptionalAs", testOptionalAs),
+        ("testOptionalTry", testOptionalTry),
+        ("testPostfix", testPostfix),
+        ("testPostfixSelf1", testPostfixSelf1),
+        ("testPostfixSelf2", testPostfixSelf2),
+        ("testPrefix", testPrefix),
+        ("testStringInterpolation", testStringInterpolation),
+        ("testStringLiteral", testStringLiteral),
+        ("testSubscript", testSubscript),
+        ("testSuper", testSuper),
+        ("testTernary", testTernary),
+        ("testTry", testTry),
+        ("testTuple", testTuple),
+        ("testTupleElement", testTupleElement),
+        ("testUnquote", testUnquote),
+        ("testVarargs", testVarargs),
+        ("testWildcard", testWildcard),
+        ("testFunction", testFunction),
+        ("testLet", testLet),
+        ("testParameter", testParameter),
+        ("testVar", testVar),
+        ("test29", test29),
+        ("test30", test30),
+    ]
 }

--- a/Tests/QuoteTests/DescriptionTests.swift
+++ b/Tests/QuoteTests/DescriptionTests.swift
@@ -1,0 +1,636 @@
+import Quote
+import XCTest
+
+public final class DescriptionTests: XCTestCase {
+  public func testDifferentiable() {
+    // NOTE: At the moment, this leads to a runtime crash.
+    // let fn: @differentiable (Float) -> Float = { x in x }
+    // blackHole(fn)
+    // let q = #quote(fn)
+    func fn() -> @differentiable (Float) -> Float { fatalError("") }
+    let q = #quote(fn())
+    assertDescription(q.type, "@differentiable (Float) -> Float")
+  }
+
+  public func testAndType() {
+    func f() -> A & B { fatalError("implement me"); }
+    let q = #quote(f())
+    assertDescription(q.type, "A & B")
+  }
+
+  public func testArrayType() {
+    let x = [1, 2, 3]
+    blackHole(x)
+    let q = #quote(x)
+    assertDescription(q.type, "[Int]")
+  }
+
+  public func testDictionaryType() {
+    let x = [40: 2]
+    blackHole(x)
+    let q = #quote(x)
+    assertDescription(q.type, "[Int: Int]")
+  }
+
+  public func testFunctionType() {
+    let x = { (x: Int) in
+      x
+    }
+    blackHole(x)
+    let q = #quote(x)
+    assertDescription(q.type, "(Int) -> Int")
+  }
+
+  public func testInOutType() {
+    let q = #quote{ (x: inout Int) in
+      x
+    }
+    assertDescription(q.type, "(inout Int) -> Int")
+  }
+
+  public func testLValueType() {
+    // TODO(#3): Find out how to conveniently test this.
+  }
+
+  public func testMetaType() {
+    let x = Int.self
+    blackHole(x)
+    let q = #quote(x)
+    assertDescription(q.type, "Int.Type")
+  }
+
+  public func testOptionalType() {
+    let x: Int? = 42
+    blackHole(x ?? 42)
+    let q = #quote(x)
+    assertDescription(q.type, "Int?")
+  }
+
+  public func testSpecializedType() {
+    let x: ClosedRange<Int> = 1...10
+    blackHole(x)
+    let q = #quote(x)
+    assertDescription(q.type, "ClosedRange[Int]")
+  }
+
+  public func testTupleType() {
+    let x = (1, "2", 3)
+    blackHole(x)
+    let q = #quote(x)
+    assertDescription(q.type, "(Int, String, Int)")
+  }
+
+  public func testTypeName() {
+    let x = 42
+    blackHole(x)
+    let q = #quote(x)
+    assertDescription(q.type, "Int")
+  }
+
+  public func testBreak() {
+    let q = #quote{
+      while true {
+        break
+      }
+    }
+    assertDescription(
+      q,
+      """
+      { () -> () in
+        while true {
+          break
+        }
+      }
+      """)
+  }
+
+  public func testContinue() {
+    let q = #quote{
+      while true {
+        continue
+      }
+    }
+    assertDescription(
+      q,
+      """
+      { () -> () in
+        while true {
+          continue
+        }
+      }
+      """)
+  }
+
+  public func testDefer() {
+    let q = #quote{
+      defer {}
+      return
+    }
+    assertDescription(
+      q,
+      """
+      { () -> () in
+        defer {
+        }
+        return ()
+      }
+      """)
+  }
+
+  public func testDo() {
+    let q = #quote{
+      do {}
+    }
+    assertDescription(
+      q,
+      """
+      { () -> () in
+        do {
+        }
+      }
+      """)
+  }
+
+  public func testFor() {
+    let range = 1...10
+    blackHole(range)
+    let q = #quote{
+      for i in range {}
+    }
+    assertDescription(
+      q,
+      """
+      { () -> () in
+        for i in range {
+        }
+      }
+      """)
+  }
+
+  public func testGuard() {
+    let q = #quote{
+      guard true else {}
+    }
+    assertDescription(
+      q,
+      """
+      { () -> () in
+        guard true else {
+        }
+      }
+      """)
+  }
+
+  public func testIf() {
+    let q = #quote{
+      if true {} else if false {} else {}
+    }
+    assertDescription(
+      q,
+      """
+      { () -> () in
+        if true {
+        } else {
+          if false {
+          }
+        }
+      }
+      """
+    )
+  }
+
+  public func testRepeat() {
+    let q = #quote{
+      repeat {} while true
+    }
+    assertDescription(
+      q,
+      """
+      { () -> () in
+        repeat {
+        } while true
+      }
+      """)
+  }
+
+  public func testReturn() {
+    let q = #quote{ () in
+      return
+    }
+    assertDescription(
+      q,
+      """
+      { () -> () in
+        return ()
+      }
+      """)
+  }
+
+  public func testThrow() {
+    let q = #quote{
+      throw X()
+    }
+    assertDescription(
+      q,
+      """
+      { () -> () in
+        throw X()
+      }
+      """)
+  }
+
+  public func testWhile() {
+    let q = #quote{
+      while true {}
+    }
+    assertDescription(
+      q,
+      """
+      { () -> () in
+        while true {
+        }
+      }
+      """)
+  }
+
+  public func testArrayLiteral() {
+    let q = #quote([40, 2])
+    assertDescription(q, "[40, 2]")
+  }
+
+  public func testAs() {
+    let q = #quote(42 as Int)
+    assertDescription(q, "(42 as Int)")
+  }
+
+  public func testAssign() {
+    var x = 0
+    x = 42  // TODO(#4): Get rid of this assignment.
+    blackHole(x)
+    let q = #quote(x = 42)
+    assertDescription(q, "x = 42")
+  }
+
+  public func testBinary() {
+    let q = #quote(40 + 2)
+    assertDescription(q, "(40 + 2)")
+  }
+
+  public func testBooleanLiteral() {
+    let q = #quote(true)
+    assertDescription(q, "true")
+  }
+
+  public func testCall1() {
+    let q = #quote(print(42))
+    assertDescription(q, "print(42)")
+  }
+
+  public func testCall2() {
+    let q = #quote(f().m())
+    assertDescription(q, "f().m()")
+  }
+
+  public func testClosure() {
+    let q = #quote{ (x: Int) in
+      x
+    }
+    assertDescription(
+      q,
+      """
+      { (x: Int) -> Int in
+        return x
+      }
+      """)
+  }
+
+  public func testConversion() {
+    testLValueType()
+  }
+
+  public func testDefault() {
+    testCall1()
+  }
+
+  public func testDictionaryLiteral() {
+    let q = #quote([40: 40, 2: 2])
+    assertDescription(q, "[40: 40, 2: 2]")
+  }
+
+  public func testFloatLiteral() {
+    let q = #quote(42.0)
+    assertDescription(q, "42.0")
+  }
+
+  public func testForce() {
+    let x: Int? = 42
+    blackHole(x ?? 42)
+    let q = #quote(x!)
+    assertDescription(q, "x!")
+  }
+
+  public func testForceAs() {
+    let x: Any = 42
+    blackHole(x)
+    let q = #quote(x as! Int)
+    assertDescription(q, "(x as! Int)")
+  }
+
+  public func testForceTry() {
+    let q = #quote(try! 42)
+    assertDescription(q, "try! 42")
+  }
+
+  public func testInout() {
+    func foo(_ x: inout Int) {}
+    var x = 0
+    blackHole(x)
+    x = 42  // TODO(#4): Get rid of this assignment.
+    let q = #quote(foo(&x))
+    assertDescription(q, "foo(&x)")
+  }
+
+  public func testIntegerLiteral() {
+    let q = #quote(42)
+    assertDescription(q, "42")
+  }
+
+  public func testIs() {
+    let x: Any = 42
+    blackHole(x)
+    let q = #quote(x is Int)
+    assertDescription(q, "(x is Int)")
+  }
+
+  public func testMagicLiteral() {
+    let q1 = #quote(#file)
+    assertDescription(q1, "#file")
+    let q2 = #quote(#line)
+    assertDescription(q2, "#line")
+    let q3 = #quote(#column)
+    assertDescription(q3, "#column")
+    let q4 = #quote(#function)
+    assertDescription(q4, "#function")
+    let q5 = #quote(#dsohandle)
+    assertDescription(q5, "#dsohandle")
+  }
+
+  public func testMember1() {
+    let x = [1, 2, 3]
+    blackHole(x)
+    let q = #quote(x.count)
+    assertDescription(q, "x.count")
+  }
+
+  public func testMember2() {
+    let q = #quote(Context.local)
+    assertDescription(q, "local")
+  }
+
+  public func testMember3() {
+    let q = #quote(E.a)
+    assertDescription(q, "a")
+  }
+
+  public func testMember4() {
+    let q = #quote(g())
+    assertDescription(q, "g()")
+  }
+
+  public func testMeta() {
+    let q = #quote(#quote(42))
+    assertDescription(q, "#quote(42)")
+  }
+
+  public func testName() {
+    let x = 42
+    blackHole(x)
+    let q = #quote(x)
+    assertDescription(q, "x")
+  }
+
+  public func testNilLiteral() {
+    let q = #quote(nil as Int?)
+    assertDescription(q, "(nil as Int?)")
+  }
+
+  public func testOptionalAs() {
+    let x: Any = 42
+    blackHole(x)
+    let q = #quote(x as? Int)
+    assertDescription(q, "(x as? Int)")
+  }
+
+  public func testOptionalTry() {
+    let q = #quote(try? 42)
+    assertDescription(q, "try? 42")
+  }
+
+  public func testPostfix() {
+    // TODO(#3): Find out how to conveniently test this.
+  }
+
+  public func testPostfixSelf1() {
+    let q = #quote(42.self)
+    assertDescription(q, "42.self")
+  }
+
+  public func testPostfixSelf2() {
+    let q = #quote(Int.self)
+    assertDescription(q, "Int.self")
+  }
+
+  public func testPrefix() {
+    let q = #quote(+42)
+    assertDescription(q, "(+42)")
+  }
+
+  public func testStringInterpolation() {
+    let x = 42
+    blackHole(x)
+    let q = #quote("x = \(x)")
+    assertDescription(q, "\"...\"")
+  }
+
+  public func testStringLiteral() {
+    let q = #quote("42")
+    assertDescription(q, "\"42\"")
+  }
+
+  public func testSubscript() {
+    let x = [1, 2, 3]
+    blackHole(x)
+    let q = #quote(x[0])
+    assertDescription(q, "x[0]")
+  }
+
+  public func testSuper() {
+    class C {
+      func p() {}
+    }
+    class D: C {
+      func q() {
+        let q = #quote(super.p())
+        assertDescription(q, "super.p()")
+      }
+    }
+    D().q()
+  }
+
+  public func testTernary() {
+    let q = #quote(true ? 40 : 2)
+    assertDescription(q, "(true ? 40 : 2)")
+  }
+
+  public func testTry() {
+    let q = #quote(try 42)
+    assertDescription(q, "try 42")
+  }
+
+  public func testTuple() {
+    let q = #quote((1, "2", 3))
+    assertDescription(q, "(1, \"2\", 3)")
+  }
+
+  public func testTupleElement() {
+    let q = #quote((1, 2).1)
+    assertDescription(q, "(1, 2).1")
+  }
+
+  public func testUnquote() {
+    let x = #quote(40)
+    let q = #quote(#unquote(x)+2)
+    assertDescription(q, "(#unquote(x) + 2)")
+  }
+
+  public func testVarargs() {
+    testCall1()
+  }
+
+  public func testWildcard() {
+    let q = #quote(_ = 42)
+    assertDescription(q, "_ = 42")
+  }
+
+  public func testFunction() {
+    // TODO(#5): Find out how to conveniently test this.
+  }
+
+  public func testLet() {
+    let q = #quote{ let x = 42 }
+    assertDescription(
+      q,
+      """
+      { () -> () in
+        let x: Int = 42
+      }
+      """)
+  }
+
+  public func testParameter() {
+    testClosure()
+  }
+
+  public func testVar() {
+    let q = #quote{ var x = 42 }
+    assertDescription(
+      q,
+      """
+      { () -> () in
+        var x: Int = 42
+      }
+      """)
+  }
+
+  public func test29() {
+    let q = #quote(1...10)
+    assertDescription(q, "(1 ... 10)")
+  }
+
+  public func test30() {
+    let x = 42
+    blackHole(x)
+    let q = #quote(Float(x))
+    assertDescription(q, "Float(x)")
+  }
+
+  private func blackHole(_ x: Any) {
+    // This method exists to silence unused variable warnings.
+    // TODO(#4): Get rid of this method.
+  }
+
+  public static let allTests = [
+    ("testDifferentiable", testDifferentiable),
+    ("testAndType", testAndType),
+    ("testArrayType", testArrayType),
+    ("testDictionaryType", testDictionaryType),
+    ("testFunctionType", testFunctionType),
+    ("testInOutType", testInOutType),
+    ("testLValueType", testLValueType),
+    ("testMetaType", testMetaType),
+    ("testOptionalType", testOptionalType),
+    ("testSpecializedType", testSpecializedType),
+    ("testTupleType", testTupleType),
+    ("testTypeName", testTypeName),
+    ("testBreak", testBreak),
+    ("testContinue", testContinue),
+    ("testDefer", testDefer),
+    ("testDo", testDo),
+    ("testFor", testFor),
+    ("testGuard", testGuard),
+    ("testIf", testIf),
+    ("testRepeat", testRepeat),
+    ("testReturn", testReturn),
+    ("testThrow", testThrow),
+    ("testWhile", testWhile),
+    ("testArrayLiteral", testArrayLiteral),
+    ("testAs", testAs),
+    ("testAssign", testAssign),
+    ("testBinary", testBinary),
+    ("testBooleanLiteral", testBooleanLiteral),
+    ("testCall1", testCall1),
+    ("testCall2", testCall2),
+    ("testClosure", testClosure),
+    ("testConversion", testConversion),
+    ("testDefault", testDefault),
+    ("testDictionaryLiteral", testDictionaryLiteral),
+    ("testFloatLiteral", testFloatLiteral),
+    ("testForce", testForce),
+    ("testForceAs", testForceAs),
+    ("testForceTry", testForceTry),
+    ("testInout", testInout),
+    ("testIntegerLiteral", testIntegerLiteral),
+    ("testIs", testIs),
+    ("testMagicLiteral", testMagicLiteral),
+    ("testMember1", testMember1),
+    ("testMember2", testMember2),
+    ("testMember3", testMember3),
+    ("testMember4", testMember4),
+    ("testMeta", testMeta),
+    ("testName", testName),
+    ("testNilLiteral", testNilLiteral),
+    ("testOptionalAs", testOptionalAs),
+    ("testOptionalTry", testOptionalTry),
+    ("testPostfix", testPostfix),
+    ("testPostfixSelf1", testPostfixSelf1),
+    ("testPostfixSelf2", testPostfixSelf2),
+    ("testPrefix", testPrefix),
+    ("testStringInterpolation", testStringInterpolation),
+    ("testStringLiteral", testStringLiteral),
+    ("testSubscript", testSubscript),
+    ("testSuper", testSuper),
+    ("testTernary", testTernary),
+    ("testTry", testTry),
+    ("testTuple", testTuple),
+    ("testTupleElement", testTupleElement),
+    ("testUnquote", testUnquote),
+    ("testVarargs", testVarargs),
+    ("testWildcard", testWildcard),
+    ("testFunction", testFunction),
+    ("testLet", testLet),
+    ("testParameter", testParameter),
+    ("testVar", testVar),
+    ("test29", test29),
+    ("test30", test30),
+  ]
+}

--- a/Tests/QuoteTests/DescriptionTests.swift
+++ b/Tests/QuoteTests/DescriptionTests.swift
@@ -49,7 +49,7 @@ public final class DescriptionTests: XCTestCase {
   }
 
   public func testLValueType() {
-    // TODO(#3): Find out how to conveniently test this.
+    // TODO(TF-729): Find out how to conveniently test this.
   }
 
   public func testMetaType() {
@@ -265,7 +265,7 @@ public final class DescriptionTests: XCTestCase {
 
   public func testAssign() {
     var x = 0
-    x = 42  // TODO(#4): Get rid of this assignment.
+    x = 42  // TODO(TF-728): Get rid of this assignment.
     blackHole(x)
     let q = #quote(x = 42)
     assertDescription(q, "x = 42")
@@ -345,7 +345,7 @@ public final class DescriptionTests: XCTestCase {
     func foo(_ x: inout Int) {}
     var x = 0
     blackHole(x)
-    x = 42  // TODO(#4): Get rid of this assignment.
+    x = 42  // TODO(TF-728): Get rid of this assignment.
     let q = #quote(foo(&x))
     assertDescription(q, "foo(&x)")
   }
@@ -427,7 +427,7 @@ public final class DescriptionTests: XCTestCase {
   }
 
   public func testPostfix() {
-    // TODO(#3): Find out how to conveniently test this.
+    // TODO(TF-729): Find out how to conveniently test this.
   }
 
   public func testPostfixSelf1() {
@@ -513,7 +513,7 @@ public final class DescriptionTests: XCTestCase {
   }
 
   public func testFunction() {
-    // TODO(#5): Find out how to conveniently test this.
+    // TODO(TF-724): Find out how to conveniently test this.
   }
 
   public func testLet() {
@@ -556,7 +556,7 @@ public final class DescriptionTests: XCTestCase {
 
   private func blackHole(_ x: Any) {
     // This method exists to silence unused variable warnings.
-    // TODO(#4): Get rid of this method.
+    // TODO(TF-728): Get rid of this method.
   }
 
   public static let allTests = [

--- a/Tests/QuoteTests/QuoteTests.swift
+++ b/Tests/QuoteTests/QuoteTests.swift
@@ -1,0 +1,341 @@
+import Quote
+import XCTest
+
+@quoted
+func foo(_ x: Float) -> Float {
+  return 1 * x
+}
+
+class Bar {
+  @quoted
+  func instanceBar(_ x: Float) -> Float {
+    return 2 * x
+  }
+
+  @quoted
+  func staticBar(_ x: Float) -> Float {
+    return 3 * x
+  }
+}
+
+// NOTE: This is a test of whether this thing successfully compiles.
+@quoted
+func noReturnType() {
+}
+
+public final class QuoteTests: XCTestCase {
+  public func testClosureWithExpr() {
+    let q = #quote{ (x: Int, y: Int) in
+      x + y
+    }
+    let _ = { q(40, 2) }
+    assertDescription(
+      q,
+      """
+      { (x: Int, y: Int) -> Int in
+        return (x + y)
+      }
+      """)
+    assertDescription(q.type, "(Int, Int) -> Int")
+  }
+
+  public func testClosureWithStmts() {
+    let q = #quote{
+      let n = 42;
+      print(n)
+    }
+    let _ = { q() }
+    assertDescription(
+      q,
+      """
+      { () -> () in
+        let n: Int = 42
+        print(n)
+      }
+      """)
+    assertDescription(q.type, "() -> ()")
+  }
+
+  public func testUnquoteManual() {
+    let u = #quote{ (x: Int, y: Int) in
+      x + y
+    }
+    let _ = { u(40, 2) }
+    let q = #quote{ (x: Int) in
+      #unquote(u)(x, x)
+    }
+    let _ = { q(42) }
+    assertDescription(
+      q,
+      """
+      { (x: Int) -> Int in
+        return #unquote(u)(x, x)
+      }
+      """)
+    assertDescription(q.type, "(Int) -> Int")
+  }
+
+  public func testUnquoteAutomatic() {
+    let t1 = _quotedFoo()
+    assertStructure(
+      t1,
+      """
+      Function(
+        Name(
+          "foo",
+          "<unstable USR>",
+          FunctionType(
+            [],
+            [TypeName("Float", "s:Sf")],
+            TypeName("Float", "s:Sf"))),
+        [Parameter(
+          nil,
+          Name(
+            "x",
+            "<unstable USR>",
+            TypeName("Float", "s:Sf")))],
+        [Return(
+          Binary(
+            IntegerLiteral(
+              1,
+              TypeName("Float", "s:Sf")),
+            Name(
+              "*",
+              "s:Sf1moiyS2f_SftFZ",
+              FunctionType(
+                [],
+                [TypeName("Float", "s:Sf"),
+                TypeName("Float", "s:Sf")],
+                TypeName("Float", "s:Sf"))),
+            Name(
+              "x",
+              "<unstable USR>",
+              TypeName("Float", "s:Sf")),
+            TypeName("Float", "s:Sf")))])
+      """
+    )
+
+    let q1 = #quote(foo)
+    assertStructure(
+      q1,
+      """
+      Unquote(
+        Name(
+          "foo",
+          "<unstable USR>",
+          FunctionType(
+            [],
+            [TypeName("Float", "s:Sf")],
+            TypeName("Float", "s:Sf"))),
+        func foo(_ x: Float) -> Float in
+          return (1 * x)
+        },
+        SpecializedType(
+          TypeName("FunctionQuote1", "s:5Quote14FunctionQuote1C"),
+          [TypeName("Float", "s:Sf"),
+          TypeName("Float", "s:Sf")]))
+      """
+    )
+
+    let t2 = Bar._quotedInstanceBar()
+    assertStructure(
+      t2,
+      """
+      Function(
+        Name(
+          "instanceBar",
+          "<unstable USR>",
+          FunctionType(
+            [],
+            [TypeName("Float", "s:Sf")],
+            TypeName("Float", "s:Sf"))),
+        [Parameter(
+          nil,
+          Name(
+            "x",
+            "<unstable USR>",
+            TypeName("Float", "s:Sf")))],
+        [Return(
+          Binary(
+            IntegerLiteral(
+              2,
+              TypeName("Float", "s:Sf")),
+            Name(
+              "*",
+              "s:Sf1moiyS2f_SftFZ",
+              FunctionType(
+                [],
+                [TypeName("Float", "s:Sf"),
+                TypeName("Float", "s:Sf")],
+                TypeName("Float", "s:Sf"))),
+            Name(
+              "x",
+              "<unstable USR>",
+              TypeName("Float", "s:Sf")),
+            TypeName("Float", "s:Sf")))])
+      """
+    )
+
+    let bar = Bar()
+    blackHole(bar)
+    let q2 = #quote(bar.instanceBar)
+    assertStructure(
+      q2,
+      """
+      Unquote(
+        Member(
+          Name(
+            "bar",
+            "<unstable USR>",
+            TypeName("Bar", "<unstable USR>")),
+          "instanceBar",
+          "<unstable USR>",
+          FunctionType(
+            [],
+            [TypeName("Float", "s:Sf")],
+            TypeName("Float", "s:Sf"))),
+        func instanceBar(_ x: Float) -> Float in
+          return (2 * x)
+        },
+        SpecializedType(
+          TypeName("FunctionQuote1", "s:5Quote14FunctionQuote1C"),
+          [TypeName("Float", "s:Sf"),
+          TypeName("Float", "s:Sf")]))
+      """
+    )
+
+    let t3 = Bar._quotedStaticBar()
+    assertStructure(
+      t3,
+      """
+      Function(
+        Name(
+          "staticBar",
+          "<unstable USR>",
+          FunctionType(
+            [],
+            [TypeName("Float", "s:Sf")],
+            TypeName("Float", "s:Sf"))),
+        [Parameter(
+          nil,
+          Name(
+            "x",
+            "<unstable USR>",
+            TypeName("Float", "s:Sf")))],
+        [Return(
+          Binary(
+            IntegerLiteral(
+              3,
+              TypeName("Float", "s:Sf")),
+            Name(
+              "*",
+              "s:Sf1moiyS2f_SftFZ",
+              FunctionType(
+                [],
+                [TypeName("Float", "s:Sf"),
+                TypeName("Float", "s:Sf")],
+                TypeName("Float", "s:Sf"))),
+            Name(
+              "x",
+              "<unstable USR>",
+              TypeName("Float", "s:Sf")),
+            TypeName("Float", "s:Sf")))])
+      """
+    )
+
+    let q3 = #quote(Bar.staticBar)
+    assertStructure(
+      q3,
+      """
+      Unquote(
+        Name(
+          "staticBar",
+          "<unstable USR>",
+          FunctionType(
+            [],
+            [TypeName("Float", "s:Sf")],
+            TypeName("Float", "s:Sf"))),
+        func staticBar(_ x: Float) -> Float in
+          return (3 * x)
+        },
+        SpecializedType(
+          TypeName("FunctionQuote1", "s:5Quote14FunctionQuote1C"),
+          [TypeName("Float", "s:Sf"),
+          TypeName("Float", "s:Sf")]))
+      """
+    )
+  }
+
+  public func testAvgPool1D() {
+    func threadIndex() -> Int { return 0 }
+    func threadCount() -> Int { return 1 }
+    let avgPool1D = #quote{
+        (out: inout [Float], input: [Float], windowSize: Int, windowStride: Int) -> Void in
+        let n = input.count
+        let outSize = (n - windowSize) / windowStride + 1
+        let outStart = threadIndex()
+        let outStride = threadCount()
+        for outIndex in stride(from: outStart, to: outSize, by: outStride) {
+          out[outIndex] = 0.0
+          let beginWindow = outIndex * windowStride
+          let endWindow = outIndex * windowStride + windowSize
+          for inputIndex in beginWindow..<endWindow {
+            out[outIndex] += input[inputIndex]
+          }
+          out[outIndex] /= Float(windowSize)
+        }
+      }
+    let _ = {
+      let x: [Float] = [1, 2, 3, 4, 5, 6]
+      var out: [Float] = [Float](repeating: 0, count: x.count)
+      let windowSize = 2
+      let windowStride = 2
+      avgPool1D(&out, x, windowSize, windowStride)
+    }
+    assertDescription(
+      avgPool1D,
+      """
+      { (out: inout [Float], input: [Float], windowSize: Int, windowStride: Int) -> Void in
+        let n: Int = input.count
+        let outSize: Int = (((n - windowSize) / windowStride) + 1)
+        let outStart: Int = threadIndex()
+        let outStride: Int = threadCount()
+        for outIndex in stride(from: outStart, to: outSize, by: outStride) {
+          out[outIndex] = 0.0
+          let beginWindow: Int = (outIndex * windowStride)
+          let endWindow: Int = ((outIndex * windowStride) + windowSize)
+          for inputIndex in (beginWindow ..< endWindow) {
+            (out[outIndex] += input[inputIndex])
+          }
+          (out[outIndex] /= Float(windowSize))
+        }
+      }
+      """
+    )
+    assertDescription(avgPool1D.type, "(inout [Float], [Float], Int, Int) -> Void")
+  }
+
+  public func test31() {
+    print(#quote(42))
+  }
+
+  public func test32() {
+    print(#quote(print(42)))
+  }
+
+  private func blackHole(_ x: Any) {
+    // This method exists to silence unused variable warnings.
+    // TODO(#4): Get rid of this method.
+  }
+
+  public static let allTests = [
+    ("testClosureWithExpr", testClosureWithExpr),
+    ("testClosureWithStmts", testClosureWithStmts),
+    ("testUnquoteManual", testUnquoteManual),
+    ("testUnquoteAutomatic", testUnquoteAutomatic),
+    ("testAvgPool1D", testAvgPool1D),
+    // NOTE: This is intentionally not run - we just need to check that the test compiles.
+    // ("test31", test31),
+    // ("test32", test32),
+  ]
+}

--- a/Tests/QuoteTests/QuoteTests.swift
+++ b/Tests/QuoteTests/QuoteTests.swift
@@ -325,7 +325,7 @@ public final class QuoteTests: XCTestCase {
 
   private func blackHole(_ x: Any) {
     // This method exists to silence unused variable warnings.
-    // TODO(#4): Get rid of this method.
+    // TODO(TF-728): Get rid of this method.
   }
 
   public static let allTests = [

--- a/Tests/QuoteTests/QuoteTests.swift
+++ b/Tests/QuoteTests/QuoteTests.swift
@@ -3,19 +3,19 @@ import XCTest
 
 @quoted
 func foo(_ x: Float) -> Float {
-  return 1 * x
+    return 1 * x
 }
 
 class Bar {
-  @quoted
-  func instanceBar(_ x: Float) -> Float {
-    return 2 * x
-  }
+    @quoted
+    func instanceBar(_ x: Float) -> Float {
+        return 2 * x
+    }
 
-  @quoted
-  func staticBar(_ x: Float) -> Float {
-    return 3 * x
-  }
+    @quoted
+    func staticBar(_ x: Float) -> Float {
+        return 3 * x
+    }
 }
 
 // NOTE: This is a test of whether this thing successfully compiles.
@@ -24,62 +24,62 @@ func noReturnType() {
 }
 
 public final class QuoteTests: XCTestCase {
-  public func testClosureWithExpr() {
-    let q = #quote{ (x: Int, y: Int) in
-      x + y
-    }
-    let _ = { q(40, 2) }
-    assertDescription(
-      q,
-      """
+    public func testClosureWithExpr() {
+        let q = #quote{ (x: Int, y: Int) in
+            x + y
+        }
+        let _ = { q(40, 2) }
+        assertDescription(
+            q,
+            """
       { (x: Int, y: Int) -> Int in
         return (x + y)
       }
       """)
-    assertDescription(q.type, "(Int, Int) -> Int")
-  }
-
-  public func testClosureWithStmts() {
-    let q = #quote{
-      let n = 42;
-      print(n)
+        assertDescription(q.type, "(Int, Int) -> Int")
     }
-    let _ = { q() }
-    assertDescription(
-      q,
-      """
+
+    public func testClosureWithStmts() {
+        let q = #quote{
+            let n = 42;
+            print(n)
+        }
+        let _ = { q() }
+        assertDescription(
+            q,
+            """
       { () -> () in
         let n: Int = 42
         print(n)
       }
       """)
-    assertDescription(q.type, "() -> ()")
-  }
+        assertDescription(q.type, "() -> ()")
+    }
 
-  public func testUnquoteManual() {
-    let u = #quote{ (x: Int, y: Int) in
-      x + y
-    }
-    let _ = { u(40, 2) }
-    let q = #quote{ (x: Int) in
-      #unquote(u)(x, x)
-    }
-    let _ = { q(42) }
-    assertDescription(
-      q,
-      """
+    public func testUnquoteManual() {
+        let u = #quote{ (x: Int, y: Int) in
+            x + y
+        }
+        let _ = { u(40, 2) }
+        let q = #quote{ (x: Int) in
+            #unquote(u)(x, x)
+        }
+        let _ = { q(42) }
+        assertDescription(
+            q,
+            """
       { (x: Int) -> Int in
         return #unquote(u)(x, x)
       }
       """)
-    assertDescription(q.type, "(Int) -> Int")
-  }
+        assertDescription(q.type, "(Int) -> Int")
+    }
 
-  public func testUnquoteAutomatic() {
-    let t1 = _quotedFoo()
-    assertStructure(
-      t1,
-      """
+    public func testUnquoteAutomatic() {
+        let t1 = _quotedFoo()
+        assertStructure(
+            t1,
+            """
       Function(
         Name(
           "foo",
@@ -113,12 +113,12 @@ public final class QuoteTests: XCTestCase {
               TypeName("Float", "s:Sf")),
             TypeName("Float", "s:Sf")))])
       """
-    )
+        )
 
-    let q1 = #quote(foo)
-    assertStructure(
-      q1,
-      """
+        let q1 = #quote(foo)
+        assertStructure(
+            q1,
+            """
       Unquote(
         Name(
           "foo",
@@ -135,12 +135,12 @@ public final class QuoteTests: XCTestCase {
           [TypeName("Float", "s:Sf"),
           TypeName("Float", "s:Sf")]))
       """
-    )
+        )
 
-    let t2 = Bar._quotedInstanceBar()
-    assertStructure(
-      t2,
-      """
+        let t2 = Bar._quotedInstanceBar()
+        assertStructure(
+            t2,
+            """
       Function(
         Name(
           "instanceBar",
@@ -174,14 +174,14 @@ public final class QuoteTests: XCTestCase {
               TypeName("Float", "s:Sf")),
             TypeName("Float", "s:Sf")))])
       """
-    )
+        )
 
-    let bar = Bar()
-    blackHole(bar)
-    let q2 = #quote(bar.instanceBar)
-    assertStructure(
-      q2,
-      """
+        let bar = Bar()
+        blackHole(bar)
+        let q2 = #quote(bar.instanceBar)
+        assertStructure(
+            q2,
+            """
       Unquote(
         Member(
           Name(
@@ -202,12 +202,12 @@ public final class QuoteTests: XCTestCase {
           [TypeName("Float", "s:Sf"),
           TypeName("Float", "s:Sf")]))
       """
-    )
+        )
 
-    let t3 = Bar._quotedStaticBar()
-    assertStructure(
-      t3,
-      """
+        let t3 = Bar._quotedStaticBar()
+        assertStructure(
+            t3,
+            """
       Function(
         Name(
           "staticBar",
@@ -241,12 +241,12 @@ public final class QuoteTests: XCTestCase {
               TypeName("Float", "s:Sf")),
             TypeName("Float", "s:Sf")))])
       """
-    )
+        )
 
-    let q3 = #quote(Bar.staticBar)
-    assertStructure(
-      q3,
-      """
+        let q3 = #quote(Bar.staticBar)
+        assertStructure(
+            q3,
+            """
       Unquote(
         Name(
           "staticBar",
@@ -263,38 +263,38 @@ public final class QuoteTests: XCTestCase {
           [TypeName("Float", "s:Sf"),
           TypeName("Float", "s:Sf")]))
       """
-    )
-  }
-
-  public func testAvgPool1D() {
-    func threadIndex() -> Int { return 0 }
-    func threadCount() -> Int { return 1 }
-    let avgPool1D = #quote{
-        (out: inout [Float], input: [Float], windowSize: Int, windowStride: Int) -> Void in
-        let n = input.count
-        let outSize = (n - windowSize) / windowStride + 1
-        let outStart = threadIndex()
-        let outStride = threadCount()
-        for outIndex in stride(from: outStart, to: outSize, by: outStride) {
-          out[outIndex] = 0.0
-          let beginWindow = outIndex * windowStride
-          let endWindow = outIndex * windowStride + windowSize
-          for inputIndex in beginWindow..<endWindow {
-            out[outIndex] += input[inputIndex]
-          }
-          out[outIndex] /= Float(windowSize)
-        }
-      }
-    let _ = {
-      let x: [Float] = [1, 2, 3, 4, 5, 6]
-      var out: [Float] = [Float](repeating: 0, count: x.count)
-      let windowSize = 2
-      let windowStride = 2
-      avgPool1D(&out, x, windowSize, windowStride)
+        )
     }
-    assertDescription(
-      avgPool1D,
-      """
+
+    public func testAvgPool1D() {
+        func threadIndex() -> Int { return 0 }
+        func threadCount() -> Int { return 1 }
+        let avgPool1D = #quote{
+                (out: inout [Float], input: [Float], windowSize: Int, windowStride: Int) -> Void in
+                let n = input.count
+                let outSize = (n - windowSize) / windowStride + 1
+                let outStart = threadIndex()
+                let outStride = threadCount()
+                for outIndex in stride(from: outStart, to: outSize, by: outStride) {
+                    out[outIndex] = 0.0
+                    let beginWindow = outIndex * windowStride
+                    let endWindow = outIndex * windowStride + windowSize
+                    for inputIndex in beginWindow..<endWindow {
+                        out[outIndex] += input[inputIndex]
+                    }
+                    out[outIndex] /= Float(windowSize)
+                }
+            }
+        let _ = {
+            let x: [Float] = [1, 2, 3, 4, 5, 6]
+            var out: [Float] = [Float](repeating: 0, count: x.count)
+            let windowSize = 2
+            let windowStride = 2
+            avgPool1D(&out, x, windowSize, windowStride)
+        }
+        assertDescription(
+            avgPool1D,
+            """
       { (out: inout [Float], input: [Float], windowSize: Int, windowStride: Int) -> Void in
         let n: Int = input.count
         let outSize: Int = (((n - windowSize) / windowStride) + 1)
@@ -311,31 +311,31 @@ public final class QuoteTests: XCTestCase {
         }
       }
       """
-    )
-    assertDescription(avgPool1D.type, "(inout [Float], [Float], Int, Int) -> Void")
-  }
+        )
+        assertDescription(avgPool1D.type, "(inout [Float], [Float], Int, Int) -> Void")
+    }
 
-  public func test31() {
-    print(#quote(42))
-  }
+    public func test31() {
+        print(#quote(42))
+    }
 
-  public func test32() {
-    print(#quote(print(42)))
-  }
+    public func test32() {
+        print(#quote(print(42)))
+    }
 
-  private func blackHole(_ x: Any) {
-    // This method exists to silence unused variable warnings.
-    // TODO(TF-728): Get rid of this method.
-  }
+    private func blackHole(_ x: Any) {
+        // This method exists to silence unused variable warnings.
+        // TODO(TF-728): Get rid of this method.
+    }
 
-  public static let allTests = [
-    ("testClosureWithExpr", testClosureWithExpr),
-    ("testClosureWithStmts", testClosureWithStmts),
-    ("testUnquoteManual", testUnquoteManual),
-    ("testUnquoteAutomatic", testUnquoteAutomatic),
-    ("testAvgPool1D", testAvgPool1D),
-    // NOTE: This is intentionally not run - we just need to check that the test compiles.
-    // ("test31", test31),
-    // ("test32", test32),
-  ]
+    public static let allTests = [
+        ("testClosureWithExpr", testClosureWithExpr),
+        ("testClosureWithStmts", testClosureWithStmts),
+        ("testUnquoteManual", testUnquoteManual),
+        ("testUnquoteAutomatic", testUnquoteAutomatic),
+        ("testAvgPool1D", testAvgPool1D),
+        // NOTE: This is intentionally not run - we just need to check that the test compiles.
+        // ("test31", test31),
+        // ("test32", test32),
+    ]
 }

--- a/Tests/QuoteTests/StructureTests.swift
+++ b/Tests/QuoteTests/StructureTests.swift
@@ -2,102 +2,102 @@ import Quote
 import XCTest
 
 public final class StructureTests: XCTestCase {
-  public func testDifferentiable() {
-    // NOTE: At the moment, this leads to a runtime crash.
-    // let fn: @differentiable (Float) -> Float = { x in x }
-    // blackHole(fn)
-    // let q = #quote(fn)
-    func fn() -> @differentiable (Float) -> Float { fatalError("") }
-    let q = #quote(fn())
-    assertStructure(
-      q.type,
-      """
+    public func testDifferentiable() {
+        // NOTE: At the moment, this leads to a runtime crash.
+        // let fn: @differentiable (Float) -> Float = { x in x }
+        // blackHole(fn)
+        // let q = #quote(fn)
+        func fn() -> @differentiable (Float) -> Float { fatalError("") }
+        let q = #quote(fn())
+        assertStructure(
+            q.type,
+            """
       FunctionType(
         [Differentiable()],
         [TypeName("Float", "s:Sf")],
         TypeName("Float", "s:Sf"))
       """
-    )
-  }
+        )
+    }
 
-  public func testAndType() {
-    func f() -> A & B { fatalError("implement me"); }
-    let q = #quote(f())
-    assertStructure(
-      q.type,
-      """
+    public func testAndType() {
+        func f() -> A & B { fatalError("implement me"); }
+        let q = #quote(f())
+        assertStructure(
+            q.type,
+            """
       AndType(
         [TypeName("A", "<unstable USR>"),
         TypeName("B", "<unstable USR>")])
       """
-    )
-  }
+        )
+    }
 
-  public func testArrayType() {
-    let x = [1, 2, 3]
-    blackHole(x)
-    let q = #quote(x)
-    assertStructure(
-      q.type,
-      """
+    public func testArrayType() {
+        let x = [1, 2, 3]
+        blackHole(x)
+        let q = #quote(x)
+        assertStructure(
+            q.type,
+            """
       ArrayType(
         TypeName("Int", "s:Si"))
       """)
-  }
+    }
 
-  public func testDictionaryType() {
-    let x = [40: 2]
-    blackHole(x)
-    let q = #quote(x)
-    assertStructure(
-      q.type,
-      """
+    public func testDictionaryType() {
+        let x = [40: 2]
+        blackHole(x)
+        let q = #quote(x)
+        assertStructure(
+            q.type,
+            """
       DictionaryType(
         TypeName("Int", "s:Si"),
         TypeName("Int", "s:Si"))
       """
-    )
-  }
-
-  public func testFunctionType() {
-    let x = { (x: Int) in
-      x
+        )
     }
-    blackHole(x)
-    let q = #quote(x)
-    assertStructure(
-      q.type,
-      """
+
+    public func testFunctionType() {
+        let x = { (x: Int) in
+            x
+        }
+        blackHole(x)
+        let q = #quote(x)
+        assertStructure(
+            q.type,
+            """
       FunctionType(
         [],
         [TypeName("Int", "s:Si")],
         TypeName("Int", "s:Si"))
       """
-    )
-  }
-
-  public func testInOutType() {
-    let q = #quote{ (x: inout Int) in
-      x
+        )
     }
-    assertStructure(
-      q.type,
-      """
+
+    public func testInOutType() {
+        let q = #quote{ (x: inout Int) in
+            x
+        }
+        assertStructure(
+            q.type,
+            """
       FunctionType(
         [],
         [InoutType(
           TypeName("Int", "s:Si"))],
         TypeName("Int", "s:Si"))
       """
-    )
-  }
+        )
+    }
 
-  public func testLValueType() {
-    func foo(_ x: inout Int) {
-      let q = #quote{ let y = x }
-      assertStructure(
-        q,
-        """
+    public func testLValueType() {
+        func foo(_ x: inout Int) {
+            let q = #quote{ let y = x }
+            assertStructure(
+                q,
+                """
         Closure(
           [],
           [Let(
@@ -118,87 +118,87 @@ public final class StructureTests: XCTestCase {
             TupleType(
               [])))
         """
-      )
+            )
+        }
+        var x = 2
+        foo(&x)
     }
-    var x = 2
-    foo(&x)
-  }
 
-  public func testMetaType() {
-    let x = Int.self
-    blackHole(x)
-    let q = #quote(x)
-    assertStructure(
-      q.type,
-      """
+    public func testMetaType() {
+        let x = Int.self
+        blackHole(x)
+        let q = #quote(x)
+        assertStructure(
+            q.type,
+            """
       MetaType(
         TypeName("Int", "s:Si"))
       """
-    )
-  }
+        )
+    }
 
-  public func testOptionalType() {
-    let x: Int? = 42
-    blackHole(x ?? 42)
-    let q = #quote(x)
-    assertStructure(
-      q.type,
-      """
+    public func testOptionalType() {
+        let x: Int? = 42
+        blackHole(x ?? 42)
+        let q = #quote(x)
+        assertStructure(
+            q.type,
+            """
       OptionalType(
         TypeName("Int", "s:Si"))
       """
-    )
-  }
+        )
+    }
 
-  public func testSpecializedType() {
-    let x: ClosedRange<Int> = 1...10
-    blackHole(x)
-    let q = #quote(x)
-    assertStructure(
-      q.type,
-      """
+    public func testSpecializedType() {
+        let x: ClosedRange<Int> = 1...10
+        blackHole(x)
+        let q = #quote(x)
+        assertStructure(
+            q.type,
+            """
       SpecializedType(
         TypeName("ClosedRange", "s:SN"),
         [TypeName("Int", "s:Si")])
       """
-    )
-  }
+        )
+    }
 
-  public func testTupleType() {
-    let x = (1, "2", 3)
-    blackHole(x)
-    let q = #quote(x)
-    assertStructure(
-      q.type,
-      """
+    public func testTupleType() {
+        let x = (1, "2", 3)
+        blackHole(x)
+        let q = #quote(x)
+        assertStructure(
+            q.type,
+            """
       TupleType(
         [TypeName("Int", "s:Si"),
         TypeName("String", "s:SS"),
         TypeName("Int", "s:Si")])
       """
-    )
-  }
+        )
+    }
 
-  public func testTypeName() {
-    let x = 42
-    blackHole(x)
-    let q = #quote(x)
-    assertStructure(
-      q.type,
-      """
+    public func testTypeName() {
+        let x = 42
+        blackHole(x)
+        let q = #quote(x)
+        assertStructure(
+            q.type,
+            """
       TypeName("Int", "s:Si")
       """)
-  }
-
-  public func testBreak() {
-    let q = #quote{
-      while true {
-        break
-      }
     }
-    assertStructure(
-      q,
-      """
+
+    public func testBreak() {
+        let q = #quote{
+            while true {
+                break
+            }
+        }
+        assertStructure(
+            q,
+            """
       Closure(
         [],
         [While(
@@ -214,18 +214,18 @@ public final class StructureTests: XCTestCase {
           TupleType(
             [])))
       """
-    )
-  }
-
-  public func testContinue() {
-    let q = #quote{
-      while true {
-        continue
-      }
+        )
     }
-    assertStructure(
-      q,
-      """
+
+    public func testContinue() {
+        let q = #quote{
+            while true {
+                continue
+            }
+        }
+        assertStructure(
+            q,
+            """
       Closure(
         [],
         [While(
@@ -241,17 +241,17 @@ public final class StructureTests: XCTestCase {
           TupleType(
             [])))
       """
-    )
-  }
-
-  public func testDefer() {
-    let q = #quote{
-      defer {}
-      return
+        )
     }
-    assertStructure(
-      q,
-      """
+
+    public func testDefer() {
+        let q = #quote{
+            defer {}
+            return
+        }
+        assertStructure(
+            q,
+            """
       Closure(
         [],
         [Defer(
@@ -268,16 +268,16 @@ public final class StructureTests: XCTestCase {
           TupleType(
             [])))
       """
-    )
-  }
-
-  public func testDo() {
-    let q = #quote{
-      do {}
+        )
     }
-    assertStructure(
-      q,
-      """
+
+    public func testDo() {
+        let q = #quote{
+            do {}
+        }
+        assertStructure(
+            q,
+            """
       Closure(
         [],
         [Do(
@@ -289,18 +289,18 @@ public final class StructureTests: XCTestCase {
           TupleType(
             [])))
       """
-    )
-  }
-
-  public func testFor() {
-    let range = 1...10
-    blackHole(range)
-    let q = #quote{
-      for i in range {}
+        )
     }
-    assertStructure(
-      q,
-      """
+
+    public func testFor() {
+        let range = 1...10
+        blackHole(range)
+        let q = #quote{
+            for i in range {}
+        }
+        assertStructure(
+            q,
+            """
       Closure(
         [],
         [For(
@@ -322,16 +322,16 @@ public final class StructureTests: XCTestCase {
           TupleType(
             [])))
       """
-    )
-  }
-
-  public func testGuard() {
-    let q = #quote{
-      guard true else {}
+        )
     }
-    assertStructure(
-      q,
-      """
+
+    public func testGuard() {
+        let q = #quote{
+            guard true else {}
+        }
+        assertStructure(
+            q,
+            """
       Closure(
         [],
         [Guard(
@@ -345,16 +345,16 @@ public final class StructureTests: XCTestCase {
           TupleType(
             [])))
       """
-    )
-  }
-
-  public func testIf() {
-    let q = #quote{
-      if true {} else if false {} else {}
+        )
     }
-    assertStructure(
-      q,
-      """
+
+    public func testIf() {
+        let q = #quote{
+            if true {} else if false {} else {}
+        }
+        assertStructure(
+            q,
+            """
       Closure(
         [],
         [If(
@@ -376,16 +376,16 @@ public final class StructureTests: XCTestCase {
           TupleType(
             [])))
       """
-    )
-  }
-
-  public func testRepeat() {
-    let q = #quote{
-      repeat {} while true
+        )
     }
-    assertStructure(
-      q,
-      """
+
+    public func testRepeat() {
+        let q = #quote{
+            repeat {} while true
+        }
+        assertStructure(
+            q,
+            """
       Closure(
         [],
         [Repeat(
@@ -400,16 +400,16 @@ public final class StructureTests: XCTestCase {
           TupleType(
             [])))
       """
-    )
-  }
-
-  public func testReturn() {
-    let q = #quote{ () in
-      return
+        )
     }
-    assertStructure(
-      q,
-      """
+
+    public func testReturn() {
+        let q = #quote{ () in
+            return
+        }
+        assertStructure(
+            q,
+            """
       Closure(
         [],
         [Return(
@@ -424,16 +424,16 @@ public final class StructureTests: XCTestCase {
           TupleType(
             [])))
       """
-    )
-  }
-
-  public func testThrow() {
-    let q = #quote{
-      throw X()
+        )
     }
-    assertStructure(
-      q,
-      """
+
+    public func testThrow() {
+        let q = #quote{
+            throw X()
+        }
+        assertStructure(
+            q,
+            """
       Closure(
         [],
         [Throw(
@@ -456,16 +456,16 @@ public final class StructureTests: XCTestCase {
           TupleType(
             [])))
       """
-    )
-  }
-
-  public func testWhile() {
-    let q = #quote{
-      while true {}
+        )
     }
-    assertStructure(
-      q,
-      """
+
+    public func testWhile() {
+        let q = #quote{
+            while true {}
+        }
+        assertStructure(
+            q,
+            """
       Closure(
         [],
         [While(
@@ -480,14 +480,14 @@ public final class StructureTests: XCTestCase {
           TupleType(
             [])))
       """
-    )
-  }
+        )
+    }
 
-  public func testArrayLiteral() {
-    let q = #quote([40, 2])
-    assertStructure(
-      q,
-      """
+    public func testArrayLiteral() {
+        let q = #quote([40, 2])
+        assertStructure(
+            q,
+            """
       ArrayLiteral(
         [IntegerLiteral(
           40,
@@ -498,31 +498,31 @@ public final class StructureTests: XCTestCase {
         ArrayType(
           TypeName("Int", "s:Si")))
       """
-    )
-  }
+        )
+    }
 
-  public func testAs() {
-    let q = #quote(42 as Int)
-    assertStructure(
-      q,
-      """
+    public func testAs() {
+        let q = #quote(42 as Int)
+        assertStructure(
+            q,
+            """
       As(
         IntegerLiteral(
           42,
           TypeName("Int", "s:Si")),
         TypeName("Int", "s:Si"))
       """
-    )
-  }
+        )
+    }
 
-  public func testAssign() {
-    var x = 0
-    x = 42  // TODO(TF-728): Get rid of this assignment.
-    blackHole(x)
-    let q = #quote(x = 42)
-    assertStructure(
-      q,
-      """
+    public func testAssign() {
+        var x = 0
+        x = 42  // TODO(TF-728): Get rid of this assignment.
+        blackHole(x)
+        let q = #quote(x = 42)
+        assertStructure(
+            q,
+            """
       Assign(
         Name(
           "x",
@@ -535,14 +535,14 @@ public final class StructureTests: XCTestCase {
         TupleType(
           []))
       """
-    )
-  }
+        )
+    }
 
-  public func testBinary() {
-    let q = #quote(40 + 2)
-    assertStructure(
-      q,
-      """
+    public func testBinary() {
+        let q = #quote(40 + 2)
+        assertStructure(
+            q,
+            """
       Binary(
         IntegerLiteral(
           40,
@@ -560,25 +560,25 @@ public final class StructureTests: XCTestCase {
           TypeName("Int", "s:Si")),
         TypeName("Int", "s:Si"))
       """
-    )
-  }
+        )
+    }
 
-  public func testBooleanLiteral() {
-    let q = #quote(true)
-    assertStructure(
-      q,
-      """
+    public func testBooleanLiteral() {
+        let q = #quote(true)
+        assertStructure(
+            q,
+            """
       BooleanLiteral(
         true,
         TypeName("Bool", "s:Sb"))
       """)
-  }
+    }
 
-  public func testCall1() {
-    let q = #quote(print(42))
-    assertStructure(
-      q,
-      """
+    public func testCall1() {
+        let q = #quote(print(42))
+        assertStructure(
+            q,
+            """
       Call(
         Name(
           "print",
@@ -611,14 +611,14 @@ public final class StructureTests: XCTestCase {
         TupleType(
           []))
       """
-    )
-  }
+        )
+    }
 
-  public func testCall2() {
-    let q = #quote(f().m())
-    assertStructure(
-      q,
-      """
+    public func testCall2() {
+        let q = #quote(f().m())
+        assertStructure(
+            q,
+            """
       Call(
         Member(
           Call(
@@ -644,16 +644,16 @@ public final class StructureTests: XCTestCase {
         TupleType(
           []))
       """
-    )
-  }
-
-  public func testClosure() {
-    let q = #quote{ (x: Int) in
-      x
+        )
     }
-    assertStructure(
-      q,
-      """
+
+    public func testClosure() {
+        let q = #quote{ (x: Int) in
+            x
+        }
+        assertStructure(
+            q,
+            """
       Closure(
         [Parameter(
           nil,
@@ -671,22 +671,22 @@ public final class StructureTests: XCTestCase {
           [TypeName("Int", "s:Si")],
           TypeName("Int", "s:Si")))
       """
-    )
-  }
+        )
+    }
 
-  public func testConversion() {
-    testLValueType()
-  }
+    public func testConversion() {
+        testLValueType()
+    }
 
-  public func testDefault() {
-    testCall1()
-  }
+    public func testDefault() {
+        testCall1()
+    }
 
-  public func testDictionaryLiteral() {
-    let q = #quote([40: 40, 2: 2])
-    assertStructure(
-      q,
-      """
+    public func testDictionaryLiteral() {
+        let q = #quote([40: 40, 2: 2])
+        assertStructure(
+            q,
+            """
       DictionaryLiteral(
         [IntegerLiteral(
           40,
@@ -704,27 +704,27 @@ public final class StructureTests: XCTestCase {
           TypeName("Int", "s:Si"),
           TypeName("Int", "s:Si")))
       """
-    )
-  }
+        )
+    }
 
-  public func testFloatLiteral() {
-    let q = #quote(42.0)
-    assertStructure(
-      q,
-      """
+    public func testFloatLiteral() {
+        let q = #quote(42.0)
+        assertStructure(
+            q,
+            """
       FloatLiteral(
         42.0,
         TypeName("Double", "s:Sd"))
       """)
-  }
+    }
 
-  public func testForce() {
-    let x: Int? = 42
-    blackHole(x ?? 42)
-    let q = #quote(x!)
-    assertStructure(
-      q,
-      """
+    public func testForce() {
+        let x: Int? = 42
+        blackHole(x ?? 42)
+        let q = #quote(x!)
+        assertStructure(
+            q,
+            """
       Force(
         Name(
           "x",
@@ -733,16 +733,16 @@ public final class StructureTests: XCTestCase {
             TypeName("Int", "s:Si"))),
         TypeName("Int", "s:Si"))
       """
-    )
-  }
+        )
+    }
 
-  public func testForceAs() {
-    let x: Any = 42
-    blackHole(x)
-    let q = #quote(x as! Int)
-    assertStructure(
-      q,
-      """
+    public func testForceAs() {
+        let x: Any = 42
+        blackHole(x)
+        let q = #quote(x as! Int)
+        assertStructure(
+            q,
+            """
       ForceAs(
         Name(
           "x",
@@ -751,32 +751,32 @@ public final class StructureTests: XCTestCase {
             [])),
         TypeName("Int", "s:Si"))
       """
-    )
-  }
+        )
+    }
 
-  public func testForceTry() {
-    let q = #quote(try! 42)
-    assertStructure(
-      q,
-      """
+    public func testForceTry() {
+        let q = #quote(try! 42)
+        assertStructure(
+            q,
+            """
       ForceTry(
         IntegerLiteral(
           42,
           TypeName("Int", "s:Si")),
         TypeName("Int", "s:Si"))
       """
-    )
-  }
+        )
+    }
 
-  public func testInout() {
-    func foo(_ x: inout Int) {}
-    var x = 0
-    blackHole(x)
-    x = 42  // TODO(TF-728): Get rid of this assignment.
-    let q = #quote(foo(&x))
-    assertStructure(
-      q,
-      """
+    public func testInout() {
+        func foo(_ x: inout Int) {}
+        var x = 0
+        blackHole(x)
+        x = 42  // TODO(TF-728): Get rid of this assignment.
+        let q = #quote(foo(&x))
+        assertStructure(
+            q,
+            """
       Call(
         Name(
           "foo",
@@ -799,27 +799,27 @@ public final class StructureTests: XCTestCase {
         TupleType(
           []))
       """
-    )
-  }
+        )
+    }
 
-  public func testIntegerLiteral() {
-    let q = #quote(42)
-    assertStructure(
-      q,
-      """
+    public func testIntegerLiteral() {
+        let q = #quote(42)
+        assertStructure(
+            q,
+            """
       IntegerLiteral(
         42,
         TypeName("Int", "s:Si"))
       """)
-  }
+    }
 
-  public func testIs() {
-    let x: Any = 42
-    blackHole(x)
-    let q = #quote(x is Int)
-    assertStructure(
-      q,
-      """
+    public func testIs() {
+        let x: Any = 42
+        blackHole(x)
+        let q = #quote(x is Int)
+        assertStructure(
+            q,
+            """
       Is(
         Name(
           "x",
@@ -829,64 +829,65 @@ public final class StructureTests: XCTestCase {
         TypeName("Int", "s:Si"),
         TypeName("Bool", "s:Sb"))
       """
-    )
-  }
+        )
+    }
 
-  public func testMagicLiteral() {
-    let q1 = #quote(#file)
-    assertStructure(
-      q1,
-      """
+    public func testMagicLiteral() {
+        let q1 = #quote(#file)
+        assertStructure(
+            q1,
+            """
       MagicLiteral(
         "file",
         TypeName("String", "s:SS"))
       """)
 
-    let q2 = #quote(#line)
-    assertStructure(
-      q2,
-      """
+        let q2 = #quote(#line)
+        assertStructure(
+            q2,
+            """
       MagicLiteral(
         "line",
         TypeName("Int", "s:Si"))
       """)
 
-    let q3 = #quote(#column)
-    assertStructure(
-      q3,
-      """
+        let q3 = #quote(#column)
+        assertStructure(
+            q3,
+            """
       MagicLiteral(
         "column",
         TypeName("Int", "s:Si"))
       """)
 
-    let q4 = #quote(#function)
-    assertStructure(
-      q4,
-      """
+        let q4 = #quote(#function)
+        assertStructure(
+            q4,
+            """
       MagicLiteral(
         "function",
         TypeName("String", "s:SS"))
-      """)
-
-    let q5 = #quote(#dsohandle)
-    assertStructure(
-      q5,
       """
+        )
+
+        let q5 = #quote(#dsohandle)
+        assertStructure(
+            q5,
+            """
       MagicLiteral(
         "dsohandle",
         TypeName("UnsafeRawPointer", "s:SV"))
       """
-    )
-  }
+        )
+    }
 
-  public func testMember1() {
-    let x = [1, 2, 3]
-    blackHole(x)
-    let q = #quote(x.count)
-    assertStructure(
-      q,
-      """
+    public func testMember1() {
+        let x = [1, 2, 3]
+        blackHole(x)
+        let q = #quote(x.count)
+        assertStructure(
+            q,
+            """
       Member(
         Name(
           "x",
@@ -897,40 +898,40 @@ public final class StructureTests: XCTestCase {
         "s:Sa5countSivp",
         TypeName("Int", "s:Si"))
       """
-    )
-  }
+        )
+    }
 
-  public func testMember2() {
-    let q = #quote(Context.local)
-    assertStructure(
-      q,
-      """
+    public func testMember2() {
+        let q = #quote(Context.local)
+        assertStructure(
+            q,
+            """
       Name(
         "local",
         "<unstable USR>",
         TypeName("Context", "<unstable USR>"))
       """
-    )
-  }
+        )
+    }
 
-  public func testMember3() {
-    let q = #quote(E.a)
-    assertStructure(
-      q,
-      """
+    public func testMember3() {
+        let q = #quote(E.a)
+        assertStructure(
+            q,
+            """
       Name(
         "a",
         "<unstable USR>",
         TypeName("E", "<unstable USR>"))
       """
-    )
-  }
+        )
+    }
 
-  public func testMember4() {
-    let q = #quote(g())
-    assertStructure(
-      q,
-      """
+    public func testMember4() {
+        let q = #quote(g())
+        assertStructure(
+            q,
+            """
       Call(
         Name(
           "g",
@@ -945,14 +946,14 @@ public final class StructureTests: XCTestCase {
         TupleType(
           []))
       """
-    )
-  }
+        )
+    }
 
-  public func testMeta() {
-    let q = #quote(#quote(42))
-    assertStructure(
-      q,
-      """
+    public func testMeta() {
+        let q = #quote(#quote(42))
+        assertStructure(
+            q,
+            """
       Meta(
         IntegerLiteral(
           42,
@@ -961,29 +962,29 @@ public final class StructureTests: XCTestCase {
           TypeName("Quote", "s:5QuoteAAC"),
           [TypeName("Int", "s:Si")]))
       """
-    )
-  }
+        )
+    }
 
-  public func testName() {
-    let x = 42
-    blackHole(x)
-    let q = #quote(x)
-    assertStructure(
-      q,
-      """
+    public func testName() {
+        let x = 42
+        blackHole(x)
+        let q = #quote(x)
+        assertStructure(
+            q,
+            """
       Name(
         "x",
         "<unstable USR>",
         TypeName("Int", "s:Si"))
       """
-    )
-  }
+        )
+    }
 
-  public func testNilLiteral() {
-    let q = #quote(nil as Int?)
-    assertStructure(
-      q,
-      """
+    public func testNilLiteral() {
+        let q = #quote(nil as Int?)
+        assertStructure(
+            q,
+            """
       As(
         NilLiteral(
           OptionalType(
@@ -991,16 +992,16 @@ public final class StructureTests: XCTestCase {
         OptionalType(
           TypeName("Int", "s:Si")))
       """
-    )
-  }
+        )
+    }
 
-  public func testOptionalAs() {
-    let x: Any = 42
-    blackHole(x)
-    let q = #quote(x as? Int)
-    assertStructure(
-      q,
-      """
+    public func testOptionalAs() {
+        let x: Any = 42
+        blackHole(x)
+        let q = #quote(x as? Int)
+        assertStructure(
+            q,
+            """
       OptionalAs(
         Name(
           "x",
@@ -1011,14 +1012,14 @@ public final class StructureTests: XCTestCase {
         OptionalType(
           TypeName("Int", "s:Si")))
       """
-    )
-  }
+        )
+    }
 
-  public func testOptionalTry() {
-    let q = #quote(try? 42)
-    assertStructure(
-      q,
-      """
+    public func testOptionalTry() {
+        let q = #quote(try? 42)
+        assertStructure(
+            q,
+            """
       OptionalTry(
         IntegerLiteral(
           42,
@@ -1026,45 +1027,45 @@ public final class StructureTests: XCTestCase {
         OptionalType(
           TypeName("Int", "s:Si")))
       """
-    )
-  }
+        )
+    }
 
-  public func testPostfix() {
-    // TODO(TF-729): Find out how to conveniently test this.
-  }
+    public func testPostfix() {
+        // TODO(TF-729): Find out how to conveniently test this.
+    }
 
-  public func testPostfixSelf1() {
-    let q = #quote(42.self)
-    assertStructure(
-      q,
-      """
+    public func testPostfixSelf1() {
+        let q = #quote(42.self)
+        assertStructure(
+            q,
+            """
       PostfixSelf(
         IntegerLiteral(
           42,
           TypeName("Int", "s:Si")),
         TypeName("Int", "s:Si"))
       """
-    )
-  }
+        )
+    }
 
-  public func testPostfixSelf2() {
-    let q = #quote(Int.self)
-    assertStructure(
-      q,
-      """
+    public func testPostfixSelf2() {
+        let q = #quote(Int.self)
+        assertStructure(
+            q,
+            """
       PostfixSelf(
         TypeName("Int", "s:Si"),
         MetaType(
           TypeName("Int", "s:Si")))
       """
-    )
-  }
+        )
+    }
 
-  public func testPrefix() {
-    let q = #quote(+42)
-    assertStructure(
-      q,
-      """
+    public func testPrefix() {
+        let q = #quote(+42)
+        assertStructure(
+            q,
+            """
       Prefix(
         Name(
           "+",
@@ -1078,39 +1079,39 @@ public final class StructureTests: XCTestCase {
           TypeName("Int", "s:Si")),
         TypeName("Int", "s:Si"))
       """
-    )
-  }
+        )
+    }
 
-  public func testStringInterpolation() {
-    let x = 42
-    blackHole(x)
-    let q = #quote("x = \(x)")
-    assertStructure(
-      q,
-      """
+    public func testStringInterpolation() {
+        let x = 42
+        blackHole(x)
+        let q = #quote("x = \(x)")
+        assertStructure(
+            q,
+            """
       StringInterpolation(
         TypeName("String", "s:SS"))
       """)
-  }
+    }
 
-  public func testStringLiteral() {
-    let q = #quote("42")
-    assertStructure(
-      q,
-      """
+    public func testStringLiteral() {
+        let q = #quote("42")
+        assertStructure(
+            q,
+            """
       StringLiteral(
         "42",
         TypeName("String", "s:SS"))
       """)
-  }
+    }
 
-  public func testSubscript() {
-    let x = [1, 2, 3]
-    blackHole(x)
-    let q = #quote(x[0])
-    assertStructure(
-      q,
-      """
+    public func testSubscript() {
+        let x = [1, 2, 3]
+        blackHole(x)
+        let q = #quote(x[0])
+        assertStructure(
+            q,
+            """
       Subscript(
         Name(
           "x",
@@ -1124,19 +1125,19 @@ public final class StructureTests: XCTestCase {
           TypeName("Int", "s:Si"))],
         TypeName("Int", "s:Si"))
       """
-    )
-  }
-
-  public func testSuper() {
-    class C {
-      func p() {}
+        )
     }
-    class D: C {
-      func q() {
-        let q = #quote(super.p())
-        assertStructure(
-          q,
-          """
+
+    public func testSuper() {
+        class C {
+            func p() {}
+        }
+        class D: C {
+            func q() {
+                let q = #quote(super.p())
+                assertStructure(
+                    q,
+                    """
           Call(
             Member(
               Super(
@@ -1153,17 +1154,17 @@ public final class StructureTests: XCTestCase {
             TupleType(
               []))
           """
-        )
-      }
+                )
+            }
+        }
+        D().q()
     }
-    D().q()
-  }
 
-  public func testTernary() {
-    let q = #quote(true ? 40 : 2)
-    assertStructure(
-      q,
-      """
+    public func testTernary() {
+        let q = #quote(true ? 40 : 2)
+        assertStructure(
+            q,
+            """
       Ternary(
         BooleanLiteral(
           true,
@@ -1176,28 +1177,28 @@ public final class StructureTests: XCTestCase {
           TypeName("Int", "s:Si")),
         TypeName("Int", "s:Si"))
       """
-    )
-  }
+        )
+    }
 
-  public func testTry() {
-    let q = #quote(try 42)
-    assertStructure(
-      q,
-      """
+    public func testTry() {
+        let q = #quote(try 42)
+        assertStructure(
+            q,
+            """
       Try(
         IntegerLiteral(
           42,
           TypeName("Int", "s:Si")),
         TypeName("Int", "s:Si"))
       """
-    )
-  }
+        )
+    }
 
-  public func testTuple() {
-    let q = #quote((1, "2", 3))
-    assertStructure(
-      q,
-      """
+    public func testTuple() {
+        let q = #quote((1, "2", 3))
+        assertStructure(
+            q,
+            """
       Tuple(
         [],
         [IntegerLiteral(
@@ -1214,14 +1215,14 @@ public final class StructureTests: XCTestCase {
           TypeName("String", "s:SS"),
           TypeName("Int", "s:Si")]))
       """
-    )
-  }
+        )
+    }
 
-  public func testTupleElement() {
-    let q = #quote((1, 2).1)
-    assertStructure(
-      q,
-      """
+    public func testTupleElement() {
+        let q = #quote((1, 2).1)
+        assertStructure(
+            q,
+            """
       TupleElement(
         Tuple(
           [],
@@ -1235,15 +1236,15 @@ public final class StructureTests: XCTestCase {
         1,
         TypeName("Int", "s:Si"))
       """
-    )
-  }
+        )
+    }
 
-  public func testUnquote() {
-    let x = #quote(40)
-    let q = #quote(#unquote(x)+2)
-    assertStructure(
-      q,
-      """
+    public func testUnquote() {
+        let x = #quote(40)
+        let q = #quote(#unquote(x)+2)
+        assertStructure(
+            q,
+            """
       Binary(
         Unquote(
           Name(
@@ -1267,18 +1268,18 @@ public final class StructureTests: XCTestCase {
           TypeName("Int", "s:Si")),
         TypeName("Int", "s:Si"))
       """
-    )
-  }
+        )
+    }
 
-  public func testVarargs() {
-    testCall1()
-  }
+    public func testVarargs() {
+        testCall1()
+    }
 
-  public func testWildcard() {
-    let q = #quote(_ = 42)
-    assertStructure(
-      q,
-      """
+    public func testWildcard() {
+        let q = #quote(_ = 42)
+        assertStructure(
+            q,
+            """
       Assign(
         Wildcard(),
         IntegerLiteral(
@@ -1287,18 +1288,18 @@ public final class StructureTests: XCTestCase {
         TupleType(
           []))
       """
-    )
-  }
+        )
+    }
 
-  public func testFunction() {
-    // TODO(TF-724): Find out how to conveniently test this.
-  }
+    public func testFunction() {
+        // TODO(TF-724): Find out how to conveniently test this.
+    }
 
-  public func testLet() {
-    let q = #quote{ let x = 42 }
-    assertStructure(
-      q,
-      """
+    public func testLet() {
+        let q = #quote{ let x = 42 }
+        assertStructure(
+            q,
+            """
       Closure(
         [],
         [Let(
@@ -1315,18 +1316,18 @@ public final class StructureTests: XCTestCase {
           TupleType(
             [])))
       """
-    )
-  }
+        )
+    }
 
-  public func testParameter() {
-    testClosure()
-  }
+    public func testParameter() {
+        testClosure()
+    }
 
-  public func testVar() {
-    let q = #quote{ var x = 42 }
-    assertStructure(
-      q,
-      """
+    public func testVar() {
+        let q = #quote{ var x = 42 }
+        assertStructure(
+            q,
+            """
       Closure(
         [],
         [Var(
@@ -1343,14 +1344,14 @@ public final class StructureTests: XCTestCase {
           TupleType(
             [])))
       """
-    )
-  }
+        )
+    }
 
-  public func test29() {
-    let q = #quote(1...10)
-    assertStructure(
-      q,
-      """
+    public func test29() {
+        let q = #quote(1...10)
+        assertStructure(
+            q,
+            """
       Binary(
         IntegerLiteral(
           1,
@@ -1372,16 +1373,16 @@ public final class StructureTests: XCTestCase {
           TypeName("ClosedRange", "s:SN"),
           [TypeName("Int", "s:Si")]))
       """
-    )
-  }
+        )
+    }
 
-  public func test30() {
-    let x = 42
-    blackHole(x)
-    let q = #quote(Float(x))
-    assertStructure(
-      q,
-      """
+    public func test30() {
+        let x = 42
+        blackHole(x)
+        let q = #quote(Float(x))
+        assertStructure(
+            q,
+            """
       Call(
         Name(
           "Float",
@@ -1397,86 +1398,86 @@ public final class StructureTests: XCTestCase {
           TypeName("Int", "s:Si"))],
         TypeName("Float", "s:Sf"))
       """
-    )
-  }
+        )
+    }
 
-  private func blackHole(_ x: Any) {
-    // This method exists to silence unused variable warnings.
-    // TODO(TF-728): Get rid of this method.
-  }
+    private func blackHole(_ x: Any) {
+        // This method exists to silence unused variable warnings.
+        // TODO(TF-728): Get rid of this method.
+    }
 
-  public static let allTests = [
-    ("testDifferentiable", testDifferentiable),
-    ("testAndType", testAndType),
-    ("testArrayType", testArrayType),
-    ("testDictionaryType", testDictionaryType),
-    ("testFunctionType", testFunctionType),
-    ("testInOutType", testInOutType),
-    ("testLValueType", testLValueType),
-    ("testMetaType", testMetaType),
-    ("testOptionalType", testOptionalType),
-    ("testSpecializedType", testSpecializedType),
-    ("testTupleType", testTupleType),
-    ("testTypeName", testTypeName),
-    ("testBreak", testBreak),
-    ("testContinue", testContinue),
-    ("testDefer", testDefer),
-    ("testDo", testDo),
-    ("testFor", testFor),
-    ("testGuard", testGuard),
-    ("testIf", testIf),
-    ("testRepeat", testRepeat),
-    ("testReturn", testReturn),
-    ("testThrow", testThrow),
-    ("testWhile", testWhile),
-    ("testArrayLiteral", testArrayLiteral),
-    ("testAs", testAs),
-    ("testAssign", testAssign),
-    ("testBinary", testBinary),
-    ("testBooleanLiteral", testBooleanLiteral),
-    ("testCall1", testCall1),
-    ("testCall2", testCall2),
-    ("testClosure", testClosure),
-    ("testConversion", testConversion),
-    ("testDefault", testDefault),
-    ("testDictionaryLiteral", testDictionaryLiteral),
-    ("testFloatLiteral", testFloatLiteral),
-    ("testForce", testForce),
-    ("testForceAs", testForceAs),
-    ("testForceTry", testForceTry),
-    ("testInout", testInout),
-    ("testIntegerLiteral", testIntegerLiteral),
-    ("testIs", testIs),
-    ("testMagicLiteral", testMagicLiteral),
-    ("testMember1", testMember1),
-    ("testMember2", testMember2),
-    ("testMember3", testMember3),
-    ("testMember4", testMember4),
-    ("testMeta", testMeta),
-    ("testName", testName),
-    ("testNilLiteral", testNilLiteral),
-    ("testOptionalAs", testOptionalAs),
-    ("testOptionalTry", testOptionalTry),
-    ("testPostfix", testPostfix),
-    ("testPostfixSelf1", testPostfixSelf1),
-    ("testPostfixSelf2", testPostfixSelf2),
-    ("testPrefix", testPrefix),
-    ("testStringInterpolation", testStringInterpolation),
-    ("testStringLiteral", testStringLiteral),
-    ("testSubscript", testSubscript),
-    ("testSuper", testSuper),
-    ("testTernary", testTernary),
-    ("testTry", testTry),
-    ("testTuple", testTuple),
-    ("testTupleElement", testTupleElement),
-    ("testUnquote", testUnquote),
-    ("testVarargs", testVarargs),
-    ("testWildcard", testWildcard),
-    ("testFunction", testFunction),
-    ("testLet", testLet),
-    ("testParameter", testParameter),
-    ("testVar", testVar),
-    ("test29", test29),
-    ("test30", test30),
-  ]
+    public static let allTests = [
+        ("testDifferentiable", testDifferentiable),
+        ("testAndType", testAndType),
+        ("testArrayType", testArrayType),
+        ("testDictionaryType", testDictionaryType),
+        ("testFunctionType", testFunctionType),
+        ("testInOutType", testInOutType),
+        ("testLValueType", testLValueType),
+        ("testMetaType", testMetaType),
+        ("testOptionalType", testOptionalType),
+        ("testSpecializedType", testSpecializedType),
+        ("testTupleType", testTupleType),
+        ("testTypeName", testTypeName),
+        ("testBreak", testBreak),
+        ("testContinue", testContinue),
+        ("testDefer", testDefer),
+        ("testDo", testDo),
+        ("testFor", testFor),
+        ("testGuard", testGuard),
+        ("testIf", testIf),
+        ("testRepeat", testRepeat),
+        ("testReturn", testReturn),
+        ("testThrow", testThrow),
+        ("testWhile", testWhile),
+        ("testArrayLiteral", testArrayLiteral),
+        ("testAs", testAs),
+        ("testAssign", testAssign),
+        ("testBinary", testBinary),
+        ("testBooleanLiteral", testBooleanLiteral),
+        ("testCall1", testCall1),
+        ("testCall2", testCall2),
+        ("testClosure", testClosure),
+        ("testConversion", testConversion),
+        ("testDefault", testDefault),
+        ("testDictionaryLiteral", testDictionaryLiteral),
+        ("testFloatLiteral", testFloatLiteral),
+        ("testForce", testForce),
+        ("testForceAs", testForceAs),
+        ("testForceTry", testForceTry),
+        ("testInout", testInout),
+        ("testIntegerLiteral", testIntegerLiteral),
+        ("testIs", testIs),
+        ("testMagicLiteral", testMagicLiteral),
+        ("testMember1", testMember1),
+        ("testMember2", testMember2),
+        ("testMember3", testMember3),
+        ("testMember4", testMember4),
+        ("testMeta", testMeta),
+        ("testName", testName),
+        ("testNilLiteral", testNilLiteral),
+        ("testOptionalAs", testOptionalAs),
+        ("testOptionalTry", testOptionalTry),
+        ("testPostfix", testPostfix),
+        ("testPostfixSelf1", testPostfixSelf1),
+        ("testPostfixSelf2", testPostfixSelf2),
+        ("testPrefix", testPrefix),
+        ("testStringInterpolation", testStringInterpolation),
+        ("testStringLiteral", testStringLiteral),
+        ("testSubscript", testSubscript),
+        ("testSuper", testSuper),
+        ("testTernary", testTernary),
+        ("testTry", testTry),
+        ("testTuple", testTuple),
+        ("testTupleElement", testTupleElement),
+        ("testUnquote", testUnquote),
+        ("testVarargs", testVarargs),
+        ("testWildcard", testWildcard),
+        ("testFunction", testFunction),
+        ("testLet", testLet),
+        ("testParameter", testParameter),
+        ("testVar", testVar),
+        ("test29", test29),
+        ("test30", test30),
+    ]
 }

--- a/Tests/QuoteTests/StructureTests.swift
+++ b/Tests/QuoteTests/StructureTests.swift
@@ -1,0 +1,1482 @@
+import Quote
+import XCTest
+
+public final class StructureTests: XCTestCase {
+  public func testDifferentiable() {
+    // NOTE: At the moment, this leads to a runtime crash.
+    // let fn: @differentiable (Float) -> Float = { x in x }
+    // blackHole(fn)
+    // let q = #quote(fn)
+    func fn() -> @differentiable (Float) -> Float { fatalError("") }
+    let q = #quote(fn())
+    assertStructure(
+      q.type,
+      """
+      FunctionType(
+        [Differentiable()],
+        [TypeName("Float", "s:Sf")],
+        TypeName("Float", "s:Sf"))
+      """
+    )
+  }
+
+  public func testAndType() {
+    func f() -> A & B { fatalError("implement me"); }
+    let q = #quote(f())
+    assertStructure(
+      q.type,
+      """
+      AndType(
+        [TypeName("A", "<unstable USR>"),
+        TypeName("B", "<unstable USR>")])
+      """
+    )
+  }
+
+  public func testArrayType() {
+    let x = [1, 2, 3]
+    blackHole(x)
+    let q = #quote(x)
+    assertStructure(
+      q.type,
+      """
+      ArrayType(
+        TypeName("Int", "s:Si"))
+      """)
+  }
+
+  public func testDictionaryType() {
+    let x = [40: 2]
+    blackHole(x)
+    let q = #quote(x)
+    assertStructure(
+      q.type,
+      """
+      DictionaryType(
+        TypeName("Int", "s:Si"),
+        TypeName("Int", "s:Si"))
+      """
+    )
+  }
+
+  public func testFunctionType() {
+    let x = { (x: Int) in
+      x
+    }
+    blackHole(x)
+    let q = #quote(x)
+    assertStructure(
+      q.type,
+      """
+      FunctionType(
+        [],
+        [TypeName("Int", "s:Si")],
+        TypeName("Int", "s:Si"))
+      """
+    )
+  }
+
+  public func testInOutType() {
+    let q = #quote{ (x: inout Int) in
+      x
+    }
+    assertStructure(
+      q.type,
+      """
+      FunctionType(
+        [],
+        [InoutType(
+          TypeName("Int", "s:Si"))],
+        TypeName("Int", "s:Si"))
+      """
+    )
+  }
+
+  public func testLValueType() {
+    func foo(_ x: inout Int) {
+      let q = #quote{ let y = x }
+      assertStructure(
+        q,
+        """
+        Closure(
+          [],
+          [Let(
+            Name(
+              "y",
+              "<unstable USR>",
+              TypeName("Int", "s:Si")),
+            Conversion(
+              Name(
+                "x",
+                "<unstable USR>",
+                LValueType(
+                  TypeName("Int", "s:Si"))),
+              TypeName("Int", "s:Si")))],
+          FunctionType(
+            [],
+            [],
+            TupleType(
+              [])))
+        """
+      )
+    }
+    var x = 2
+    foo(&x)
+  }
+
+  public func testMetaType() {
+    let x = Int.self
+    blackHole(x)
+    let q = #quote(x)
+    assertStructure(
+      q.type,
+      """
+      MetaType(
+        TypeName("Int", "s:Si"))
+      """
+    )
+  }
+
+  public func testOptionalType() {
+    let x: Int? = 42
+    blackHole(x ?? 42)
+    let q = #quote(x)
+    assertStructure(
+      q.type,
+      """
+      OptionalType(
+        TypeName("Int", "s:Si"))
+      """
+    )
+  }
+
+  public func testSpecializedType() {
+    let x: ClosedRange<Int> = 1...10
+    blackHole(x)
+    let q = #quote(x)
+    assertStructure(
+      q.type,
+      """
+      SpecializedType(
+        TypeName("ClosedRange", "s:SN"),
+        [TypeName("Int", "s:Si")])
+      """
+    )
+  }
+
+  public func testTupleType() {
+    let x = (1, "2", 3)
+    blackHole(x)
+    let q = #quote(x)
+    assertStructure(
+      q.type,
+      """
+      TupleType(
+        [TypeName("Int", "s:Si"),
+        TypeName("String", "s:SS"),
+        TypeName("Int", "s:Si")])
+      """
+    )
+  }
+
+  public func testTypeName() {
+    let x = 42
+    blackHole(x)
+    let q = #quote(x)
+    assertStructure(
+      q.type,
+      """
+      TypeName("Int", "s:Si")
+      """)
+  }
+
+  public func testBreak() {
+    let q = #quote{
+      while true {
+        break
+      }
+    }
+    assertStructure(
+      q,
+      """
+      Closure(
+        [],
+        [While(
+          nil,
+          [BooleanLiteral(
+            true,
+            TypeName("Bool", "s:Sb"))],
+          [Break(
+            nil)])],
+        FunctionType(
+          [],
+          [],
+          TupleType(
+            [])))
+      """
+    )
+  }
+
+  public func testContinue() {
+    let q = #quote{
+      while true {
+        continue
+      }
+    }
+    assertStructure(
+      q,
+      """
+      Closure(
+        [],
+        [While(
+          nil,
+          [BooleanLiteral(
+            true,
+            TypeName("Bool", "s:Sb"))],
+          [Continue(
+            nil)])],
+        FunctionType(
+          [],
+          [],
+          TupleType(
+            [])))
+      """
+    )
+  }
+
+  public func testDefer() {
+    let q = #quote{
+      defer {}
+      return
+    }
+    assertStructure(
+      q,
+      """
+      Closure(
+        [],
+        [Defer(
+          []),
+        Return(
+          Tuple(
+            [],
+            [],
+            TupleType(
+              [])))],
+        FunctionType(
+          [],
+          [],
+          TupleType(
+            [])))
+      """
+    )
+  }
+
+  public func testDo() {
+    let q = #quote{
+      do {}
+    }
+    assertStructure(
+      q,
+      """
+      Closure(
+        [],
+        [Do(
+          nil,
+          [])],
+        FunctionType(
+          [],
+          [],
+          TupleType(
+            [])))
+      """
+    )
+  }
+
+  public func testFor() {
+    let range = 1...10
+    blackHole(range)
+    let q = #quote{
+      for i in range {}
+    }
+    assertStructure(
+      q,
+      """
+      Closure(
+        [],
+        [For(
+          nil,
+          Name(
+            "i",
+            "<unstable USR>",
+            TypeName("Int", "s:Si")),
+          Name(
+            "range",
+            "<unstable USR>",
+            SpecializedType(
+              TypeName("ClosedRange", "s:SN"),
+              [TypeName("Int", "s:Si")])),
+          [])],
+        FunctionType(
+          [],
+          [],
+          TupleType(
+            [])))
+      """
+    )
+  }
+
+  public func testGuard() {
+    let q = #quote{
+      guard true else {}
+    }
+    assertStructure(
+      q,
+      """
+      Closure(
+        [],
+        [Guard(
+          [BooleanLiteral(
+            true,
+            TypeName("Bool", "s:Sb"))],
+          [])],
+        FunctionType(
+          [],
+          [],
+          TupleType(
+            [])))
+      """
+    )
+  }
+
+  public func testIf() {
+    let q = #quote{
+      if true {} else if false {} else {}
+    }
+    assertStructure(
+      q,
+      """
+      Closure(
+        [],
+        [If(
+          nil,
+          [BooleanLiteral(
+            true,
+            TypeName("Bool", "s:Sb"))],
+          [],
+          [If(
+            nil,
+            [BooleanLiteral(
+              false,
+              TypeName("Bool", "s:Sb"))],
+            [],
+            [])])],
+        FunctionType(
+          [],
+          [],
+          TupleType(
+            [])))
+      """
+    )
+  }
+
+  public func testRepeat() {
+    let q = #quote{
+      repeat {} while true
+    }
+    assertStructure(
+      q,
+      """
+      Closure(
+        [],
+        [Repeat(
+          nil,
+          [],
+          BooleanLiteral(
+            true,
+            TypeName("Bool", "s:Sb")))],
+        FunctionType(
+          [],
+          [],
+          TupleType(
+            [])))
+      """
+    )
+  }
+
+  public func testReturn() {
+    let q = #quote{ () in
+      return
+    }
+    assertStructure(
+      q,
+      """
+      Closure(
+        [],
+        [Return(
+          Tuple(
+            [],
+            [],
+            TupleType(
+              [])))],
+        FunctionType(
+          [],
+          [],
+          TupleType(
+            [])))
+      """
+    )
+  }
+
+  public func testThrow() {
+    let q = #quote{
+      throw X()
+    }
+    assertStructure(
+      q,
+      """
+      Closure(
+        [],
+        [Throw(
+          Conversion(
+            Call(
+              Name(
+                "X",
+                "<unstable USR>",
+                FunctionType(
+                  [],
+                  [],
+                  TypeName("X", "<unstable USR>"))),
+              [],
+              [],
+              TypeName("X", "<unstable USR>")),
+            TypeName("Error", "s:s5ErrorP")))],
+        FunctionType(
+          [],
+          [],
+          TupleType(
+            [])))
+      """
+    )
+  }
+
+  public func testWhile() {
+    let q = #quote{
+      while true {}
+    }
+    assertStructure(
+      q,
+      """
+      Closure(
+        [],
+        [While(
+          nil,
+          [BooleanLiteral(
+            true,
+            TypeName("Bool", "s:Sb"))],
+          [])],
+        FunctionType(
+          [],
+          [],
+          TupleType(
+            [])))
+      """
+    )
+  }
+
+  public func testArrayLiteral() {
+    let q = #quote([40, 2])
+    assertStructure(
+      q,
+      """
+      ArrayLiteral(
+        [IntegerLiteral(
+          40,
+          TypeName("Int", "s:Si")),
+        IntegerLiteral(
+          2,
+          TypeName("Int", "s:Si"))],
+        ArrayType(
+          TypeName("Int", "s:Si")))
+      """
+    )
+  }
+
+  public func testAs() {
+    let q = #quote(42 as Int)
+    assertStructure(
+      q,
+      """
+      As(
+        IntegerLiteral(
+          42,
+          TypeName("Int", "s:Si")),
+        TypeName("Int", "s:Si"))
+      """
+    )
+  }
+
+  public func testAssign() {
+    var x = 0
+    x = 42  // TODO(#4): Get rid of this assignment.
+    blackHole(x)
+    let q = #quote(x = 42)
+    assertStructure(
+      q,
+      """
+      Assign(
+        Name(
+          "x",
+          "<unstable USR>",
+          LValueType(
+            TypeName("Int", "s:Si"))),
+        IntegerLiteral(
+          42,
+          TypeName("Int", "s:Si")),
+        TupleType(
+          []))
+      """
+    )
+  }
+
+  public func testBinary() {
+    let q = #quote(40 + 2)
+    assertStructure(
+      q,
+      """
+      Binary(
+        IntegerLiteral(
+          40,
+          TypeName("Int", "s:Si")),
+        Name(
+          "+",
+          "s:Si1poiyS2i_SitFZ",
+          FunctionType(
+            [],
+            [TypeName("Int", "s:Si"),
+            TypeName("Int", "s:Si")],
+            TypeName("Int", "s:Si"))),
+        IntegerLiteral(
+          2,
+          TypeName("Int", "s:Si")),
+        TypeName("Int", "s:Si"))
+      """
+    )
+  }
+
+  public func testBooleanLiteral() {
+    let q = #quote(true)
+    assertStructure(
+      q,
+      """
+      BooleanLiteral(
+        true,
+        TypeName("Bool", "s:Sb"))
+      """)
+  }
+
+  public func testCall1() {
+    let q = #quote(print(42))
+    assertStructure(
+      q,
+      """
+      Call(
+        Name(
+          "print",
+          "s:s5print_9separator10terminatoryypd_S2StF",
+          FunctionType(
+            [],
+            [AndType(
+              []),
+            TypeName("String", "s:SS"),
+            TypeName("String", "s:SS")],
+            TupleType(
+              []))),
+        [nil],
+        [Varargs(
+          [Conversion(
+            IntegerLiteral(
+              42,
+              TypeName("Int", "s:Si")),
+            AndType(
+              []))],
+          ArrayType(
+            AndType(
+              []))),
+        Default(
+          "",
+          TypeName("String", "s:SS")),
+        Default(
+          "",
+          TypeName("String", "s:SS"))],
+        TupleType(
+          []))
+      """
+    )
+  }
+
+  public func testCall2() {
+    let q = #quote(f().m())
+    assertStructure(
+      q,
+      """
+      Call(
+        Member(
+          Call(
+            Name(
+              "f",
+              "<unstable USR>",
+              FunctionType(
+                [],
+                [],
+                TypeName("P", "<unstable USR>"))),
+            [],
+            [],
+            TypeName("P", "<unstable USR>")),
+          "m",
+          "<unstable USR>",
+          FunctionType(
+            [],
+            [],
+            TupleType(
+              []))),
+        [],
+        [],
+        TupleType(
+          []))
+      """
+    )
+  }
+
+  public func testClosure() {
+    let q = #quote{ (x: Int) in
+      x
+    }
+    assertStructure(
+      q,
+      """
+      Closure(
+        [Parameter(
+          nil,
+          Name(
+            "x",
+            "<unstable USR>",
+            TypeName("Int", "s:Si")))],
+        [Return(
+          Name(
+            "x",
+            "<unstable USR>",
+            TypeName("Int", "s:Si")))],
+        FunctionType(
+          [],
+          [TypeName("Int", "s:Si")],
+          TypeName("Int", "s:Si")))
+      """
+    )
+  }
+
+  public func testConversion() {
+    testLValueType()
+  }
+
+  public func testDefault() {
+    testCall1()
+  }
+
+  public func testDictionaryLiteral() {
+    let q = #quote([40: 40, 2: 2])
+    assertStructure(
+      q,
+      """
+      DictionaryLiteral(
+        [IntegerLiteral(
+          40,
+          TypeName("Int", "s:Si")),
+        IntegerLiteral(
+          40,
+          TypeName("Int", "s:Si")),
+        IntegerLiteral(
+          2,
+          TypeName("Int", "s:Si")),
+        IntegerLiteral(
+          2,
+          TypeName("Int", "s:Si"))],
+        DictionaryType(
+          TypeName("Int", "s:Si"),
+          TypeName("Int", "s:Si")))
+      """
+    )
+  }
+
+  public func testFloatLiteral() {
+    let q = #quote(42.0)
+    assertStructure(
+      q,
+      """
+      FloatLiteral(
+        42.0,
+        TypeName("Double", "s:Sd"))
+      """)
+  }
+
+  public func testForce() {
+    let x: Int? = 42
+    blackHole(x ?? 42)
+    let q = #quote(x!)
+    assertStructure(
+      q,
+      """
+      Force(
+        Name(
+          "x",
+          "<unstable USR>",
+          OptionalType(
+            TypeName("Int", "s:Si"))),
+        TypeName("Int", "s:Si"))
+      """
+    )
+  }
+
+  public func testForceAs() {
+    let x: Any = 42
+    blackHole(x)
+    let q = #quote(x as! Int)
+    assertStructure(
+      q,
+      """
+      ForceAs(
+        Name(
+          "x",
+          "<unstable USR>",
+          AndType(
+            [])),
+        TypeName("Int", "s:Si"))
+      """
+    )
+  }
+
+  public func testForceTry() {
+    let q = #quote(try! 42)
+    assertStructure(
+      q,
+      """
+      ForceTry(
+        IntegerLiteral(
+          42,
+          TypeName("Int", "s:Si")),
+        TypeName("Int", "s:Si"))
+      """
+    )
+  }
+
+  public func testInout() {
+    func foo(_ x: inout Int) {}
+    var x = 0
+    blackHole(x)
+    x = 42  // TODO(#4): Get rid of this assignment.
+    let q = #quote(foo(&x))
+    assertStructure(
+      q,
+      """
+      Call(
+        Name(
+          "foo",
+          "<unstable USR>",
+          FunctionType(
+            [],
+            [InoutType(
+              TypeName("Int", "s:Si"))],
+            TupleType(
+              []))),
+        [nil],
+        [InOut(
+          Name(
+            "x",
+            "<unstable USR>",
+            LValueType(
+              TypeName("Int", "s:Si"))),
+          InoutType(
+            TypeName("Int", "s:Si")))],
+        TupleType(
+          []))
+      """
+    )
+  }
+
+  public func testIntegerLiteral() {
+    let q = #quote(42)
+    assertStructure(
+      q,
+      """
+      IntegerLiteral(
+        42,
+        TypeName("Int", "s:Si"))
+      """)
+  }
+
+  public func testIs() {
+    let x: Any = 42
+    blackHole(x)
+    let q = #quote(x is Int)
+    assertStructure(
+      q,
+      """
+      Is(
+        Name(
+          "x",
+          "<unstable USR>",
+          AndType(
+            [])),
+        TypeName("Int", "s:Si"),
+        TypeName("Bool", "s:Sb"))
+      """
+    )
+  }
+
+  public func testMagicLiteral() {
+    let q1 = #quote(#file)
+    assertStructure(
+      q1,
+      """
+      MagicLiteral(
+        "file",
+        TypeName("String", "s:SS"))
+      """)
+
+    let q2 = #quote(#line)
+    assertStructure(
+      q2,
+      """
+      MagicLiteral(
+        "line",
+        TypeName("Int", "s:Si"))
+      """)
+
+    let q3 = #quote(#column)
+    assertStructure(
+      q3,
+      """
+      MagicLiteral(
+        "column",
+        TypeName("Int", "s:Si"))
+      """)
+
+    let q4 = #quote(#function)
+    assertStructure(
+      q4,
+      """
+      MagicLiteral(
+        "function",
+        TypeName("String", "s:SS"))
+      """)
+
+    let q5 = #quote(#dsohandle)
+    assertStructure(
+      q5,
+      """
+      MagicLiteral(
+        "dsohandle",
+        TypeName("UnsafeRawPointer", "s:SV"))
+      """
+    )
+  }
+
+  public func testMember1() {
+    let x = [1, 2, 3]
+    blackHole(x)
+    let q = #quote(x.count)
+    assertStructure(
+      q,
+      """
+      Member(
+        Name(
+          "x",
+          "<unstable USR>",
+          ArrayType(
+            TypeName("Int", "s:Si"))),
+        "count",
+        "s:Sa5countSivp",
+        TypeName("Int", "s:Si"))
+      """
+    )
+  }
+
+  public func testMember2() {
+    let q = #quote(Context.local)
+    assertStructure(
+      q,
+      """
+      Name(
+        "local",
+        "<unstable USR>",
+        TypeName("Context", "<unstable USR>"))
+      """
+    )
+  }
+
+  public func testMember3() {
+    let q = #quote(E.a)
+    assertStructure(
+      q,
+      """
+      Name(
+        "a",
+        "<unstable USR>",
+        TypeName("E", "<unstable USR>"))
+      """
+    )
+  }
+
+  public func testMember4() {
+    let q = #quote(g())
+    assertStructure(
+      q,
+      """
+      Call(
+        Name(
+          "g",
+          "<unstable USR>",
+          FunctionType(
+            [],
+            [],
+            TupleType(
+              []))),
+        [],
+        [],
+        TupleType(
+          []))
+      """
+    )
+  }
+
+  public func testMeta() {
+    let q = #quote(#quote(42))
+    assertStructure(
+      q,
+      """
+      Meta(
+        IntegerLiteral(
+          42,
+          TypeName("Int", "s:Si")),
+        SpecializedType(
+          TypeName("Quote", "s:5QuoteAAC"),
+          [TypeName("Int", "s:Si")]))
+      """
+    )
+  }
+
+  public func testName() {
+    let x = 42
+    blackHole(x)
+    let q = #quote(x)
+    assertStructure(
+      q,
+      """
+      Name(
+        "x",
+        "<unstable USR>",
+        TypeName("Int", "s:Si"))
+      """
+    )
+  }
+
+  public func testNilLiteral() {
+    let q = #quote(nil as Int?)
+    assertStructure(
+      q,
+      """
+      As(
+        NilLiteral(
+          OptionalType(
+            TypeName("Int", "s:Si"))),
+        OptionalType(
+          TypeName("Int", "s:Si")))
+      """
+    )
+  }
+
+  public func testOptionalAs() {
+    let x: Any = 42
+    blackHole(x)
+    let q = #quote(x as? Int)
+    assertStructure(
+      q,
+      """
+      OptionalAs(
+        Name(
+          "x",
+          "<unstable USR>",
+          AndType(
+            [])),
+        TypeName("Int", "s:Si"),
+        OptionalType(
+          TypeName("Int", "s:Si")))
+      """
+    )
+  }
+
+  public func testOptionalTry() {
+    let q = #quote(try? 42)
+    assertStructure(
+      q,
+      """
+      OptionalTry(
+        IntegerLiteral(
+          42,
+          TypeName("Int", "s:Si")),
+        OptionalType(
+          TypeName("Int", "s:Si")))
+      """
+    )
+  }
+
+  public func testPostfix() {
+    // TODO(#3): Find out how to conveniently test this.
+  }
+
+  public func testPostfixSelf1() {
+    let q = #quote(42.self)
+    assertStructure(
+      q,
+      """
+      PostfixSelf(
+        IntegerLiteral(
+          42,
+          TypeName("Int", "s:Si")),
+        TypeName("Int", "s:Si"))
+      """
+    )
+  }
+
+  public func testPostfixSelf2() {
+    let q = #quote(Int.self)
+    assertStructure(
+      q,
+      """
+      PostfixSelf(
+        TypeName("Int", "s:Si"),
+        MetaType(
+          TypeName("Int", "s:Si")))
+      """
+    )
+  }
+
+  public func testPrefix() {
+    let q = #quote(+42)
+    assertStructure(
+      q,
+      """
+      Prefix(
+        Name(
+          "+",
+          "s:s18AdditiveArithmeticPsE1popyxxFZ",
+          FunctionType(
+            [],
+            [TypeName("Int", "s:Si")],
+            TypeName("Int", "s:Si"))),
+        IntegerLiteral(
+          42,
+          TypeName("Int", "s:Si")),
+        TypeName("Int", "s:Si"))
+      """
+    )
+  }
+
+  public func testStringInterpolation() {
+    let x = 42
+    blackHole(x)
+    let q = #quote("x = \(x)")
+    assertStructure(
+      q,
+      """
+      StringInterpolation(
+        TypeName("String", "s:SS"))
+      """)
+  }
+
+  public func testStringLiteral() {
+    let q = #quote("42")
+    assertStructure(
+      q,
+      """
+      StringLiteral(
+        "42",
+        TypeName("String", "s:SS"))
+      """)
+  }
+
+  public func testSubscript() {
+    let x = [1, 2, 3]
+    blackHole(x)
+    let q = #quote(x[0])
+    assertStructure(
+      q,
+      """
+      Subscript(
+        Name(
+          "x",
+          "<unstable USR>",
+          ArrayType(
+            TypeName("Int", "s:Si"))),
+        "s:SayxSicip",
+        [nil],
+        [IntegerLiteral(
+          0,
+          TypeName("Int", "s:Si"))],
+        TypeName("Int", "s:Si"))
+      """
+    )
+  }
+
+  public func testSuper() {
+    class C {
+      func p() {}
+    }
+    class D: C {
+      func q() {
+        let q = #quote(super.p())
+        assertStructure(
+          q,
+          """
+          Call(
+            Member(
+              Super(
+                TypeName("C", "<unstable USR>")),
+              "p",
+              "<unstable USR>",
+              FunctionType(
+                [],
+                [],
+                TupleType(
+                  []))),
+            [],
+            [],
+            TupleType(
+              []))
+          """
+        )
+      }
+    }
+    D().q()
+  }
+
+  public func testTernary() {
+    let q = #quote(true ? 40 : 2)
+    assertStructure(
+      q,
+      """
+      Ternary(
+        BooleanLiteral(
+          true,
+          TypeName("Bool", "s:Sb")),
+        IntegerLiteral(
+          40,
+          TypeName("Int", "s:Si")),
+        IntegerLiteral(
+          2,
+          TypeName("Int", "s:Si")),
+        TypeName("Int", "s:Si"))
+      """
+    )
+  }
+
+  public func testTry() {
+    let q = #quote(try 42)
+    assertStructure(
+      q,
+      """
+      Try(
+        IntegerLiteral(
+          42,
+          TypeName("Int", "s:Si")),
+        TypeName("Int", "s:Si"))
+      """
+    )
+  }
+
+  public func testTuple() {
+    let q = #quote((1, "2", 3))
+    assertStructure(
+      q,
+      """
+      Tuple(
+        [],
+        [IntegerLiteral(
+          1,
+          TypeName("Int", "s:Si")),
+        StringLiteral(
+          "2",
+          TypeName("String", "s:SS")),
+        IntegerLiteral(
+          3,
+          TypeName("Int", "s:Si"))],
+        TupleType(
+          [TypeName("Int", "s:Si"),
+          TypeName("String", "s:SS"),
+          TypeName("Int", "s:Si")]))
+      """
+    )
+  }
+
+  public func testTupleElement() {
+    let q = #quote((1, 2).1)
+    assertStructure(
+      q,
+      """
+      TupleElement(
+        Tuple(
+          [],
+          [IntegerLiteral(
+            1,
+            TypeName("Int", "s:Si")),
+          IntegerLiteral(
+            2,
+            TypeName("Int", "s:Si"))],
+          UnknownTree()),
+        1,
+        TypeName("Int", "s:Si"))
+      """
+    )
+  }
+
+  public func testUnquote() {
+    let x = #quote(40)
+    let q = #quote(#unquote(x)+2)
+    assertStructure(
+      q,
+      """
+      Binary(
+        Unquote(
+          Name(
+            "x",
+            "<unstable USR>",
+            SpecializedType(
+              TypeName("Quote", "s:5QuoteAAC"),
+              [TypeName("Int", "s:Si")])),
+          40,
+          TypeName("Int", "s:Si")),
+        Name(
+          "+",
+          "s:Si1poiyS2i_SitFZ",
+          FunctionType(
+            [],
+            [TypeName("Int", "s:Si"),
+            TypeName("Int", "s:Si")],
+            TypeName("Int", "s:Si"))),
+        IntegerLiteral(
+          2,
+          TypeName("Int", "s:Si")),
+        TypeName("Int", "s:Si"))
+      """
+    )
+  }
+
+  public func testVarargs() {
+    testCall1()
+  }
+
+  public func testWildcard() {
+    let q = #quote(_ = 42)
+    assertStructure(
+      q,
+      """
+      Assign(
+        Wildcard(),
+        IntegerLiteral(
+          42,
+          TypeName("Int", "s:Si")),
+        TupleType(
+          []))
+      """
+    )
+  }
+
+  public func testFunction() {
+    // TODO(#5): Find out how to conveniently test this.
+  }
+
+  public func testLet() {
+    let q = #quote{ let x = 42 }
+    assertStructure(
+      q,
+      """
+      Closure(
+        [],
+        [Let(
+          Name(
+            "x",
+            "<unstable USR>",
+            TypeName("Int", "s:Si")),
+          IntegerLiteral(
+            42,
+            TypeName("Int", "s:Si")))],
+        FunctionType(
+          [],
+          [],
+          TupleType(
+            [])))
+      """
+    )
+  }
+
+  public func testParameter() {
+    testClosure()
+  }
+
+  public func testVar() {
+    let q = #quote{ var x = 42 }
+    assertStructure(
+      q,
+      """
+      Closure(
+        [],
+        [Var(
+          Name(
+            "x",
+            "<unstable USR>",
+            TypeName("Int", "s:Si")),
+          IntegerLiteral(
+            42,
+            TypeName("Int", "s:Si")))],
+        FunctionType(
+          [],
+          [],
+          TupleType(
+            [])))
+      """
+    )
+  }
+
+  public func test29() {
+    let q = #quote(1...10)
+    assertStructure(
+      q,
+      """
+      Binary(
+        IntegerLiteral(
+          1,
+          TypeName("Int", "s:Si")),
+        Name(
+          "...",
+          "s:SLsE3zzzoiySNyxGx_xtFZ",
+          FunctionType(
+            [],
+            [TypeName("Int", "s:Si"),
+            TypeName("Int", "s:Si")],
+            SpecializedType(
+              TypeName("ClosedRange", "s:SN"),
+              [TypeName("Int", "s:Si")]))),
+        IntegerLiteral(
+          10,
+          TypeName("Int", "s:Si")),
+        SpecializedType(
+          TypeName("ClosedRange", "s:SN"),
+          [TypeName("Int", "s:Si")]))
+      """
+    )
+  }
+
+  public func test30() {
+    let x = 42
+    blackHole(x)
+    let q = #quote(Float(x))
+    assertStructure(
+      q,
+      """
+      Call(
+        Name(
+          "Float",
+          "s:SfySfSicfc",
+          FunctionType(
+            [],
+            [TypeName("Int", "s:Si")],
+            TypeName("Float", "s:Sf"))),
+        [nil],
+        [Name(
+          "x",
+          "<unstable USR>",
+          TypeName("Int", "s:Si"))],
+        TypeName("Float", "s:Sf"))
+      """
+    )
+  }
+
+  private func blackHole(_ x: Any) {
+    // This method exists to silence unused variable warnings.
+    // TODO(#4): Get rid of this method.
+  }
+
+  public static let allTests = [
+    ("testDifferentiable", testDifferentiable),
+    ("testAndType", testAndType),
+    ("testArrayType", testArrayType),
+    ("testDictionaryType", testDictionaryType),
+    ("testFunctionType", testFunctionType),
+    ("testInOutType", testInOutType),
+    ("testLValueType", testLValueType),
+    ("testMetaType", testMetaType),
+    ("testOptionalType", testOptionalType),
+    ("testSpecializedType", testSpecializedType),
+    ("testTupleType", testTupleType),
+    ("testTypeName", testTypeName),
+    ("testBreak", testBreak),
+    ("testContinue", testContinue),
+    ("testDefer", testDefer),
+    ("testDo", testDo),
+    ("testFor", testFor),
+    ("testGuard", testGuard),
+    ("testIf", testIf),
+    ("testRepeat", testRepeat),
+    ("testReturn", testReturn),
+    ("testThrow", testThrow),
+    ("testWhile", testWhile),
+    ("testArrayLiteral", testArrayLiteral),
+    ("testAs", testAs),
+    ("testAssign", testAssign),
+    ("testBinary", testBinary),
+    ("testBooleanLiteral", testBooleanLiteral),
+    ("testCall1", testCall1),
+    ("testCall2", testCall2),
+    ("testClosure", testClosure),
+    ("testConversion", testConversion),
+    ("testDefault", testDefault),
+    ("testDictionaryLiteral", testDictionaryLiteral),
+    ("testFloatLiteral", testFloatLiteral),
+    ("testForce", testForce),
+    ("testForceAs", testForceAs),
+    ("testForceTry", testForceTry),
+    ("testInout", testInout),
+    ("testIntegerLiteral", testIntegerLiteral),
+    ("testIs", testIs),
+    ("testMagicLiteral", testMagicLiteral),
+    ("testMember1", testMember1),
+    ("testMember2", testMember2),
+    ("testMember3", testMember3),
+    ("testMember4", testMember4),
+    ("testMeta", testMeta),
+    ("testName", testName),
+    ("testNilLiteral", testNilLiteral),
+    ("testOptionalAs", testOptionalAs),
+    ("testOptionalTry", testOptionalTry),
+    ("testPostfix", testPostfix),
+    ("testPostfixSelf1", testPostfixSelf1),
+    ("testPostfixSelf2", testPostfixSelf2),
+    ("testPrefix", testPrefix),
+    ("testStringInterpolation", testStringInterpolation),
+    ("testStringLiteral", testStringLiteral),
+    ("testSubscript", testSubscript),
+    ("testSuper", testSuper),
+    ("testTernary", testTernary),
+    ("testTry", testTry),
+    ("testTuple", testTuple),
+    ("testTupleElement", testTupleElement),
+    ("testUnquote", testUnquote),
+    ("testVarargs", testVarargs),
+    ("testWildcard", testWildcard),
+    ("testFunction", testFunction),
+    ("testLet", testLet),
+    ("testParameter", testParameter),
+    ("testVar", testVar),
+    ("test29", test29),
+    ("test30", test30),
+  ]
+}

--- a/Tests/QuoteTests/StructureTests.swift
+++ b/Tests/QuoteTests/StructureTests.swift
@@ -517,7 +517,7 @@ public final class StructureTests: XCTestCase {
 
   public func testAssign() {
     var x = 0
-    x = 42  // TODO(#4): Get rid of this assignment.
+    x = 42  // TODO(TF-728): Get rid of this assignment.
     blackHole(x)
     let q = #quote(x = 42)
     assertStructure(
@@ -772,7 +772,7 @@ public final class StructureTests: XCTestCase {
     func foo(_ x: inout Int) {}
     var x = 0
     blackHole(x)
-    x = 42  // TODO(#4): Get rid of this assignment.
+    x = 42  // TODO(TF-728): Get rid of this assignment.
     let q = #quote(foo(&x))
     assertStructure(
       q,
@@ -1030,7 +1030,7 @@ public final class StructureTests: XCTestCase {
   }
 
   public func testPostfix() {
-    // TODO(#3): Find out how to conveniently test this.
+    // TODO(TF-729): Find out how to conveniently test this.
   }
 
   public func testPostfixSelf1() {
@@ -1291,7 +1291,7 @@ public final class StructureTests: XCTestCase {
   }
 
   public func testFunction() {
-    // TODO(#5): Find out how to conveniently test this.
+    // TODO(TF-724): Find out how to conveniently test this.
   }
 
   public func testLet() {
@@ -1402,7 +1402,7 @@ public final class StructureTests: XCTestCase {
 
   private func blackHole(_ x: Any) {
     // This method exists to silence unused variable warnings.
-    // TODO(#4): Get rid of this method.
+    // TODO(TF-728): Get rid of this method.
   }
 
   public static let allTests = [


### PR DESCRIPTION
Swift works great as an infinitely hackable syntactic interface to
semantics that are defined by the compiler underneath it.
The two options today are LLVM (there's a running joke that Swift is
just syntactic sugar for LLVM) and TensorFlow graphs (which is the
contribution of early versions of Swift for TensorFlow).

Multi-Level Intermediate Representation (MLIR) is a generalization of
both the LLVM IR and TensorFlow graphs to represent arbitrary
computations at multiple levels of abstraction to enable
domain-specific optimizations and code generation (e.g. for CPUs, GPUs,
TPUs, and other hardware targets).

In https://docs.google.com/document/d/1UIPWl4lvBTozBD5OQ9SrxgcM7rA4pODMOjqQv3tm57w/edit,
we've written down some thoughts on several ways to metaprogram MLIR
in Swift - starting from treating MLIR programs as strings and then
gradually increasing the level of language integration with Swift.

Seeking to obtain experimental evaluation of the designs explored
in the document, in this commit, we're introducing an experimental
prototype of quasiquotes, a language feature that allows "quoting"
snippets of code which are then transformed into data structures
available to Swift programs. These data structures can then be used
for all sorts of purposes, including translation to MLIR.

This code doesn't fully implement the theorized design yet, but we
believe that it is already useful for experimentation. We are evaluating
available approaches and garnering community feedback. Please let us
know what you think!