### PR TITLE
This is required with the latest snapshot.

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -158,6 +158,7 @@ To install Swift for TensorFlow, download one of the packages below and follow t
 
     ```console
     $ export PATH=/Library/Developer/Toolchains/swift-latest/usr/bin:"${PATH}"
+    $ export DYLD_LIBRARY_PATH=/Library/Developer/Toolchains/swift-latest//usr/lib/swift/macosx/:"${DYLD_LIBRARY_PATH}"
     ```
 
 7. **CUDA-only**: If you downloaded a CUDA GPU-enabled toolchain, add the library path(s) for CUDA and cuDNN to `$LD_LIBRARY_PATH`:


### PR DESCRIPTION
Without this, s4tf form the command line produces:

```
s4tf$ swift run
dyld: Symbol not found: _$s11AllKeyPathss0B12PathIterablePTl
  Referenced from: /Library/Developer/Toolchains/swift-tensorflow-DEVELOPMENT-2020-02-04-a.xctoolchain/usr/lib/swift/macosx/libswiftTensorFlow.dylib
  Expected in: /usr/lib/swift/libswiftCore.dylib
 in /Library/Developer/Toolchains/swift-tensorflow-DEVELOPMENT-2020-02-04-a.xctoolchain/usr/lib/swift/macosx/libswiftTensorFlow.dylib
Abort trap: 6
```