### PR TITLE
Add Swift AutoDiff implementation overview.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ out the following documentation.
 Document | Last Updated | Status |
 -------- | ------------ | ------ |
 [Swift Differentiable Programming Design Overview](https://docs.google.com/document/d/1bPepWLfRQa6CtXqKA8CDQ87uZHixNav-TFjLSisuKag/edit?usp=sharing) | June 2019 | Current
+[Swift Differentiable Programming Implementation Overview](https://docs.google.com/document/d/1tgxHh7dxbpkQ8Y-LSs2IXAuMWPd8RrtJLkxA80qBRYc/edit?usp=sharing) | August 2019 | Current
 [Differentiable Types](docs/DifferentiableTypes.md) | March 2019 | Outdated
 [Differentiable Functions and Differentiation APIs](docs/DifferentiableFunctions.md) | March 2019 | Outdated
 [Dynamic Property Iteration using Key Paths](docs/DynamicPropertyIteration.md) | March 2019 | Current


### PR DESCRIPTION
Add Swift AutoDiff implementation overview (http://bit.ly/swift-autodiff-internals) by @dan-zheng and @bartchr808.