### PR TITLE
Remove deprecated `allDifferentiableVariables` from tutorial.

### DIFF
--- a/docs/site/tutorials/model_training_walkthrough.ipynb
+++ b/docs/site/tutorials/model_training_walkthrough.ipynb
@@ -757,7 +757,7 @@
    },
    "outputs": [],
    "source": [
-    "optimizer.update(&model.allDifferentiableVariables, along: grads)"
+    "optimizer.update(&model, along: grads)"
    ]
   },
   {
@@ -854,7 +854,7 @@
     "            let logits = model(batch.features)\n",
     "            return softmaxCrossEntropy(logits: logits, labels: batch.labels)\n",
     "        }\n",
-    "        optimizer.update(&model.allDifferentiableVariables, along: grad)\n",
+    "        optimizer.update(&model, along: grad)\n",
     "        \n",
     "        let logits = model(batch.features)\n",
     "        epochAccuracy += accuracy(predictions: logits.argmax(squeezingAxis: 1), truths: batch.labels)\n",


### PR DESCRIPTION
The remaining uses of `allDifferentiableVariables`/`AllDifferentiableVariables` are in `docs`, which is acceptable because each doc has "Last updated" and "Status" fields in the [README](https://github.com/tensorflow/swift#technology-deep-dive).

```
$ grep -nr "allDiff" .
./docs/ParameterOptimization.md:340:print(dense.allDifferentiableVariables)
./docs/ParameterOptimization.md:374:optimizer.update(&dense.allDifferentiableVariables, with: 𝛁dense)
./docs/ParameterOptimization.md:491:    optimizer.update(&classifier.allDifferentiableVariables, along: 𝛁model)
./docs/DifferentiableTypes.md:114:    var allDifferentiableVariables: AllDifferentiableVariables { get }
./docs/DifferentiableTypes.md:134:* `var allDifferentiableVariables: AllDifferentiableVariables` represents all differentiable variables in an instance of the conforming type, where `associatedtype AllDifferentiableVariables` is the type of all differentiable variables.
./docs/DifferentiableTypes.md:190:`var allDifferentiableVariables: AllDifferentiableVariables` is synthesized as a computed property that mirrors the differentiation properties of the conforming type.
./docs/DifferentiableTypes.md:193:* It is synthesized with a setter only when all differentiation properties are mutable and themselves all have mutable `allDifferentiableVariables` properties.
./docs/DifferentiableTypes.md:198:var allDifferentiableVariables: AllDifferentiableVariables {
./docs/DifferentiableTypes.md:204:var allDifferentiableVariables: AllDifferentiableVariables {
./docs/DifferentiableTypes.md:248:    // var allDifferentiableVariables: AllDifferentiableVariables {
./KNOWN_ISSUES.md:62:* [ ] The [`Differentiable`] protocol's `allDifferentiableVariables` requirement
./proposals/LayerProtocolRevision.md:43:    optimizer.update(&model.allDifferentiableVariables, along: gradients)
./proposals/LayerProtocolRevision.md:162:  optimizer.update(&model.allDifferentiableVariables, along: gradients)
```