### PR TITLE
Remove obsolete Xcode 10 usage instructions.

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -142,9 +142,9 @@ To install Swift for TensorFlow, download one of the packages below and follow t
 
 3. An Xcode toolchain (`.xctoolchain`) includes a copy of the compiler, lldb, and other related tools needed to provide a cohesive development experience for working in a specific version of Swift.
 
-4. Open Xcode’s `Preferences`, navigate to `Components > Toolchains`, and select the installed Swift for TensorFlow toolchain.
+4. Open Xcode's `Preferences`, navigate to `Components > Toolchains`, and select the installed Swift for TensorFlow toolchain.
 
-5. Xcode uses the selected toolchain for building Swift code, debugging, and even code completion and syntax coloring. You’ll see a new toolchain indicator in Xcode’s toolbar when Xcode is using a Swift toolchain. Select the Xcode toolchain to go back to Xcode’s built-in tools.  **Note:** in Xcode 10, you may also have to switch to the legacy build system.  In Xcode go to `File > Project Settings` and set the build system to `Legacy Build System`.
+5. Xcode uses the selected toolchain for building Swift code, debugging, and even code completion and syntax coloring. You'll see a new toolchain indicator in Xcode's toolbar when Xcode is using a Swift toolchain. Select the Xcode toolchain to go back to Xcode's built-in tools.
 
 <p align="center">
   <img src="docs/images/Installation-XcodePreferences.png?raw=true" alt="Select toolchain in Xcode preferences."/>

--- a/Usage.md
+++ b/Usage.md
@@ -151,16 +151,6 @@ Next, switch to the new toolchain. Open Xcode’s `Preferences`, navigate to `Co
 
 Swift for TensorFlow does not officially support Xcode Playgrounds, and related bugs are tracked by [TF-500](https://bugs.swift.org/browse/TF-500).
 
-To build an executable with Xcode 10 or 11, you must change some project settings from their default values:
-
- 1. In the menu bar, select `File > Project Settings`.
-
- 2. Then, select `Legacy Build System` for Build Settings and click `Done`.
-
- 3. In your target's Build Settings:
-   * Go to `Apple Clang - Code Generation > Optimization Level` and select `Fast [-O, O1]`. This isn't strictly necessary for debugging, but building without optimization will lead to much slower execution.
-   * Change `Runpath Search Paths` to `$(TOOLCHAIN_DIR)`.
-
 ## Visual Studio Code setup for Swift (only tested on Linux)
 
 1. Install the [LLDB extension](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb).


### PR DESCRIPTION
Using Xcode's legacy build system is no longer required.