### PR TITLE
Implement Operation.operands and Terminator.operands

### DIFF
--- a/Sources/SIL/SIL.swift
+++ b/Sources/SIL/SIL.swift
@@ -495,6 +495,7 @@ public enum TupleElements: Equatable {
 public indirect enum Type: Equatable {
     case addressType(_ type: Type)
     case attributedType(_ attributes: [TypeAttribute], _ type: Type)
+    case coroutineTokenType
     case functionType(_ parameters: [Type], _ result: Type)
     case genericType(_ parameters: [String], _ requirements: [TypeRequirement], _ type: Type)
     case namedType(_ name: String)

--- a/Sources/SIL/SIL.swift
+++ b/Sources/SIL/SIL.swift
@@ -84,6 +84,13 @@ public struct TerminatorDef: Equatable {
 public enum InstructionDef: Equatable {
     case `operator`(OperatorDef)
     case terminator(TerminatorDef)
+
+    var instruction: Instruction {
+        switch self {
+        case let .operator(def): return .operator(def.operator)
+        case let .terminator(def): return .terminator(def.terminator)
+        }
+    }
 }
 
 

--- a/Sources/SIL/SILAnalysis.swift
+++ b/Sources/SIL/SILAnalysis.swift
@@ -46,7 +46,8 @@ extension Operator: AlphaConvertible {
         case let .apply(nothrow, value, substitutions, arguments, type):
             return .apply(nothrow, s(value), substitutions, arguments.map(s), type)
         case let .beginAccess(access, enforcement, noNestedConflict, builtin, operand):
-            return .beginAccess(access, enforcement, noNestedConflict, builtin, operand.alphaConverted(using: s))
+            return .beginAccess(
+                access, enforcement, noNestedConflict, builtin, operand.alphaConverted(using: s))
         case let .beginApply(nothrow, value, substitutions, arguments, type):
             return .beginApply(nothrow, s(value), substitutions, arguments.map(s), type)
         case let .beginBorrow(operand):
@@ -195,11 +196,193 @@ extension Array: AlphaConvertible where Element: AlphaConvertible {
     }
 }
 
+func substitute(_ type: Type, using s: (String) -> Type) -> Type {
+    switch type {
+    case let .addressType(subtype):
+        return .addressType(substitute(subtype, using: s))
+    case let .attributedType(attributes, subtype):
+        return .attributedType(attributes, substitute(subtype, using: s))
+    case .coroutineTokenType:
+        return .coroutineTokenType
+    case let .functionType(parameters, result):
+        return .functionType(
+            parameters.map { substitute($0, using: s) }, substitute(result, using: s))
+    case let .genericType(parameters, requirements, subtype):
+        return .genericType(
+            parameters,
+            requirements,
+            substitute(subtype, using: { parameters.contains($0) ? .namedType($0) : s($0) }))
+    case let .namedType(name):
+        return s(name)
+    case let .selectType(subtype, name):
+        return .selectType(substitute(subtype, using: s), name)
+    case .selfType:
+        return .selfType
+    case let .specializedType(genericType, arguments):
+        return .specializedType(
+            substitute(genericType, using: s), arguments.map { substitute($0, using: s) })
+    case let .tupleType(elementTypes):
+        return .tupleType(elementTypes.map { substitute($0, using: s) })
+    case let .withOwnership(attribute, subtype):
+        return .withOwnership(attribute, substitute(subtype, using: s))
+    }
+}
+
+func specialize(_ type: Type, to arguments: [Type]) -> Type {
+    switch type {
+    case let .addressType(subtype):
+        return .addressType(specialize(subtype, to: arguments))
+    case let .attributedType(attributes, subtype):
+        return .attributedType(attributes, specialize(subtype, to: arguments))
+    case let .genericType(parameters, _, subtype):
+        guard parameters.count == arguments.count else {
+            fatalError(
+                "Specializing a generic type with \(parameters.count) parameters using \(arguments.count) arguments"
+            )
+        }
+        let valuation = [String: Type](
+            zip(parameters, arguments),
+            uniquingKeysWith: { _, _ in fatalError("Duplicate parameter names in generic type") })
+        return substitute(subtype, using: { valuation[$0]! })
+    case let .selectType(subtype, name):
+        return .selectType(specialize(subtype, to: arguments), name)
+    case let .withOwnership(attribute, subtype):
+        return .withOwnership(attribute, specialize(subtype, to: arguments))
+    case .coroutineTokenType: fallthrough
+    case .functionType(_, _): fallthrough
+    case .namedType(_): fallthrough
+    case .selfType: fallthrough
+    case .specializedType(_, _): fallthrough
+    case .tupleType(_):
+        fatalError("Specializing a type that is not generic")
+    }
+}
+
+func destructFunctionType(_ type: Type) -> (arguments: [Type], result: Type) {
+    switch type {
+    case let .attributedType(_, subtype):
+        return destructFunctionType(subtype)
+    case let .functionType(arguments, result):
+        return (arguments, result)
+    case let .genericType(_, _, subtype):
+        return destructFunctionType(subtype)
+    case let .withOwnership(_, subtype):
+        return destructFunctionType(subtype)
+    case .addressType(_): fallthrough
+    case .coroutineTokenType: fallthrough
+    case .namedType(_): fallthrough
+    case .selectType(_, _): fallthrough
+    case .selfType: fallthrough
+    case .specializedType(_, _): fallthrough
+    case .tupleType(_):
+        fatalError("Expected a function type")
+    }
+}
+
 extension Operator {
-    public var operandNames: [String]? {
-        if case .unknown(_) = self { return nil }
-        var names: [String] = []
-        let _ = alphaConverted(using: { names.append($0);return $0 })
-        return names
+    public var operands: [Operand]? {
+        switch self {
+        case .allocStack(_, _): return []
+        case let .apply(_, function, substitutions, arguments, type):
+            let specializedType = substitutions.isEmpty ? type : specialize(type, to: substitutions)
+            let (arguments:argumentTypes, result:_) = destructFunctionType(specializedType)
+            return [Operand(function, type)] + zip(arguments, argumentTypes).map {
+                Operand($0.0, $0.1)
+            }
+        case let .beginAccess(_, _, _, _, operand): return [operand]
+        case let .beginApply(_, function, substitutions, arguments, type):
+            let specializedType = substitutions.isEmpty ? type : specialize(type, to: substitutions)
+            let (arguments:rawArgumentTypes, result:_) = destructFunctionType(specializedType)
+            let argumentTypes = rawArgumentTypes.map {
+                guard case let .attributedType(attributes, subtype) = $0,
+                    attributes.first == .yields
+                else {
+                    fatalError("Coroutine results should have @yields attributes")
+                }
+                if attributes.count == 1 {
+                    return subtype
+                } else {
+                    return .attributedType(Array(attributes.suffix(from: 1)), subtype)
+                }
+            } + [Type.coroutineTokenType]
+            assert(arguments.count == argumentTypes.count)
+            return [Operand(function, type)] + zip(arguments, argumentTypes).map {
+                Operand($0.0, $0.1)
+            }
+        case let .beginBorrow(operand): return [operand]
+        case let .builtin(_, operands, _): return operands
+        case let .condFail(operand, _): return [operand]
+        case let .convertEscapeToNoescape(_, _, operand, _): return [operand]
+        case let .convertFunction(operand, _, _): return [operand]
+        case let .copyAddr(_, value, _, operand): return [Operand(value, operand.type), operand]
+        case let .copyValue(operand): return [operand]
+        case let .deallocStack(operand): return [operand]
+        case let .debugValue(operand, _): return [operand]
+        case let .debugValueAddr(operand, _): return [operand]
+        case let .destroyValue(operand): return [operand]
+        case let .destructureTuple(operand): return [operand]
+        case let .endAccess(_, operand): return [operand]
+        case let .endApply(value): return [Operand(value, .coroutineTokenType)]
+        case let .endBorrow(operand): return [operand]
+        case let .enum(_, _, maybeOperand): return maybeOperand.map { [$0] } ?? []
+        case .floatLiteral(_, _): return []
+        case .functionRef(_, _): return []
+        case .globalAddr(_, _): return []
+        case let .indexAddr(addr, index): return [addr, index]
+        case .integerLiteral(_, _): return []
+        case let .load(_, operand): return [operand]
+        case let .markDependence(operand, on): return [operand, on]
+        case .metatype(_): return []
+        case let .partialApply(_, _, function, substitutions, arguments, type):
+            let specializedType = substitutions.isEmpty ? type : specialize(type, to: substitutions)
+            let (arguments:allArgumentTypes, result:_) = destructFunctionType(specializedType)
+            let argumentTypes = allArgumentTypes.suffix(arguments.count)
+            assert(arguments.count == argumentTypes.count)
+            return [Operand(function, type)] + zip(arguments, argumentTypes).map {
+                Operand($0.0, $0.1)
+            }
+        case let .pointerToAddress(operand, _, _): return [operand]
+        case let .releaseValue(operand): return [operand]
+        case let .retainValue(operand): return [operand]
+        case let .store(value, _, operand):
+            guard case let .addressType(valueType) = operand.type else {
+                fatalError("Store to a non-address type operand")
+            }
+            return [Operand(value, valueType), operand]
+        case .stringLiteral(_, _): return []
+        case let .strongRelease(operand): return [operand]
+        case let .strongRetain(operand): return [operand]
+        case let .struct(_, operands): return operands
+        case let .structElementAddr(operand, _): return [operand]
+        case let .structExtract(operand, _): return [operand]
+        case let .thinToThickFunction(operand, _): return [operand]
+        case let .tuple(elements):
+            switch elements {
+            case let .unlabeled(operands): return operands
+            case let .labeled(tupleType, operands):
+                guard case let .tupleType(elementTypes) = tupleType else {
+                    fatalError("Tuple of non-tuple type")
+                }
+                return zip(operands, elementTypes).map { Operand($0.0, $0.1) }
+            }
+        case let .tupleExtract(operand, _): return [operand]
+        case .unknown(_): return nil
+        case .witnessMethod(_, _, _, _): return []
+        }
+    }
+}
+
+extension Terminator {
+    public var operands: [Operand]? {
+        switch self {
+        case let .br(_, operands): return operands
+        case let .condBr(cond, _, trueOperands, _, falseOperands):
+            return [Operand(cond, .selectType(.namedType("Builtin"), "Int1"))] + trueOperands
+                + falseOperands
+        case let .return(operand): return [operand]
+        case let .switchEnum(operand, _): return [operand]
+        case .unknown(_): return nil
+        case .unreachable: return []
+        }
     }
 }

--- a/Sources/SIL/SILPrinter.swift
+++ b/Sources/SIL/SILPrinter.swift
@@ -537,6 +537,8 @@ class SILPrinter: Printer {
         case let .attributedType(attrs, type):
             print("", attrs, " ", " ") { print($0) }
             naked(type)
+        case .coroutineTokenType:
+            print("!CoroutineTokenType!")
         case let .functionType(params, result):
             print("(", params, ", ", ")") { naked($0) }
             print(" -> ")

--- a/Tests/SILTests/SILAnalysisTests.swift
+++ b/Tests/SILTests/SILAnalysisTests.swift
@@ -2,16 +2,23 @@ import Foundation
 import XCTest
 @testable import SIL
 
+func parseDef(_ source: String) -> InstructionDef? {
+    do {
+        let p = SILParser(forString: source)
+        return try p.parseInstructionDef()
+    } catch {
+        XCTFail(String(describing: error) + "\n" + source)
+        return nil
+    }
+}
+
+
 public final class SILAnalysisTests: XCTestCase {
+    lazy var parsedInstructionDefs: [InstructionDef] = instructionDefs.compactMap(parseDef)
+
     public func testAlphaConverted() {
-        for instructionDef in instructionDefs {
-            do {
-                let p = SILParser(forString: instructionDef)
-                let i = try p.parseInstructionDef()
-                checkValueNames(i.alphaConverted(using: { _ in "%TEST_NAME" }))
-            } catch {
-                XCTFail(String(describing: error) + "\n" + instructionDef)
-            }
+        for def in parsedInstructionDefs {
+            checkValueNames(def.alphaConverted(using: { _ in "%TEST_NAME" }))
         }
     }
 
@@ -19,7 +26,6 @@ public final class SILAnalysisTests: XCTestCase {
     func checkValueNames(_ i: InstructionDef) {
       var readingValueName = false
       var name = ""
-      print(i.description)
       for c in i.description {
         if c == "%" {
           name = "%"
@@ -36,10 +42,55 @@ public final class SILAnalysisTests: XCTestCase {
         }
       }
     }
+
+    public func testOperandsSeeAllValueNames() {
+        for def in parsedInstructionDefs {
+            var valueNames: [String] = []
+            let _ = def.instruction.alphaConverted(using: { valueNames.append($0); return $0 })
+            guard let operands = def.instruction.operands else {
+                XCTFail("Failed to retrieve operands of \(def)")
+                continue
+            }
+            XCTAssertEqual(operands.map{ $0.value }, valueNames)
+        }
+    }
+
+    public func testOperandsOfApplyInstructions() {
+        func verifyApply(_ defSource: String, _ expectedOperands: [Operand]) {
+            guard let partialApplyDef = parseDef(defSource) else {
+                return XCTFail("Failed to parse the partial_apply case")
+            }
+            let partialApply = partialApplyDef.instruction
+            guard let operands = partialApply.operands else {
+                return XCTFail("Failed to get a correct list of operands")
+            }
+            XCTAssertEqual(Array(operands[1...]), expectedOperands)
+        }
+        verifyApply(
+            "apply %8<Int, Int>(%2, %6) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Strideable, τ_0_1 : Strideable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> ()",
+            [
+                Operand("%2", .attributedType([.inGuaranteed], .namedType("Int"))),
+                Operand("%6", .attributedType([.inGuaranteed], .namedType("Int"))),
+            ]
+        )
+        verifyApply(
+            "begin_apply %266(%125, %265) : $@yield_once @convention(method) (Int, @inout Array<Float>) -> @yields @inout Float",
+            [
+                Operand("%125", .namedType("Int")),
+                Operand("%265", .attributedType([.inout], .specializedType(.namedType("Array"), [.namedType("Float")]))),
+            ]
+        )
+        verifyApply(
+            "%4 = partial_apply [callee_guaranteed] %2<Scalar>(%3) : $@convention(thin) <τ_0_0 where τ_0_0 : TensorFlowScalar> (@guaranteed Tensor<τ_0_0>) -> Bool",
+            [Operand("%3", .attributedType([.guaranteed], .specializedType(.namedType("Tensor"), [.namedType("Scalar")])))]
+        )
+    }
 }
 
 extension SILAnalysisTests {
     public static let allTests = [
         ("testAlphaConverted", testAlphaConverted),
+        ("testOperandsSeeAllValueNames", testOperandsSeeAllValueNames),
+        ("testOperandsOfApplyInstructions", testOperandsOfApplyInstructions),
     ]
 }

--- a/Tests/SILTests/SILAnalysisTests.swift
+++ b/Tests/SILTests/SILAnalysisTests.swift
@@ -12,7 +12,6 @@ func parseDef(_ source: String) -> InstructionDef? {
     }
 }
 
-
 public final class SILAnalysisTests: XCTestCase {
     lazy var parsedInstructionDefs: [InstructionDef] = instructionDefs.compactMap(parseDef)
 
@@ -24,34 +23,34 @@ public final class SILAnalysisTests: XCTestCase {
 
     // Only allows %TEST_NAME as the value name
     func checkValueNames(_ i: InstructionDef) {
-      var readingValueName = false
-      var name = ""
-      for c in i.description {
-        if c == "%" {
-          name = "%"
-          assert(!readingValueName)
-          readingValueName = true
-          continue
+        var readingValueName = false
+        var name = ""
+        for c in i.description {
+            if c == "%" {
+                name = "%"
+                assert(!readingValueName)
+                readingValueName = true
+                continue
+            }
+            guard readingValueName else { continue }
+            if c.isLetter || c.isNumber || c == "_" {
+                name.append(c)
+            } else {
+                XCTAssertEqual(name, "%TEST_NAME")
+                readingValueName = false
+            }
         }
-        guard readingValueName else { continue }
-        if c.isLetter || c.isNumber || c == "_" {
-          name.append(c)
-        } else {
-          XCTAssertEqual(name, "%TEST_NAME")
-          readingValueName = false
-        }
-      }
     }
 
     public func testOperandsSeeAllValueNames() {
         for def in parsedInstructionDefs {
             var valueNames: [String] = []
-            let _ = def.instruction.alphaConverted(using: { valueNames.append($0); return $0 })
+            let _ = def.instruction.alphaConverted(using: { valueNames.append($0);return $0 })
             guard let operands = def.instruction.operands else {
                 XCTFail("Failed to retrieve operands of \(def)")
                 continue
             }
-            XCTAssertEqual(operands.map{ $0.value }, valueNames)
+            XCTAssertEqual(operands.map { $0.value }, valueNames)
         }
     }
 
@@ -77,12 +76,21 @@ public final class SILAnalysisTests: XCTestCase {
             "begin_apply %266(%125, %265) : $@yield_once @convention(method) (Int, @inout Array<Float>) -> @yields @inout Float",
             [
                 Operand("%125", .namedType("Int")),
-                Operand("%265", .attributedType([.inout], .specializedType(.namedType("Array"), [.namedType("Float")]))),
+                Operand(
+                    "%265",
+                    .attributedType(
+                        [.inout], .specializedType(.namedType("Array"), [.namedType("Float")]))),
             ]
         )
         verifyApply(
             "%4 = partial_apply [callee_guaranteed] %2<Scalar>(%3) : $@convention(thin) <τ_0_0 where τ_0_0 : TensorFlowScalar> (@guaranteed Tensor<τ_0_0>) -> Bool",
-            [Operand("%3", .attributedType([.guaranteed], .specializedType(.namedType("Tensor"), [.namedType("Scalar")])))]
+            [
+                Operand(
+                    "%3",
+                    .attributedType(
+                        [.guaranteed],
+                        .specializedType(.namedType("Tensor"), [.namedType("Scalar")])))
+            ]
         )
     }
 }


### PR DESCRIPTION
Apparently some transformations are best done when you have the type information available.

I'm not really sure what's the best way to test this, so I guess I'll just add a few checks at least for non-trivial cases in a subsequent commit. This is meant to be slightly WIP, but I'm putting it out for comments.