### PR TITLE
Keep float_literal arguments as Strings

### DIFF
--- a/Sources/SIL/SIL.swift
+++ b/Sources/SIL/SIL.swift
@@ -170,7 +170,7 @@ public enum Instruction {
     // https://github.com/apple/swift/blob/master/docs/SIL.rst#float-literal
     // float_literal $Builtin.FPIEEE32, 0x0
     // float_literal $Builtin.FPIEEE64, 0x3F800000
-    case floatLiteral(_ type: Type, _ value: Int)
+    case floatLiteral(_ type: Type, _ value: String)
 
     // https://github.com/apple/swift/blob/master/docs/SIL.rst#function-ref
     // function_ref @$s4main11threadCountSiyF : $@convention(thin) () -> Int

--- a/Sources/SIL/SILParser.swift
+++ b/Sources/SIL/SILParser.swift
@@ -164,7 +164,8 @@ class SILParser: Parser {
         case "float_literal":
             let type = try parseType()
             try take(",")
-            let value = try parseInt()
+            try take("0x")
+            let value = take(while: { $0.isHexDigit })
             return .floatLiteral(type, value)
         case "function_ref":
             let name = try parseFunctionName()

--- a/Sources/SIL/SILPrinter.swift
+++ b/Sources/SIL/SILPrinter.swift
@@ -139,8 +139,8 @@ class SILPrinter: Printer {
         case let .floatLiteral(type, value):
             print("float_literal ")
             print(type)
-            print(", ")
-            hex(value)
+            print(", 0x")
+            print(value)
         case let .functionRef(name, type):
             print("function_ref ")
             print("@")


### PR DESCRIPTION
Literals that cannot be represented exactly using a short floating
point value (e.g. 0.4) get saved as 80-bit numbers, which cannot
be loaded into regular Swift ints. Since there's no standard type
that would provide arbitrary precision integers, we maintain the
value as a String.