### PR TITLE
docs: add installation instructions for Windows

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -83,13 +83,14 @@ To install Swift for TensorFlow, download one of the packages below and follow t
 
 ## Development Snapshots
 
-| Download | Date |
-|----------|------|
-| [Xcode 11](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2020-03-17-a-osx.pkg) | March 17, 2020 |
-| [Ubuntu 18.04 (CPU Only)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-ubuntu18.04.tar.gz) | Nightly |
-| [Ubuntu 18.04 (CUDA 10.1)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda10.1-cudnn7-ubuntu18.04.tar.gz) | Nightly |
-| [Ubuntu 18.04 (CUDA 10.0)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda10.0-cudnn7-ubuntu18.04.tar.gz) | Nightly |
-| [Ubuntu 18.04 (CUDA 9.2)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda9.2-cudnn7-ubuntu18.04.tar.gz) | Nightly |
+| Download |
+|----------|
+| [Xcode 11 (March 17, 2020)](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2020-03-17-a-osx.pkg) |
+| [Ubuntu 18.04 (CPU Only) (Nightly)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-ubuntu18.04.tar.gz) |
+| [Ubuntu 18.04 (CUDA 10.1) (Nightly)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda10.1-cudnn7-ubuntu18.04.tar.gz) |
+| [Ubuntu 18.04 (CUDA 10.0) (Nightly)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda10.0-cudnn7-ubuntu18.04.tar.gz) |
+| [Ubuntu 18.04 (CUDA 9.2) (Nightly)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda9.2-cudnn7-ubuntu18.04.tar.gz) |
+| [Windows (March 6, 2020)](https://storage.googleapis.com/azure-pipelines-storage/Swift%20for%20TensorFlow/Windows/s4tf-windows-x64-27604-20200306.1.exe) |
 
 <details>
   <summary>Older Packages</summary>
@@ -219,6 +220,58 @@ $ export PATH=$(pwd)/usr/bin:"${PATH}"
 You can now execute the `swift` command to run the REPL or build Swift projects.
 
 **Note:** If you are using a CUDA build and you have an NVIDIA GPU with a compute capability other than 3.5 or 7.0, then you will experience a ~10 minute delay the first time you execute a TensorFlow operation, while TensorFlow compiles kernels for your GPU's compute capability. The program will not print anything out and it will appear to be frozen.
+
+## Windows
+
+### Requirements
+
+* Windows 10 RedStone 4 (10.0.17763.0) or later
+* Visual Studio 2017 or later (Visual Studio 2019 is recommended)
+* CMake 3.16 or later
+
+### Installation
+
+1. Install Visual Studio from [Microsoft](https://visualstudio.microsoft.com).
+
+  The following table lists the **required** set of installed components:
+
+| Component | ID |
+|-----------|----|
+| MSVC v142 - VS 2019 C++ x64/x86 build tools (v14.25) | Microsoft.VisualStudio.Component.VC.Tools.x86.x64 |
+| Windows Univeral C Runtime | Microsoft.VisualStudio.Component.Windows10SDK |
+| Windows 10 SDK (10.0.17763.0)<sup>[1](#windows-sdk-version)</sup> | Microsoft.VisualStudio.Component.Windows10SDK.17763 |
+
+  <sup><a name="windows-sdk-version">1</a></sup> You may install a newer SDK if you desire. 17763 is listed here to match the minimum Windows release supported.
+
+  The following table lists the additional **recommended** set of installed components:
+
+| Component | ID |
+|-----------|----|
+| C++ ATL for latest v142 build tools (x86 & x64)<sup>[1](#windows-atl)</sup> | Microsoft.VisualStudio.Component.VC.ATL |
+| C++ CMake tools for Windows<sup>[2](#windows-cmake)</sup> | Microsoft.VisualStudio.Component.VC.CMake.Project |
+| Git for Windows<sup>[3](#windows-git)</sup> | Microsoft.VisualStudio.Component.Git |
+| Python 3 64-bit (3.7.5)<sup>[4](#windows-python)</sup> | Component.CPython.x64 |
+
+  <sup><a name="windows-atl">1</a></sup> Needed for parts of lldb<br/>
+  <sup><a name="windows-cmake">2</a></sup> Provides `ninja` which is needed for building projects. You may download it from [ninja-build](https://github.com/ninja-build/ninja) instead.<br/>
+  <sup><a name="windows-git">3</a></sup> Provides `git` to clone projects from GitHub. You may download it from [git-scm](https://git-scm.com/) instead.<br/>
+  <sup><a name="windows-python">4</a></sup> Provides `python` needed for Python integration. You may download it from [python](https://www.python.org/) instead.<br/>
+
+2. Install CMake from [cmake](https://www.cmake.org).
+
+3. Download and run the latest release from [Swift for TensorFlow](https://storage.googleapis.com/azure-pipelines-storage/Swift%20for%20TensorFlow/Windows/s4tf-windows-x64-27604-20200306.1.exe). The installer will install a toolchain into `%SystemDrive%\Library\Developer\Toolchains`. The toolchain (`.xctoolchain`) includes a copy of the compiler, lldb, and other related tools needed to provide a cohesive development experience for working in a specific version of Swift.
+
+4. Deploy the Windows SDK modulemaps from an (elevated) "Administrator" `x64 Native Tools for VS2019 Command Prompt` shell:
+
+```cmd
+set SDKROOT=%SystemDrive%\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk
+copy "%SDKROOT%\usr\share\ucrt.modulemap" "%UniversalCRTSdkDir%\Include\%UCRTVersion%\ucrt\module.modulemap"
+copy "%SDKROOT%\usr\share\visualc.modulemap" "%VCToolsInstallDir%\include\module.modulemap"
+copy "%SDKROOT%\usr\share\visualc.apinotes" "%VCToolsInstallDir%\include\visualc.apinotes"
+copy "%SDKROOT%\usr\share\winsdk.modulemap" "%UniversalCRTSdkDir%\Include\%UCRTVersion%\um\module.modulemap"
+```
+
+**NOTE**: this will be need to be re-run every time Visual Studio is updated.
 
 # Verify the Installation
 


### PR DESCRIPTION
This adds initial documentation for getting started with the Windows
build.  Although it references a static version of the build, the same
instructions currently apply to the nightlies.