### PR TITLE
Emit unknown instruction upon parse failures

### DIFF
--- a/Sources/SIL/SILParser.swift
+++ b/Sources/SIL/SILParser.swift
@@ -51,14 +51,22 @@ class SILParser: Parser {
     // https://github.com/apple/swift/blob/master/docs/SIL.rst#basic-blocks
     func parseInstructionDef() throws -> InstructionDef {
         let result = try parseResult()
-        let instruction = try parseInstruction()
+        let instruction = parseInstruction()
         let sourceInfo = try parseSourceInfo()
         return InstructionDef(result, instruction, sourceInfo)
     }
 
     // https://github.com/apple/swift/blob/master/docs/SIL.rst#instruction-set
-    func parseInstruction() throws -> Instruction {
+    func parseInstruction() -> Instruction {
         let instructionName = take(while: { $0.isLetter || $0 == "_" })
+        do {
+            return try parseInstructionBody(instructionName)
+        } catch {
+            return .unknown(instructionName)
+        }
+    }
+
+    func parseInstructionBody(_ instructionName: String) throws -> Instruction {
         switch instructionName {
         case "alloc_stack":
             let type = try parseType()

--- a/Tests/SILTests/SILParserTests.swift
+++ b/Tests/SILTests/SILParserTests.swift
@@ -13,6 +13,19 @@ public final class SILParserTests: XCTestCase {
             XCTFail("Failed to parse the instruction def: \(error)")
         }
     }
+
+    public func testInstructionParseError() {
+        let instr = "%122 = apply garbage..."
+        let parser = SILParser(forString: instr)
+        do {
+            let def = try parser.parseInstructionDef()
+            guard case .unknown("apply") = def.instruction else {
+                return XCTFail("Expected .unknown(apply), got \(def.instruction)")
+            }
+        } catch {
+            XCTFail("Failed to parse the instruction def: \(error)")
+        }
+    }
 }
 
 extension SILParserTests {


### PR DESCRIPTION
SILGen sometimes emit weird things, but I don't really care about them, and this lets the tool handle failures more gracefully.