### PR TITLE
add a base deps dockerfile

### DIFF
--- a/utils/base-deps-docker/Dockerfile
+++ b/utils/base-deps-docker/Dockerfile
@@ -1,0 +1,43 @@
+# A Docker image with all dependencies required to run (not build) an S4TF toolchain.
+
+ARG S4TF_CUDA_VERSION
+ARG S4TF_CUDNN_VERSION
+
+FROM nvidia/cuda:${S4TF_CUDA_VERSION}-cudnn${S4TF_CUDNN_VERSION}-devel-ubuntu18.04
+
+# ARGs from before FROM are cleared after the FROM, so we repeat ourselves.
+ARG S4TF_CUDA_VERSION
+ARG S4TF_CUDNN_VERSION
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install Swift deps.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        python \
+        python-dev \
+        python-pip \
+        python-setuptools \
+        python-tk \
+        python3 \
+        python3-dev \
+        python3-pip \
+        python3-setuptools \
+        clang \
+        libcurl4-openssl-dev \
+        libicu-dev \
+        libpython-dev \
+        libpython3-dev \
+        libncurses5-dev \
+        libxml2 \
+        libblocksruntime-dev \
+        libbsd-dev \
+# Install Python libraries
+    && pip3 install numpy matplotlib gym psutil junit-xml \
+# Configure cuda
+    && echo "/usr/local/cuda-${S4TF_CUDA_VERSION}/targets/x86_64-linux/lib/stubs" > /etc/ld.so.conf.d/cuda-${S4TF_CUDA_VERSION}-stubs.conf \
+    && ldconfig

--- a/utils/base-deps-docker/build.sh
+++ b/utils/base-deps-docker/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Builds base deps docker images for various CUDA versions, and uploads them to
+# the Google Container Registry.
+
+set -exuo pipefail
+
+do_build() {
+  export S4TF_CUDA_VERSION="$1"
+  export S4TF_CUDNN_VERSION="$2"
+  IMAGE_NAME="gcr.io/swift-tensorflow/base-deps-cuda${S4TF_CUDA_VERSION}-cudnn${S4TF_CUDNN_VERSION}-ubuntu18.04"
+  sudo -E docker build \
+    -t "$IMAGE_NAME" \
+    --build-arg S4TF_CUDA_VERSION \
+    --build-arg S4TF_CUDNN_VERSION \
+    .
+  docker push "$IMAGE_NAME"
+}
+
+do_build 9.2 7
+do_build 10.0 7
+do_build 10.1 7


### PR DESCRIPTION
This builds and uploads docker images with the base dependencies, so that our CI builds can use this instead of duplicating the code and work to install the dependencies.