### PR TITLE
Mention the legacy build system option

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -163,6 +163,8 @@ To install Swift for TensorFlow, download one of the packages below and follow t
     $ export LD_LIBRARY_PATH=/usr/local/cuda/lib:"${LD_LIBRARY_PATH}"
     ```
 
+**Note:** if after selecting the TensorFlow toolchain in Xcode you still get "No such module 'TensorFlow'" error try setting the legacy build system under `File` -> `Project Settings...` -> `Build System`
+
 ## Linux
 
 Packages for Linux are tar archives including a copy of the Swift compiler, lldb, and related tools. You can install them anywhere as long as the extracted tools are in your PATH.


### PR DESCRIPTION
I just install the toolchain (Xcode 11.3.1 - TF 0.6.0) and got _No such module TensofrFlow_ error. Looking through the issues there are 3 or 4 related to this error all fixed by setting the _Build System_ to `Legacy Build System` instead of the `New Build System` which is the default now.

This fix also works for me so I thought it could be a good idea to have it mentioned in the instructions.

Thanks for this repo!