### PR TITLE
X10 tutorial - avoid `scalarized()` in loops for defaultXLA

### DIFF
--- a/docs/site/tutorials/introducing_x10.ipynb
+++ b/docs/site/tutorials/introducing_x10.ipynb
@@ -309,7 +309,7 @@
         "colab_type": "text"
       },
       "source": [
-        "\"Now, we will implement basic progress tracking and reporting.  All intermediate statistics are kept as tensors on the same device where training is run and `scalarized()` is called only during reporting. This will be especially important later when using X10, because it avoids unnecessary materialization of lazy tensors.\""
+        "Now, we will implement basic progress tracking and reporting.  All intermediate statistics are kept as tensors on the same device where training is run and `scalarized()` is called only during reporting. This will be especially important later when using X10, because it avoids unnecessary materialization of lazy tensors."
       ]
     },
     {

--- a/docs/site/tutorials/introducing_x10.ipynb
+++ b/docs/site/tutorials/introducing_x10.ipynb
@@ -36,26 +36,14 @@
       "metadata": {
         "colab_type": "code",
         "id": "kZRlD4utdPuX",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        },
-        "outputId": "34002f79-193b-4341-9649-a5ac7452be20"
+        "colab": {}
       },
       "source": [
         "%install '.package(url: \"https://github.com/tensorflow/swift-models\", .branch(\"tensorflow-0.9\"))' Datasets ImageClassificationModels\n",
         "print(\"\\u{001B}[2J\")"
       ],
-      "execution_count": 1,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "\r\n"
-          ],
-          "name": "stdout"
-        }
-      ]
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -276,11 +264,7 @@
       "metadata": {
         "colab_type": "code",
         "id": "kqXILiXhq-iM",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 309
-        },
-        "outputId": "dff4d635-70fd-4470-a008-de398841aee7"
+        "colab": {}
       },
       "source": [
         "import Datasets\n",
@@ -289,31 +273,8 @@
         "let batchSize = 128\n",
         "let dataset = MNIST(batchSize: batchSize)"
       ],
-      "execution_count": 4,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Loading resource: train-images-idx3-ubyte\r\n",
-            "File does not exist locally at expected path: /root/.cache/swift-models/datasets/MNIST/train-images-idx3-ubyte and must be fetched\r\n",
-            "Fetching URL: https://storage.googleapis.com/cvdf-datasets/mnist/train-images-idx3-ubyte.gz...\n",
-            "Archive saved to: /root/.cache/swift-models/datasets/MNIST\n",
-            "Loading resource: train-labels-idx1-ubyte\n",
-            "File does not exist locally at expected path: /root/.cache/swift-models/datasets/MNIST/train-labels-idx1-ubyte and must be fetched\n",
-            "Fetching URL: https://storage.googleapis.com/cvdf-datasets/mnist/train-labels-idx1-ubyte.gz...\n",
-            "Archive saved to: /root/.cache/swift-models/datasets/MNIST\n",
-            "Loading resource: t10k-images-idx3-ubyte\n",
-            "File does not exist locally at expected path: /root/.cache/swift-models/datasets/MNIST/t10k-images-idx3-ubyte and must be fetched\n",
-            "Fetching URL: https://storage.googleapis.com/cvdf-datasets/mnist/t10k-images-idx3-ubyte.gz...\n",
-            "Archive saved to: /root/.cache/swift-models/datasets/MNIST\n",
-            "Loading resource: t10k-labels-idx1-ubyte\n",
-            "File does not exist locally at expected path: /root/.cache/swift-models/datasets/MNIST/t10k-labels-idx1-ubyte and must be fetched\n",
-            "Fetching URL: https://storage.googleapis.com/cvdf-datasets/mnist/t10k-labels-idx1-ubyte.gz...\n",
-            "Archive saved to: /root/.cache/swift-models/datasets/MNIST\n"
-          ],
-          "name": "stdout"
-        }
-      ]
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -400,11 +361,7 @@
       "metadata": {
         "colab_type": "code",
         "id": "W9bUsiOxVf_v",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 139
-        },
-        "outputId": "aee85b65-c302-44a6-a1ab-fe5f3ef68a96"
+        "colab": {}
       },
       "source": [
         "print(\"Beginning training...\")\n",
@@ -447,21 +404,8 @@
         "        \"\"\")\n",
         "}"
       ],
-      "execution_count": 16,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Beginning training...\n",
-            "[Epoch 1] Training Loss: 0.047, Training Accuracy: 59084/60000 (98.5%), Test Loss: 0.048, Test Accuracy: 9842/10000 (98.4%) seconds per epoch: 36.0\n",
-            "[Epoch 2] Training Loss: 0.040, Training Accuracy: 59282/60000 (98.8%), Test Loss: 0.051, Test Accuracy: 9838/10000 (98.4%) seconds per epoch: 35.5\n",
-            "[Epoch 3] Training Loss: 0.035, Training Accuracy: 59354/60000 (98.9%), Test Loss: 0.047, Test Accuracy: 9849/10000 (98.5%) seconds per epoch: 35.3\n",
-            "[Epoch 4] Training Loss: 0.031, Training Accuracy: 59402/60000 (99.0%), Test Loss: 0.044, Test Accuracy: 9856/10000 (98.6%) seconds per epoch: 35.4\n",
-            "[Epoch 5] Training Loss: 0.027, Training Accuracy: 59492/60000 (99.2%), Test Loss: 0.044, Test Accuracy: 9860/10000 (98.6%) seconds per epoch: 35.4\n"
-          ],
-          "name": "stdout"
-        }
-      ]
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -490,34 +434,14 @@
       "metadata": {
         "id": "MaN7fM-lAe7r",
         "colab_type": "code",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 85
-        },
-        "outputId": "5e756224-6e44-4972-92ee-12d0bd0dba7a"
+        "colab": {}
       },
       "source": [
         "let device = Device.defaultXLA\n",
         "device"
       ],
-      "execution_count": 17,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "▿ Device(kind: .CPU, ordinal: 0, backend: .XLA)\n",
-              "  - kind : TensorFlow.Device.Kind.CPU\n",
-              "  - ordinal : 0\n",
-              "  - backend : TensorFlow.Device.Backend.XLA\n"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 17
-        }
-      ]
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -569,11 +493,7 @@
       "metadata": {
         "colab_type": "code",
         "id": "XrZee8n3Y17_",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 139
-        },
-        "outputId": "8ee567c7-6b5c-477c-b3be-c3290d2eb133"
+        "colab": {}
       },
       "source": [
         "print(\"Beginning training...\")\n",
@@ -622,21 +542,8 @@
         "        \"\"\")\n",
         "}"
       ],
-      "execution_count": 21,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Beginning training...\n",
-            "[Epoch 1] Training Loss: 0.462, Training Accuracy: 51378/60000 (85.6%), Test Loss: 0.154, Test Accuracy: 9536/10000 (95.4%) seconds per epoch: 48.3\n",
-            "[Epoch 2] Training Loss: 0.131, Training Accuracy: 57582/60000 (96.0%), Test Loss: 0.109, Test Accuracy: 9655/10000 (96.6%) seconds per epoch: 41.4\n",
-            "[Epoch 3] Training Loss: 0.090, Training Accuracy: 58346/60000 (97.2%), Test Loss: 0.086, Test Accuracy: 9706/10000 (97.1%) seconds per epoch: 39.2\n",
-            "[Epoch 4] Training Loss: 0.070, Training Accuracy: 58695/60000 (97.8%), Test Loss: 0.121, Test Accuracy: 9566/10000 (95.7%) seconds per epoch: 39.3\n",
-            "[Epoch 5] Training Loss: 0.057, Training Accuracy: 58924/60000 (98.2%), Test Loss: 0.068, Test Accuracy: 9781/10000 (97.8%) seconds per epoch: 39.2\n"
-          ],
-          "name": "stdout"
-        }
-      ]
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",

--- a/docs/site/tutorials/introducing_x10.ipynb
+++ b/docs/site/tutorials/introducing_x10.ipynb
@@ -309,7 +309,7 @@
         "colab_type": "text"
       },
       "source": [
-        "Now, we wiil implement basic progress tracking and reporting.  All data is kept as tensors on the same device where training is run and calls `scalarized()` only during reporting to avoid unneccesary materialization of lazy tensors."
+        "\"Now, we will implement basic progress tracking and reporting.  All intermediate statistics are kept as tensors on the same device where training is run and `scalarized()` is called only during reporting. This will be especially important later when using X10, because it avoids unnecessary materialization of lazy tensors.\""
       ]
     },
     {
@@ -325,7 +325,9 @@
         "    var totalGuessCount = Tensor<Int32>(0, on: Device.default)\n",
         "    var totalLoss = Tensor<Float>(0, on: Device.default)\n",
         "    var batches: Int = 0\n",
-        "    var accuracy: Float { Float(correctGuessCount.scalarized()) / Float(totalGuessCount.scalarized()) * 100 } \n",
+        "    var accuracy: Float { \n",
+        "        Float(correctGuessCount.scalarized()) / Float(totalGuessCount.scalarized()) * 100 \n",
+        "    } \n",
         "    var averageLoss: Float { totalLoss.scalarized() / Float(batches) }\n",
         "\n",
         "    init(on device: Device = Device.default) {\n",

--- a/docs/site/tutorials/introducing_x10.ipynb
+++ b/docs/site/tutorials/introducing_x10.ipynb
@@ -36,14 +36,26 @@
       "metadata": {
         "colab_type": "code",
         "id": "kZRlD4utdPuX",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        },
+        "outputId": "34002f79-193b-4341-9649-a5ac7452be20"
       },
       "source": [
         "%install '.package(url: \"https://github.com/tensorflow/swift-models\", .branch(\"tensorflow-0.9\"))' Datasets ImageClassificationModels\n",
         "print(\"\\u{001B}[2J\")"
       ],
-      "execution_count": 0,
-      "outputs": []
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "\r\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "code",
@@ -133,7 +145,8 @@
         "colab": {}
       },
       "source": [
-        "import TensorFlow"
+        "import TensorFlow\n",
+        "import Foundation"
       ],
       "execution_count": 0,
       "outputs": []
@@ -263,7 +276,11 @@
       "metadata": {
         "colab_type": "code",
         "id": "kqXILiXhq-iM",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 309
+        },
+        "outputId": "dff4d635-70fd-4470-a008-de398841aee7"
       },
       "source": [
         "import Datasets\n",
@@ -272,8 +289,31 @@
         "let batchSize = 128\n",
         "let dataset = MNIST(batchSize: batchSize)"
       ],
-      "execution_count": 0,
-      "outputs": []
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Loading resource: train-images-idx3-ubyte\r\n",
+            "File does not exist locally at expected path: /root/.cache/swift-models/datasets/MNIST/train-images-idx3-ubyte and must be fetched\r\n",
+            "Fetching URL: https://storage.googleapis.com/cvdf-datasets/mnist/train-images-idx3-ubyte.gz...\n",
+            "Archive saved to: /root/.cache/swift-models/datasets/MNIST\n",
+            "Loading resource: train-labels-idx1-ubyte\n",
+            "File does not exist locally at expected path: /root/.cache/swift-models/datasets/MNIST/train-labels-idx1-ubyte and must be fetched\n",
+            "Fetching URL: https://storage.googleapis.com/cvdf-datasets/mnist/train-labels-idx1-ubyte.gz...\n",
+            "Archive saved to: /root/.cache/swift-models/datasets/MNIST\n",
+            "Loading resource: t10k-images-idx3-ubyte\n",
+            "File does not exist locally at expected path: /root/.cache/swift-models/datasets/MNIST/t10k-images-idx3-ubyte and must be fetched\n",
+            "Fetching URL: https://storage.googleapis.com/cvdf-datasets/mnist/t10k-images-idx3-ubyte.gz...\n",
+            "Archive saved to: /root/.cache/swift-models/datasets/MNIST\n",
+            "Loading resource: t10k-labels-idx1-ubyte\n",
+            "File does not exist locally at expected path: /root/.cache/swift-models/datasets/MNIST/t10k-labels-idx1-ubyte and must be fetched\n",
+            "Fetching URL: https://storage.googleapis.com/cvdf-datasets/mnist/t10k-labels-idx1-ubyte.gz...\n",
+            "Archive saved to: /root/.cache/swift-models/datasets/MNIST\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -304,6 +344,50 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "cwNDwzS2QgS1",
+        "colab_type": "text"
+      },
+      "source": [
+        "Now, we wiil implement basic progress tracking and reporting.  All data is kept as tensors on the same device where training is run and calls `scalarized()` only during reporting to avoid unneccesary materialization of lazy tensors."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "eNzOdly3QY_P",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "struct Statistics {\n",
+        "    var correctGuessCount = Tensor<Int32>(0, on: Device.default)\n",
+        "    var totalGuessCount = Tensor<Int32>(0, on: Device.default)\n",
+        "    var totalLoss = Tensor<Float>(0, on: Device.default)\n",
+        "    var batches: Int = 0\n",
+        "    var accuracy: Float { Float(correctGuessCount.scalarized()) / Float(totalGuessCount.scalarized()) * 100 } \n",
+        "    var averageLoss: Float { totalLoss.scalarized() / Float(batches) }\n",
+        "\n",
+        "    init(on device: Device = Device.default) {\n",
+        "        correctGuessCount = Tensor<Int32>(0, on: device)\n",
+        "        totalGuessCount = Tensor<Int32>(0, on: device)\n",
+        "        totalLoss = Tensor<Float>(0, on: device)\n",
+        "    }\n",
+        "\n",
+        "    mutating func update(logits: Tensor<Float>, labels: Tensor<Int32>, loss: Tensor<Float>) {\n",
+        "        let correct = logits.argmax(squeezingAxis: 1) .== labels\n",
+        "        correctGuessCount += Tensor<Int32>(correct).sum()\n",
+        "        totalGuessCount += Int32(labels.shape[0])\n",
+        "        totalLoss += loss\n",
+        "        batches += 1\n",
+        "    }\n",
+        "}"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "colab_type": "text",
         "id": "w3lmTRCWT5sS"
       },
@@ -316,19 +400,17 @@
       "metadata": {
         "colab_type": "code",
         "id": "W9bUsiOxVf_v",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 139
+        },
+        "outputId": "aee85b65-c302-44a6-a1ab-fe5f3ef68a96"
       },
       "source": [
         "print(\"Beginning training...\")\n",
         "\n",
-        "struct Statistics {\n",
-        "    var correctGuessCount: Int = 0\n",
-        "    var totalGuessCount: Int = 0\n",
-        "    var totalLoss: Float = 0\n",
-        "    var batches: Int = 0\n",
-        "}\n",
-        "\n",
         "for epoch in 1...epochCount {\n",
+        "    let start = Date()\n",
         "    var trainStats = Statistics()\n",
         "    var testStats = Statistics()\n",
         "    \n",
@@ -337,13 +419,8 @@
         "        let (images, labels) = (batch.first, batch.second)\n",
         "        let 𝛁model = TensorFlow.gradient(at: eagerModel) { eagerModel -> Tensor<Float> in\n",
         "            let ŷ = eagerModel(images)\n",
-        "            let correctPredictions = ŷ.argmax(squeezingAxis: 1) .== labels\n",
-        "            trainStats.correctGuessCount += Int(\n",
-        "                Tensor<Int32>(correctPredictions).sum().scalarized())\n",
-        "            trainStats.totalGuessCount += batch.first.shape[0]\n",
         "            let loss = softmaxCrossEntropy(logits: ŷ, labels: labels)\n",
-        "            trainStats.totalLoss += loss.scalarized()\n",
-        "            trainStats.batches += 1\n",
+        "            trainStats.update(logits: ŷ, labels: labels, loss: loss)\n",
         "            return loss\n",
         "        }\n",
         "        eagerOptimizer.update(&eagerModel, along: 𝛁model)\n",
@@ -353,30 +430,38 @@
         "    for batch in dataset.test.sequenced() {\n",
         "        let (images, labels) = (batch.first, batch.second)\n",
         "        let ŷ = eagerModel(images)\n",
-        "        let correctPredictions = ŷ.argmax(squeezingAxis: 1) .== labels\n",
         "        let loss = softmaxCrossEntropy(logits: ŷ, labels: labels)\n",
-        "        testStats.correctGuessCount += Int(Tensor<Int32>(correctPredictions).sum().scalarized())\n",
-        "        testStats.totalGuessCount += batch.first.shape[0]\n",
-        "        testStats.totalLoss += loss.scalarized()\n",
-        "        testStats.batches += 1\n",
+        "        testStats.update(logits: ŷ, labels: labels, loss: loss)\n",
         "    }\n",
         "\n",
-        "    let trainAccuracy = Float(trainStats.correctGuessCount) / Float(trainStats.totalGuessCount)\n",
-        "    let testAccuracy = Float(testStats.correctGuessCount) / Float(testStats.totalGuessCount)\n",
         "    print(\n",
         "        \"\"\"\n",
         "        [Epoch \\(epoch)] \\\n",
-        "        Training Loss: \\(trainStats.totalLoss / Float(trainStats.batches)), \\\n",
+        "        Training Loss: \\(String(format: \"%.3f\", trainStats.averageLoss)), \\\n",
         "        Training Accuracy: \\(trainStats.correctGuessCount)/\\(trainStats.totalGuessCount) \\\n",
-        "        (\\(trainAccuracy)), \\\n",
-        "        Test Loss: \\(testStats.totalLoss / Float(testStats.batches)), \\\n",
+        "        (\\(String(format: \"%.1f\", trainStats.accuracy))%), \\\n",
+        "        Test Loss: \\(String(format: \"%.3f\", testStats.averageLoss)), \\\n",
         "        Test Accuracy: \\(testStats.correctGuessCount)/\\(testStats.totalGuessCount) \\\n",
-        "        (\\(testAccuracy))\n",
+        "        (\\(String(format: \"%.1f\", testStats.accuracy))%) \\\n",
+        "        seconds per epoch: \\(String(format: \"%.1f\", Date().timeIntervalSince(start)))\n",
         "        \"\"\")\n",
         "}"
       ],
-      "execution_count": 0,
-      "outputs": []
+      "execution_count": 16,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Beginning training...\n",
+            "[Epoch 1] Training Loss: 0.047, Training Accuracy: 59084/60000 (98.5%), Test Loss: 0.048, Test Accuracy: 9842/10000 (98.4%) seconds per epoch: 36.0\n",
+            "[Epoch 2] Training Loss: 0.040, Training Accuracy: 59282/60000 (98.8%), Test Loss: 0.051, Test Accuracy: 9838/10000 (98.4%) seconds per epoch: 35.5\n",
+            "[Epoch 3] Training Loss: 0.035, Training Accuracy: 59354/60000 (98.9%), Test Loss: 0.047, Test Accuracy: 9849/10000 (98.5%) seconds per epoch: 35.3\n",
+            "[Epoch 4] Training Loss: 0.031, Training Accuracy: 59402/60000 (99.0%), Test Loss: 0.044, Test Accuracy: 9856/10000 (98.6%) seconds per epoch: 35.4\n",
+            "[Epoch 5] Training Loss: 0.027, Training Accuracy: 59492/60000 (99.2%), Test Loss: 0.044, Test Accuracy: 9860/10000 (98.6%) seconds per epoch: 35.4\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -405,14 +490,34 @@
       "metadata": {
         "id": "MaN7fM-lAe7r",
         "colab_type": "code",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 85
+        },
+        "outputId": "5e756224-6e44-4972-92ee-12d0bd0dba7a"
       },
       "source": [
         "let device = Device.defaultXLA\n",
         "device"
       ],
-      "execution_count": 0,
-      "outputs": []
+      "execution_count": 17,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "▿ Device(kind: .CPU, ordinal: 0, backend: .XLA)\n",
+              "  - kind : TensorFlow.Device.Kind.CPU\n",
+              "  - ordinal : 0\n",
+              "  - backend : TensorFlow.Device.Backend.XLA\n"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 17
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -464,21 +569,19 @@
       "metadata": {
         "colab_type": "code",
         "id": "XrZee8n3Y17_",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 139
+        },
+        "outputId": "8ee567c7-6b5c-477c-b3be-c3290d2eb133"
       },
       "source": [
         "print(\"Beginning training...\")\n",
         "\n",
-        "struct Statistics {\n",
-        "    var correctGuessCount: Int = 0\n",
-        "    var totalGuessCount: Int = 0\n",
-        "    var totalLoss: Float = 0\n",
-        "    var batches: Int = 0\n",
-        "}\n",
-        "\n",
         "for epoch in 1...epochCount {\n",
-        "    var trainStats = Statistics()\n",
-        "    var testStats = Statistics()\n",
+        "    let start = Date()\n",
+        "    var trainStats = Statistics(on: device)\n",
+        "    var testStats = Statistics(on: device)\n",
         "    \n",
         "    Context.local.learningPhase = .training\n",
         "    for batch in dataset.training.sequenced() {\n",
@@ -487,13 +590,8 @@
         "        let labels = Tensor(copying: eagerLabels, to: device)\n",
         "        let 𝛁model = TensorFlow.gradient(at: x10Model) { x10Model -> Tensor<Float> in\n",
         "            let ŷ = x10Model(images)\n",
-        "            let correctPredictions = ŷ.argmax(squeezingAxis: 1) .== labels\n",
-        "            trainStats.correctGuessCount += Int(\n",
-        "                Tensor<Int32>(correctPredictions).sum().scalarized())\n",
-        "            trainStats.totalGuessCount += batch.first.shape[0]\n",
         "            let loss = softmaxCrossEntropy(logits: ŷ, labels: labels)\n",
-        "            trainStats.totalLoss += loss.scalarized()\n",
-        "            trainStats.batches += 1\n",
+        "            trainStats.update(logits: ŷ, labels: labels, loss: loss)\n",
         "            return loss\n",
         "        }\n",
         "        x10Optimizer.update(&x10Model, along: 𝛁model)\n",
@@ -506,31 +604,39 @@
         "        let images = Tensor(copying: eagerImages, to: device)\n",
         "        let labels = Tensor(copying: eagerLabels, to: device)\n",
         "        let ŷ = x10Model(images)\n",
-        "        let correctPredictions = ŷ.argmax(squeezingAxis: 1) .== labels\n",
         "        let loss = softmaxCrossEntropy(logits: ŷ, labels: labels)\n",
         "        LazyTensorBarrier()\n",
-        "        testStats.correctGuessCount += Int(Tensor<Int32>(correctPredictions).sum().scalarized())\n",
-        "        testStats.totalGuessCount += batch.first.shape[0]\n",
-        "        testStats.totalLoss += loss.scalarized()\n",
-        "        testStats.batches += 1\n",
+        "        testStats.update(logits: ŷ, labels: labels, loss: loss)\n",
         "    }\n",
         "\n",
-        "    let trainAccuracy = Float(trainStats.correctGuessCount) / Float(trainStats.totalGuessCount)\n",
-        "    let testAccuracy = Float(testStats.correctGuessCount) / Float(testStats.totalGuessCount)\n",
         "    print(\n",
         "        \"\"\"\n",
         "        [Epoch \\(epoch)] \\\n",
-        "        Training Loss: \\(trainStats.totalLoss / Float(trainStats.batches)), \\\n",
+        "        Training Loss: \\(String(format: \"%.3f\", trainStats.averageLoss)), \\\n",
         "        Training Accuracy: \\(trainStats.correctGuessCount)/\\(trainStats.totalGuessCount) \\\n",
-        "        (\\(trainAccuracy)), \\\n",
-        "        Test Loss: \\(testStats.totalLoss / Float(testStats.batches)), \\\n",
+        "        (\\(String(format: \"%.1f\", trainStats.accuracy))%), \\\n",
+        "        Test Loss: \\(String(format: \"%.3f\", testStats.averageLoss)), \\\n",
         "        Test Accuracy: \\(testStats.correctGuessCount)/\\(testStats.totalGuessCount) \\\n",
-        "        (\\(testAccuracy))\n",
+        "        (\\(String(format: \"%.1f\", testStats.accuracy))%) \\\n",
+        "        seconds per epoch: \\(String(format: \"%.1f\", Date().timeIntervalSince(start)))\n",
         "        \"\"\")\n",
         "}"
       ],
-      "execution_count": 0,
-      "outputs": []
+      "execution_count": 21,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Beginning training...\n",
+            "[Epoch 1] Training Loss: 0.462, Training Accuracy: 51378/60000 (85.6%), Test Loss: 0.154, Test Accuracy: 9536/10000 (95.4%) seconds per epoch: 48.3\n",
+            "[Epoch 2] Training Loss: 0.131, Training Accuracy: 57582/60000 (96.0%), Test Loss: 0.109, Test Accuracy: 9655/10000 (96.6%) seconds per epoch: 41.4\n",
+            "[Epoch 3] Training Loss: 0.090, Training Accuracy: 58346/60000 (97.2%), Test Loss: 0.086, Test Accuracy: 9706/10000 (97.1%) seconds per epoch: 39.2\n",
+            "[Epoch 4] Training Loss: 0.070, Training Accuracy: 58695/60000 (97.8%), Test Loss: 0.121, Test Accuracy: 9566/10000 (95.7%) seconds per epoch: 39.3\n",
+            "[Epoch 5] Training Loss: 0.057, Training Accuracy: 58924/60000 (98.2%), Test Loss: 0.068, Test Accuracy: 9781/10000 (97.8%) seconds per epoch: 39.2\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "markdown",


### PR DESCRIPTION
Keeping accumulated training statistics as tensors and only calling `scalarized()` for printing appears to speed up performance ~2x with XLA devices.  The timings below were done on Colab free instances.

- seconds per epoch - CPU - XLA goes from 82 to 39 
- seconds per epoch - TPU - XLA goes from 11.8 to 6.5
- seconds per epoch - CPU - Eager - goes from 37 to 35 (probably noise, reported for comparison)

The changes I made are:

-  import Foundation to time and report seconds per epoch
-  data in Statistics struct as Tensors so `scalarized()` called outside batch loops
-  add `Statistics.init(on: device)` to avoid device mismatch errors
-  DRY accumulating batch statistics with `update()` method
-  format print strings with fewer decimal places

There may be a simpler way to get the same impact in the training tutorial.  Also, I have seen [similar Statistics code](https://github.com/tensorflow/swift-apis/blob/master/Sources/x10/swift_bindings/training_loop.swift#L122) that might be a more general solution.
 