### PR TITLE
import PythonKit or Python

### DIFF
--- a/docs/site/tutorials/model_training_walkthrough.ipynb
+++ b/docs/site/tutorials/model_training_walkthrough.ipynb
@@ -128,7 +128,11 @@
    "outputs": [],
    "source": [
     "import TensorFlow\n",
-    "import Python"
+    "#if canImport(PythonKit)\n",
+    "    import PythonKit\n",
+    "#else\n",
+    "    import Python\n",
+    "#endif"
    ]
   },
   {

--- a/docs/site/tutorials/python_interoperability.ipynb
+++ b/docs/site/tutorials/python_interoperability.ipynb
@@ -78,7 +78,11 @@
    },
    "outputs": [],
    "source": [
-    "import Python\n",
+    "#if canImport(PythonKit)\n",
+    "    import PythonKit\n",
+    "#else\n",
+    "    import Python\n",
+    "#endif\n",
     "print(Python.version)"
    ]
   },


### PR DESCRIPTION
Import PythonKit or Python depending on which one is available, to support the Python => PythonKit transition.