### PR TITLE
[dpcs] Remove reference to deprecated type.

### DIFF
--- a/docs/DifferentiableFunctions.md
+++ b/docs/DifferentiableFunctions.md
@@ -176,7 +176,7 @@ methods return the partial derivative with respect to `self`. For these methods,
 `@differentiable` infers `self` as a varying parameter by default.
 
 ```swift
-struct Vector: Differentiable, VectorNumeric {
+struct Vector: Differentiable {
     var x, y: Float
 
     // Differentiable computed property.


### PR DESCRIPTION
`VectorNumeric` has been renamed to `VectorProtocol`.
Remove reference to `VectorNumeric`, since it's not important to the example.