### PR TITLE
Release 2019-08-28 toolchain for macOS.

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -59,7 +59,7 @@ To install Swift for TensorFlow, download one of the packages below and follow t
 
 | Download | Date |
 |----------|------|
-| [Xcode 11](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2019-08-25-a-osx.pkg) | August 25, 2019 |
+| [Xcode 11](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2019-08-28-a-osx.pkg) | August 28, 2019 |
 | [Ubuntu 18.04 (CPU Only)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-ubuntu18.04.tar.gz) | Nightly |
 | [Ubuntu 18.04 (CUDA 10.0)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda10.0-cudnn7-ubuntu18.04.tar.gz) | Nightly |
 | [Ubuntu 18.04 (CUDA 9.2)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda9.2-cudnn7-ubuntu18.04.tar.gz) | Nightly |


### PR DESCRIPTION
https://github.com/apple/swift/commit/aa4fd5996192efa9d4caad5e6d597c3f882553f3

Remove 2019-08-25 toolchain, which had a z3 linker error.

Verified that 2019-08-28 toolchain works:
```console
$ swiftenv global tensorflow-DEVELOPMENT-2019-08-28-a
$ swift --version
Swift version 5.1-dev (LLVM 200186e28b, Swift 2f377d9cf2)
Target: x86_64-apple-darwin18.7.0
# No linker errors.
```