### PR TITLE
Use `python3 -m pip` instead of pip3

### DIFF
--- a/utils/install-ubuntu1804.sh
+++ b/utils/install-ubuntu1804.sh
@@ -77,7 +77,7 @@ if [[ ! -z "$JUPYTER_URL" ]]; then
   tar -xf "$INSTALL_LOCATION"/swift-jupyter.tar.gz -C "$INSTALL_LOCATION"
   rm "$INSTALL_LOCATION"/swift-jupyter.tar.gz
 
-  pip3 install -r "$INSTALL_LOCATION"/swift-jupyter/requirements.txt
+  python3 -m pip install -r "$INSTALL_LOCATION"/swift-jupyter/requirements.txt
 
   python3 "$INSTALL_LOCATION"/swift-jupyter/register.py --user --swift-toolchain "$INSTALL_LOCATION" --swift-python-library /usr/lib/x86_64-linux-gnu/libpython3.6m.so
 fi


### PR DESCRIPTION
There is some weird thing going on with pip3 when its upgraded. This gets around that.