### PR TITLE
Fix typos in protocol_oriented_generics.ipynb

### DIFF
--- a/docs/site/tutorials/protocol_oriented_generics.ipynb
+++ b/docs/site/tutorials/protocol_oriented_generics.ipynb
@@ -75,9 +75,9 @@
    "source": [
     "## Protocols\n",
     "\n",
-    "Inheritence is a powerful way to organize code in programming languages that allows you to share code between multiple components of the program.\n",
+    "Inheritance is a powerful way to organize code in programming languages that allows you to share code between multiple components of the program.\n",
     "\n",
-    "In Swift, there are different ways to express inheritence. One of those ways you may be familiar with already - class inheritence. However, Swift has another way - protocols.\n",
+    "In Swift, there are different ways to express inheritance. One of those ways you may be familiar with already - class inheritance. However, Swift has another way - protocols.\n",
     "\n",
     "In this tutorial, we will explore protocols - an alternative to subclassing that allows you to achieve similar goals through different tradeoffs. In Swift, protocols contain multiple abstract members. Classes, structs and enums can conform to multiple protocols and the conformance relationship can be established retroactively. All that enables some designs that aren't easily expressible in Swift using subclassing. We will walk through the idioms that support the use of protocols (extensions and protocol constraints), as well as the limitations of protocols.\n"
    ]

--- a/docs/site/tutorials/protocol_oriented_generics.ipynb
+++ b/docs/site/tutorials/protocol_oriented_generics.ipynb
@@ -77,7 +77,7 @@
     "\n",
     "Inheritance is a powerful way to organize code in programming languages that allows you to share code between multiple components of the program.\n",
     "\n",
-    "In Swift, there are different ways to express inheritance. One of those ways you may be familiar with already - class inheritance. However, Swift has another way - protocols.\n",
+    "In Swift, there are different ways to express inheritance. You may already be familiar with one of those ways, from other languages: class inheritance. However, Swift has another way: protocols.\n",
     "\n",
     "In this tutorial, we will explore protocols - an alternative to subclassing that allows you to achieve similar goals through different tradeoffs. In Swift, protocols contain multiple abstract members. Classes, structs and enums can conform to multiple protocols and the conformance relationship can be established retroactively. All that enables some designs that aren't easily expressible in Swift using subclassing. We will walk through the idioms that support the use of protocols (extensions and protocol constraints), as well as the limitations of protocols.\n"
    ]


### PR DESCRIPTION
Inheritance was spelled incorrectly in a few places.