### PR TITLE
Update differentiable programming manifesto link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ out the following documentation.
 
 Document | Last Updated | Status |
 -------- | ------------ | ------ |
-[Differentiable Programming Mega-Proposal](https://forums.swift.org/t/differentiable-programming-mega-proposal/28547) | September 2019 | Current
+[Differentiable Programming Mega-Proposal](https://github.com/apple/swift/blob/master/docs/DifferentiableProgramming.md) | September 2019 | Current
 [Swift Differentiable Programming Design Overview](https://docs.google.com/document/d/1bPepWLfRQa6CtXqKA8CDQ87uZHixNav-TFjLSisuKag/edit?usp=sharing) | June 2019 | Current
 [Swift Differentiable Programming Implementation Overview](https://docs.google.com/document/d/1_BirmTqdotglwNTOcYAW-ib6mx_jl-gH9Dbg4WmHZh0) | August 2019 | Current
 [Differentiable Types](docs/DifferentiableTypes.md) | March 2019 | Outdated


### PR DESCRIPTION
`docs/DifferentiableProgramming.md` in [apple/swift](https://github.com/apple/swift) is the canonical version.