### PR TITLE
Temporarily disable InstructionTests.swift on Linux

### DIFF
--- a/Tests/SILTests/InstructionTests.swift
+++ b/Tests/SILTests/InstructionTests.swift
@@ -1,4 +1,6 @@
 // TODO(TF-764): Make sure that libSIL tests run on Linux.
+// At the moment, InstructionTests use a macOS-only trick to dynamically generate test cases.
+// That not just doesn't work on Linux but also doesn't compile.
 #if os(macOS)
 import XCTest
 @testable import SIL

--- a/Tests/SILTests/InstructionTests.swift
+++ b/Tests/SILTests/InstructionTests.swift
@@ -1,3 +1,5 @@
+// TODO(TF-764): Make sure that libSIL tests run on Linux.
+#if os(macOS)
 import XCTest
 @testable import SIL
 
@@ -83,3 +85,4 @@ final class InstructionTests: XCTestCase {
         return testSuite
     }
 }
+#endif


### PR DESCRIPTION
InstructionTests don't build on Linux, and that currently blocks
libQuote (https://bugs.swift.org/browse/TF-762).

As a result, I'm excluding that file from being compiled on Linux
and opening a ticket to address that (https://bugs.swift.org/browse/TF-764).