### PR TITLE
Release 2020-04-17 toolchain for macOS.

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -85,7 +85,7 @@ To install Swift for TensorFlow, download one of the packages below and follow t
 
 | Download |
 |----------|
-| [Xcode 11 (April 15, 2020)](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2020-04-15-a-osx.pkg) |
+| [Xcode 11 (April 17, 2020)](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2020-04-17-a-osx.pkg) |
 | [Ubuntu 18.04 (CPU Only) (Nightly)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-ubuntu18.04.tar.gz) |
 | [Ubuntu 18.04 (x10 TPU, CPU) (Nightly)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-x10-ubuntu18.04.tar.gz) |
 | [Ubuntu 18.04 (CUDA 10.1) (Nightly)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda10.1-cudnn7-ubuntu18.04.tar.gz) |
@@ -101,6 +101,7 @@ To install Swift for TensorFlow, download one of the packages below and follow t
 
 | Download |
 |----------|
+| [April 15, 2020](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2020-04-15-a-osx.pkg) |
 | [April 7, 2020](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2020-04-07-a-osx.pkg) |
 | [March 25, 2020](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2020-03-25-a-osx.pkg) |
 | [March 20, 2020](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2020-03-20-a-osx.pkg) |


### PR DESCRIPTION
https://github.com/apple/swift/commit/039d371753a6d864b2057bb7953b79147ae6e6be

---

Notable change: fixed `swift build` serialization issue in https://github.com/apple/swift/pull/31083/commits/a0f098a4785a4e518f76e8c55f5cda7221fea951.

Known issue (TF-1252): `swift test` sometimes fails with a loader issue.

<details>
<p>

To reproduce (with Xcode 11.4):

```console
$ git clone https://github.com/ewconnell/swiftrt.git
$ git checkout autodiff
$ swift test
2020-04-18 10:55:55.135 xctest[41288:4216401] The bundle “SwiftRTPackageTests.xctest” couldn’t be loaded. Try reinstalling the bundle.
2020-04-18 10:55:55.135 xctest[41288:4216401] (dlopen(/tmp/swiftrt/.build/x86_64-apple-macosx/debug/SwiftRTPackageTests.xctest/Contents/MacOS/SwiftRTPackageTests, 265): Symbol not found: _$s13TangentVectors14DifferentiablePTl
  Referenced from: /tmp/swiftrt/.build/x86_64-apple-macosx/debug/SwiftRTPackageTests.xctest/Contents/MacOS/SwiftRTPackageTests
  Expected in: /usr/lib/swift/libswiftCore.dylib
 in /tmp/swiftrt/.build/x86_64-apple-macosx/debug/SwiftRTPackageTests.xctest/Contents/MacOS/SwiftRTPackageTests)
```

</p>
</details>