### PR TITLE
Allow selectively skipping certain groups of tests on Linux

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,12 +2,18 @@ import QuoteTests
 import SILTests
 import XCTest
 
-let tests = [
-    // QuoteTests
+#if !SKIP_QUOTE_TESTS
+let quoteTests = [
     testCase(CompilationTests.allTests),
     testCase(QuoteTests.DescriptionTests.allTests),
     testCase(StructureTests.allTests),
-    // SILTests
+]
+#else
+let quoteTests = [XCTestCaseEntry]()
+#endif
+
+#if !SKIP_SIL_TESTS
+let silTests = [
     testCase(BitcodeTests.allTests),
     testCase(BitsTests.allTests),
     testCase(BitstreamTests.allTests),
@@ -16,4 +22,9 @@ let tests = [
     testCase(ModuleTests.allTests),
     testCase(PrinterTests.allTests),
 ]
+#else
+let silTests = [XCTestCaseEntry]()
+#endif
+
+let tests = quoteTests + silTests
 XCTMain(tests)


### PR DESCRIPTION
This is necessary for Google3 import where Quote and SIL are
imported as two different libraries.

By default, both Quote and SIL tests are running. If necessary, either
group of tests can be skipped via:

    swift test -Xswiftc -D -Xswiftc SKIP_QUOTE_TESTS
    swift test -Xswiftc -D -Xswiftc SKIP_SIL_TESTS

Incantations for Bazel/Blaze are irrelevant to this repository,
so I won't be including them here.

These incantations only work on Linux.