### PR TITLE
Add an SExpr parser

### DIFF
--- a/Sources/SIL/Parser.swift
+++ b/Sources/SIL/Parser.swift
@@ -48,12 +48,18 @@ class Parser {
         return chars.suffix(from: cursor).starts(with: Array(query))
     }
 
+    func peek() -> Character {
+      return chars[cursor]
+    }
+
     /// If chars[cursor..] starts with a given string, consume string and skip trivia afterwards.
     /// Otherwise, raise a parse error.
-    func take(_ query: String) throws {
+    func take(_ query: String, keepingTrivia: Bool = false) throws {
         guard peek(query) else { throw parseError("\(query) expected") }
         cursor += query.count
-        skipTrivia()
+        if !keepingTrivia {
+          skipTrivia()
+        }
     }
 
     /// If chars[cursor..-1] starts with a given string, consume string, skip trivia and return true.
@@ -84,7 +90,7 @@ class Parser {
 
     /// If cursor points to whitespace or comment, consume until it doesn't.
     /// This provides a cheap way to make whitespace and comments insignificant.
-    private func skipTrivia() {
+    func skipTrivia() {
         guard cursor < chars.count else { return }
         if chars[cursor].isWhitespace {
             cursor += 1

--- a/Sources/SIL/Parser.swift
+++ b/Sources/SIL/Parser.swift
@@ -48,18 +48,12 @@ class Parser {
         return chars.suffix(from: cursor).starts(with: Array(query))
     }
 
-    func peek() -> Character {
-      return chars[cursor]
-    }
-
     /// If chars[cursor..] starts with a given string, consume string and skip trivia afterwards.
     /// Otherwise, raise a parse error.
-    func take(_ query: String, keepingTrivia: Bool = false) throws {
+    func take(_ query: String) throws {
         guard peek(query) else { throw parseError("\(query) expected") }
         cursor += query.count
-        if !keepingTrivia {
-          skipTrivia()
-        }
+        skipTrivia()
     }
 
     /// If chars[cursor..-1] starts with a given string, consume string, skip trivia and return true.
@@ -90,7 +84,7 @@ class Parser {
 
     /// If cursor points to whitespace or comment, consume until it doesn't.
     /// This provides a cheap way to make whitespace and comments insignificant.
-    func skipTrivia() {
+    private func skipTrivia() {
         guard cursor < chars.count else { return }
         if chars[cursor].isWhitespace {
             cursor += 1

--- a/Sources/SIL/SExpr.swift
+++ b/Sources/SIL/SExpr.swift
@@ -1,0 +1,126 @@
+// This is a temporary addition to libSIL and will likely be removed in the future.
+// It is a hack that allows one to read the output of e.g. swiftc -dump-ast.
+public enum SExpr : Equatable {
+    public enum Property : Equatable {
+      case value(SExpr)
+      case field(String, SExpr)
+    }
+
+    case symbol(String)
+    case string(String)
+    case sourceRange(String) // We don't parse those further right now
+    case record(String, [Property])
+
+    public static func parse(fromPath path: String) throws -> SExpr {
+        let parser = try SExprParser(forPath: path)
+        return try parser.parseExpr()
+    }
+}
+
+class SExprParser: Parser {
+    func parseExpr() throws -> SExpr {
+        if skip("(") {
+            var properties: [SExpr.Property] = []
+            guard case let .symbol(name) = try parseExpr() else {
+                throw parseError("Expected an expression body to start with a symbol")
+            }
+            while !skip(")") {
+                let expr = try parseExpr()
+                if case let .symbol(propName) = expr, skip("=") {
+                    properties.append(.field(propName, try parseValue()))
+                } else {
+                    if case let .symbol(exprValue) = expr {
+                        guard !exprValue.isEmpty else {
+                            throw parseError("An empty property?")
+                        }
+                    }
+                    properties.append(.value(expr))
+                }
+            }
+            return .record(name, properties)
+        }
+        return try parseValue()
+    }
+
+    func parseValue() throws -> SExpr {
+        if skip("'") {
+            let result = take(while: { $0 != "'" })
+            try take("'")
+            return .string(result)
+        }
+        if skip("\"") {
+            let result = take(while: { $0 != "\"" })
+            try take("\"")
+            return .string(result)
+        }
+        if skip("[") {
+            let result = take(while: { $0 != "]" })
+            try take("]")
+            return .sourceRange(result)
+        }
+        return try parseSymbol()
+    }
+
+    func parseSymbol() throws -> SExpr {
+        // NB: This is more complicated than it ever should be because swiftc
+        //     likes to print badly formed symbols that look like Module.(file).Type
+        var result = ""
+        while true {
+            let c = peek()
+            if !c.isWhitespace && !"()=".contains(c) {
+                let cs = String(c)
+                try take(cs, keepingTrivia: true)
+                result += cs
+                continue
+            }
+            if c == "(", skip("(file)") {
+                result += "(file)"
+                continue
+            }
+            break
+        }
+        skipTrivia()
+        return .symbol(result)
+    }
+}
+
+class SExprPrinter: Printer {
+    func printExpr(_ e: SExpr) {
+        switch e {
+        case let .symbol(value): print(value)
+        case let .string(value): print("'\(value)'")
+        case let .sourceRange(value): print("[\(value)]")
+        case let .record(name, properties):
+            print("(")
+            print(name)
+            for prop in properties {
+                switch prop {
+                case let .value(value):
+                  if case .record(_, _) = value {
+                    print("\n")
+                    indent()
+                    printExpr(value)
+                    unindent()
+                  } else {
+                    print(" ")
+                    printExpr(value)
+                  }
+                case let .field(name, value):
+                  print(" ")
+                  print(name)
+                  print("=")
+                  printExpr(value)
+                }
+            }
+            print(")")
+        }
+    }
+}
+
+extension SExpr: CustomStringConvertible {
+    public var description: String {
+        let printer = SExprPrinter()
+        printer.printExpr(self)
+        return printer.description
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -22,6 +22,7 @@ let silTests = [
     testCase(InstructionTests.allTests),
     testCase(ModuleTests.allTests),
     testCase(PrinterTests.allTests),
+    testCase(SExprTests.allTests),
 ]
 #else
 let silTests = [XCTestCaseEntry]()

--- a/Tests/SILTests/Resources/Example.sexpr
+++ b/Tests/SILTests/Resources/Example.sexpr
@@ -1,0 +1,50 @@
+(source_file "a.sil"
+  (import_decl range=[a.sil:3:1 - line:3:8] 'Builtin')
+  (import_decl range=[a.sil:4:1 - line:4:8] 'Swift')
+  (import_decl range=[a.sil:5:1 - line:5:8] 'SwiftShims')
+  (import_decl range=[a.sil:7:1 - line:7:8] 'TensorFlow')
+  (struct_decl range=[a.sil:9:1 - line:14:1] "Conv2d" interface type='Conv2d.Type' access=internal non-resilient
+    (pattern_binding_decl range=[a.sil:10:16 - line:10:43]
+      (pattern_typed type='Tensor<Float>'
+        (pattern_named type='Tensor<Float>' 'w')
+        (type_ident
+          (component id='Tensor' bind=TensorFlow.(file).Tensor)
+          (type_ident
+            (component id='Float' bind=Swift.(file).Float)))))
+    (var_decl range=[a.sil:10:20 - line:10:20] "w" type='Tensor<Float>' interface type='Tensor<Float>' access=internal let readImpl=stored immutable
+      (accessor_decl range=[a.sil:10:39 - line:10:39] 'anonname=0x7fa061817580' interface type='(Conv2d) -> () -> Tensor<Float>' access=internal get_for=w
+        (parameter "self" interface type='Conv2d')
+        (parameter_list)))
+    (pattern_binding_decl range=[a.sil:11:16 - line:11:43]
+      (pattern_typed type='Tensor<Float>'
+        (pattern_named type='Tensor<Float>' 'b')
+        (type_ident
+          (component id='Tensor' bind=TensorFlow.(file).Tensor)
+          (type_ident
+            (component id='Float' bind=Swift.(file).Float)))))
+    (var_decl range=[a.sil:11:20 - line:11:20] "b" type='Tensor<Float>' interface type='Tensor<Float>' access=internal let readImpl=stored immutable
+      (accessor_decl range=[a.sil:11:39 - line:11:39] 'anonname=0x7fa0618178b0' interface type='(Conv2d) -> () -> Tensor<Float>' access=internal get_for=b
+        (parameter "self" interface type='Conv2d')
+        (parameter_list)))
+    (func_decl range=[a.sil:12:3 - line:12:49] "apply(_:)" interface type='(Conv2d) -> (Tensor<Float>) -> Tensor<Float>' access=internal
+      (parameter "self" interface type='Conv2d')
+      (parameter_list
+        (parameter "x" interface type='Tensor<Float>') range=[a.sil:12:13 - line:12:32])
+      (result
+        (type_ident
+          (component id='Tensor' bind=TensorFlow.(file).Tensor)
+          (type_ident
+            (component id='Float' bind=Swift.(file).Float)))))
+    (constructor_decl range=[a.sil:13:3 - line:13:42] "init(w:b:)" interface type='(Conv2d.Type) -> (Tensor<Float>, Tensor<Float>) -> Conv2d' access=internal designated
+      (parameter "self" interface type='Conv2d' inout)
+      (parameter_list
+        (parameter "w" apiName=w interface type='Tensor<Float>')
+        (parameter "b" apiName=b interface type='Tensor<Float>') range=[a.sil:13:7 - line:13:42])))
+  (func_decl range=[a.sil:16:1 - line:16:43] "f(_:)" interface type='(Tensor<Float>) -> Tensor<Float>' access=internal
+    (parameter_list
+      (parameter "x" interface type='Tensor<Float>') range=[a.sil:16:7 - line:16:26])
+    (result
+      (type_ident
+        (component id='Tensor' bind=TensorFlow.(file).Tensor)
+        (type_ident
+          (component id='Float' bind=Swift.(file).Float))))))

--- a/Tests/SILTests/SExprTests.swift
+++ b/Tests/SILTests/SExprTests.swift
@@ -17,9 +17,7 @@ public final class SExprTests: XCTestCase {
             }
             let sexpr = try SExpr.parse(fromPath: sourcePath)
             let actual = sexpr.description + "\n"
-            print(normalize(expected))
-            print(actual)
-            if (normalize(expected) != actual) {
+            if normalize(expected) != actual {
                 if let actualFile = FileManager.default.makeTemporaryFile() {
                     let actualPath = actualFile.path
                     FileManager.default.createFile(atPath: actualPath, contents: Data(actual.utf8))

--- a/Tests/SILTests/SExprTests.swift
+++ b/Tests/SILTests/SExprTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import XCTest
+import SIL
+
+public final class SExprTests: XCTestCase {
+    public func testExample() {
+        testRoundtrip("Tests/SILTests/Resources/Example.sexpr")
+    }
+
+    private func testRoundtrip(_ sourcePath: String) {
+        do {
+            guard let expectedData = FileManager.default.contents(atPath: sourcePath) else {
+                return XCTFail("\(sourcePath) not found")
+            }
+            guard let expected = String(data: expectedData, encoding: .utf8) else {
+                return XCTFail("\(sourcePath) not in UTF-8")
+            }
+            let sexpr = try SExpr.parse(fromPath: sourcePath)
+            let actual = sexpr.description + "\n"
+            print(normalize(expected))
+            print(actual)
+            if (normalize(expected) != actual) {
+                if let actualFile = FileManager.default.makeTemporaryFile() {
+                    let actualPath = actualFile.path
+                    FileManager.default.createFile(atPath: actualPath, contents: Data(actual.utf8))
+                    if shelloutOrFail("colordiff", "-u", sourcePath, actualPath) {
+                        XCTFail("Roundtrip failed: expected \(sourcePath), actual: \(actualPath)")
+                    } else {
+                        XCTFail("Roundtrip failed: expected \(sourcePath), actual: \n\(actual)")
+                    }
+                } else {
+                    XCTFail("Roundtrip failed")
+                }
+            }
+        } catch {
+            XCTFail(String(describing: error))
+        }
+    }
+
+    func normalize(_ s: String) -> String {
+      return s.replacingOccurrences(of: "\"", with: "'")
+    }
+}
+
+extension SExprTests {
+    public static let allTests = [
+        ("testExample", testExample),
+    ]
+}
+


### PR DESCRIPTION
This is a cheap way of analyzing the AST descriptions produced by
swiftc. The syntax is very janky which causes some hidden complexities
in the `parseSymbol` implementation, but all in all it ends up being
really simple.

As discussed with @burmako this is not 100% in scope of the library today, but seems better than making `Parser` and `Printer` public.