### PR TITLE
Fix outdated type name in protocol_oriented_generics.ipynb

### DIFF
--- a/docs/site/tutorials/protocol_oriented_generics.ipynb
+++ b/docs/site/tutorials/protocol_oriented_generics.ipynb
@@ -269,11 +269,11 @@
         "> \"error: cannot assign to property: 'car' is a 'let' constant\"\n",
         "*/\n",
         "\n",
-        "// func modify(car: Car, toColor color: Color) -> Void {\n",
+        "// func modify(car: FastCar, toColor color: Color) -> Void {\n",
         "//   car.color = color\n",
         "// }\n",
         "\n",
-        "// car = Car(color: .red, horsePower: 250)\n",
+        "// car = FastCar(color: .red, horsePower: 250)\n",
         "// print(car.description())\n",
         "// modify(car: &car, toColor: .blue)\n",
         "// print(car.description())\n"


### PR DESCRIPTION
This PR contains a minor fix only.

- Update `Car` -> `FastCar` at comment lines.