### PR TITLE
Update Usage.md Colab and REPL instructions

### DIFF
--- a/Usage.md
+++ b/Usage.md
@@ -2,7 +2,6 @@
 
 This document explains basic usage of Swift for TensorFlow, including:
 * How to run Swift in Colaboratory
-* How to run the Swift REPL
 * How to use the Swift interpreter and compiler
 * How to use Swift for TensorFlow with Xcode (**macOS only**)
 
@@ -14,56 +13,11 @@ To see example models written using Swift for TensorFlow, go to [tensorflow/swif
 
 [Colaboratory](https://colab.research.google.com) is a free [Jupyter](https://jupyter.org/) notebook environment that requires no setup and runs entirely in the cloud.
 
-To launch Swift in Colab, just open [this blank Swift notebook](https://colab.research.google.com/github/tensorflow/swift/blob/master/notebooks/blank_swift.ipynb)!
+[Click here to create a Swift notebook in Colaboratory](https://colab.research.google.com/notebook#create=true&language=swift)!
 
 Put Swift code in the cell, and click the play button on the left of the cell (or hit Ctrl + Enter) to execute it.
 
 For examples of what you can do, visit [this tutorial](https://colab.research.google.com/github/tensorflow/swift/blob/master/docs/site/tutorials/model_training_walkthrough.ipynb) in Colab.
-
-## REPL (Read Eval Print Loop)
-
-You must have a working toolchain for Swift for TensorFlow (`swift`, `swiftc`, etc) before proceeding with these instructions. If not, please [install Swift for TensorFlow](Installation.md) or [build from source](https://github.com/apple/swift/blob/tensorflow/README.md) before proceeding.
-
-An easy way to experiment with Swift is the Read Eval Print Loop, or REPL. To try it, open your terminal application and run `swift`.
-
-You should see a prompt, similar to the following:
-
-```console
-Welcome to Swift version 4.2-dev (LLVM 04bdb56f3d, Clang b44dbbdf44). Type :help for assistance.
-  1>
-```
-
-You can type Swift statements and the REPL will execute them immediately. Results are formatted nicely:
-
-```console
-  1> import TensorFlow
-  2> var x = Tensor<Float>([[1, 2], [3, 4]])
-x: TensorFlow.Tensor<Float> = [[1.0, 2.0], [3.0, 4.0]]
-  3> x + x
-$R0: TensorFlow.Tensor<Float> = [[2.0, 4.0], [6.0, 8.0]]
-  4> for _ in 0..<3 {
-  5.     x += x
-  6. }
-  7> x
-$R1: TensorFlow.Tensor<Float> = [[8.0, 16.0], [24.0, 32.0]]
-  8> x[0] + x[1]
-$R2: TensorFlow.Tensor<Float> = [32.0, 48.0]
-```
-
-**Note:** using the `TensorFlow` module in the Swift REPL on macOS is known to
-be problematic since Swift for TensorFlow 0.5.
-[TF-940](https://bugs.swift.org/browse/TF-940) tracks this issue.
-
-```console
-$ swift
-Welcome to Swift version 5.1-dev (LLVM 200186e28b, Swift 1238976565).
-Type :help for assistance.
-  1> import TensorFlow
-  2> Tensor(1)
-error: Couldn't lookup symbols:
-  TensorFlow.TensorHandle.init(copyingFromCTensor: Swift.OpaquePointer) -> TensorFlow.TensorHandle<A>
-  TensorFlow.TensorHandle.init(copyingFromCTensor: Swift.OpaquePointer) -> TensorFlow.TensorHandle<A>
-```
 
 ## Interpreter
 


### PR DESCRIPTION
* Updates the Colab instructions to use the "create new notebook" link that recently appeared.
* Deletes the REPL usage instructions, because we do not want to support it until we have more time to keep it stable. (Colab and Swift-Jupyter are the suggested alternatives).