### PR TITLE
[AutoDiff] Update method-style differential operators in tutorial.

### DIFF
--- a/docs/site/tutorials/custom_differentiation.ipynb
+++ b/docs/site/tutorials/custom_differentiation.ipynb
@@ -108,7 +108,7 @@
     "    return pow(𝑒, x)\n",
     "}\n",
     "\n",
-    "@differentiating(sillyExp)\n",
+    "@derivative(of: sillyExp)\n",
     "func sillyDerivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {\n",
     "    let y = sillyExp(x)\n",
     "    return (value: y, pullback: { v in v * y })\n",


### PR DESCRIPTION
Use top-level differential operators instead of method-style ones, which have been removed.