### PR TITLE
fix python interoperability notebook

### DIFF
--- a/docs/site/tutorials/python_interoperability.ipynb
+++ b/docs/site/tutorials/python_interoperability.ipynb
@@ -78,6 +78,7 @@
    },
    "outputs": [],
    "source": [
+    "// comment so that Colab does not interpret `#if ...` as a comment\n",
     "#if canImport(PythonKit)\n",
     "    import PythonKit\n",
     "#else\n",


### PR DESCRIPTION
Colab treats the first line as a comment if it begins with "#". So adding any line above the "#if" line fixes it.

Fixes https://github.com/tensorflow/swift/issues/405.