### PR TITLE
Release 2019-08-08 toolchain for macOS.

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -59,7 +59,7 @@ To install Swift for TensorFlow, download one of the packages below and follow t
 
 | Download | Date |
 |----------|------|
-| [Xcode 11](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2019-07-25-a-osx.pkg) | July 25, 2019 |
+| [Xcode 11](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2019-08-08-a-osx.pkg) | August 8, 2019 |
 | [Ubuntu 18.04 (CPU Only)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-ubuntu18.04.tar.gz) | Nightly |
 | [Ubuntu 18.04 (CUDA 10.0)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda10.0-cudnn7-ubuntu18.04.tar.gz) | Nightly |
 | [Ubuntu 18.04 (CUDA 9.2)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda9.2-cudnn7-ubuntu18.04.tar.gz) | Nightly |
@@ -68,6 +68,12 @@ To install Swift for TensorFlow, download one of the packages below and follow t
   <summary>Older Packages</summary>
 
 ### Xcode
+
+#### Xcode 11
+
+| Download |
+|----------|
+| [July 25, 2019](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2019-07-25-a-osx.pkg) |
 
 #### Xcode 10
 


### PR DESCRIPTION
https://github.com/apple/swift/commit/083af3784e1b369b787c7af9b6ba5814bdf489a2

Note: toolchain is locally signed, not Google-signed, to work around https://github.com/tensorflow/swift/issues/222.
No progress on Google signing for Catalina.