### PR TITLE
Add tiny changes to model_training_walkthrough.ipynb

### DIFF
--- a/docs/site/tutorials/model_training_walkthrough.ipynb
+++ b/docs/site/tutorials/model_training_walkthrough.ipynb
@@ -7,7 +7,7 @@
     "id": "QyCcF45zBQ3E"
    },
    "source": [
-    "##### Copyright 2018 The TensorFlow Authors. [Licensed under the Apache License, Version 2.0](#scrollTo=y_UVSRtBBsJk)."
+    "##### Copyright 2019 The TensorFlow Authors. [Licensed under the Apache License, Version 2.0](#scrollTo=y_UVSRtBBsJk)."
    ]
   },
   {
@@ -836,7 +836,7 @@
     "  </td></tr>\n",
     "</table>\n",
     "\n",
-    "Swift for TensorFlow has many [optimization algorithms](https://github.com/rxwei/DeepLearning/blob/master/Sources/DeepLearning/Optimizer.swift) available for training. This model uses the SGD optimizer that implements the *[stochastic gradient descent](https://developers.google.com/machine-learning/crash-course/glossary#gradient_descent)* (SGD) algorithm. The `learningRate` sets the step size to take for each iteration down the hill. This is a *hyperparameter* that you'll commonly adjust to achieve better results."
+    "Swift for TensorFlow has many [optimization algorithms](https://github.com/rxwei/DeepLearning/blob/master/Sources/DeepLearning/Optimizer.swift) available for training. This model uses the SGD optimizer that implements the *[stochastic gradient descent](https://developers.google.com/machine-learning/crash-course/glossary#gradient_descent)* (SGD) algorithm. The `learningRate` sets the step size to take for each iteration down the hill. This is a *[hyperparameter](https://developers.google.com/machine-learning/glossary/#hyperparameter)* that you'll commonly adjust to achieve better results."
    ]
   },
   {
@@ -972,7 +972,7 @@
     "5. Keep track of some stats for visualization.\n",
     "6. Repeat for each epoch.\n",
     "\n",
-    "The `epochCount` variable is the number of times to loop over the dataset collection. Counter-intuitively, training a model longer does not guarantee a better model. `epochCount` is a *[hyperparameter](https://developers.google.com/machine-learning/glossary/#hyperparameter)* that you can tune. Choosing the right number usually requires both experience and experimentation."
+    "The `epochCount` variable is the number of times to loop over the dataset collection. Counter-intuitively, training a model longer does not guarantee a better model. `epochCount` is a *[hyperparameter]* that you can tune. Choosing the right number usually requires both experience and experimentation."
    ]
   },
   {
@@ -1048,7 +1048,7 @@
     "    trainAccuracyResults.append(epochAccuracy)\n",
     "    trainLossResults.append(epochLoss)\n",
     "    if epoch % 50 == 0 {\n",
-    "        print(\"Epoch \\(epoch): Loss: \\(epochLoss), Accuracy: \\(epochAccuracy)\")\n",
+    "        print(\"Epoch: \\(epoch) Loss: \\(epochLoss), Accuracy: \\(epochAccuracy)\")\n",
     "    }\n",
     "}"
    ]


### PR DESCRIPTION
Tiny changes, barely noticeable.

P.S. Assuming `allDifferentiableVariables` will be deprecated later here, as it currently won't run without it in Google Colab after installing the latest Swift4TF version.