### PR TITLE
Quick fix for missing comment on the license block.

### DIFF
--- a/docs/site/tutorials/introducing_x10.ipynb
+++ b/docs/site/tutorials/introducing_x10.ipynb
@@ -53,7 +53,7 @@
         "colab": {}
       },
       "source": [
-        "#@title Licensed under the Apache License, Version 2.0 (the \"License\"); { display-mode: \"form\" }\n",
+        "// #@title Licensed under the Apache License, Version 2.0 (the \"License\"); { display-mode: \"form\" }\n",
         "// Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "// you may not use this file except in compliance with the License.\n",
         "// You may obtain a copy of the License at\n",


### PR DESCRIPTION
I accidentally lost a comment when I moved the comment block down to insert the package installation cell. This should fix the errors we're observing in our internal tests.