### PR TITLE
Release 2020-05-08 toolchain for macOS.

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -96,7 +96,7 @@ To install Swift for TensorFlow, download one of the packages below and follow t
 
 | Download |
 |----------|
-| [Xcode 11 (May 7, 2020)](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2020-05-07-a-osx.pkg) |
+| [Xcode 11 (May 8, 2020)](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2020-05-08-a-osx.pkg) |
 | [Ubuntu 18.04 (CPU, TPU) (Nightly)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-ubuntu18.04.tar.gz) |
 | [Ubuntu 18.04 (CPU, CUDA 10.2, TPU) (Nightly)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda10.2-cudnn7-ubuntu18.04.tar.gz) |
 | [Ubuntu 18.04 (CPU, CUDA 10.1, TPU) (Nightly)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda10.1-cudnn7-ubuntu18.04.tar.gz) |
@@ -111,6 +111,7 @@ To install Swift for TensorFlow, download one of the packages below and follow t
 
 | Download |
 |----------|
+| [May 7, 2020](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2020-05-07-a-osx.pkg) |
 | [May 3, 2020](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2020-05-03-a-osx.pkg) |
 | [April 17, 2020](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2020-04-17-a-osx.pkg) |
 | [April 15, 2020](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2020-04-15-a-osx.pkg) |


### PR DESCRIPTION
https://github.com/apple/swift/commit/a68fa1120ed849d60aa27a1dad5589d9b64ff934

---

Notable changes: TF-1260 (macOS 10.15 `swiftc` binary dynamic linker issues) has been fixed.

We shouldn't see errors like this anymore:
```
dyld: Symbol not found: _$s11AllKeyPathss0B12PathIterablePTl
  Referenced from: /Library/Developer/Toolchains/swift-tensorflow-DEVELOPMENT-2020-04-23-a.xctoolchain/usr/lib/swift/macosx/libswiftTensorFlow.dylib
  Expected in: /usr/lib/swift/libswiftCore.dylib
 in /Library/Developer/Toolchains/swift-tensorflow-DEVELOPMENT-2020-04-23-a.xctoolchain/usr/lib/swift/macosx/libswiftTensorFlow.dylib
[1]    67267 abort      ./tf
```