### PR TITLE
Deprecate `Differentiable.AllDifferentiableVariables`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ let (𝛁model, 𝛁input) = model.gradient(at: 2.0) { model, input in
     model.applied(to: input)
 }
 
-print(𝛁model) // Model.AllDifferentiableVariables(w: 2.0, b: 1.0)
+print(𝛁model) // Model.TangentVector(w: 2.0, b: 1.0)
 print(𝛁input) // 4.0
 ```
 


### PR DESCRIPTION
Follow-up to https://github.com/apple/swift/pull/26527.

---

Confirmed code snippet output:

```console
$ cat readme.swift
// Custom differentiable type.
struct Model: Differentiable {
    var w: Float
    var b: Float
    func applied(to input: Float) -> Float {
        return w * input + b
    }
}

// Differentiate using `Differentiable.gradient(at:in:)`.
let model = Model(w: 4.0, b: 3.0)
let (𝛁model, 𝛁input) = model.gradient(at: 2.0) { model, input in
    model.applied(to: input)
}

print(𝛁model) // Model.TangentVector(w: 2.0, b: 1.0)
print(𝛁input) // 4.0

$ swift readme.swift
TangentVector(w: 2.0, b: 1.0)
4.0
```