### PR TITLE
Release 2020-05-13 toolchain for macOS.

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -95,7 +95,7 @@ To install Swift for TensorFlow, download one of the packages below and follow t
 
 | Download |
 |----------|
-| [Xcode 11 (May 9, 2020)](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2020-05-09-a-osx.pkg) |
+| [Xcode 11 (May 13, 2020)](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2020-05-13-a-osx.pkg) |
 | [Ubuntu 18.04 (CPU, TPU) (Nightly)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-ubuntu18.04.tar.gz) |
 | [Ubuntu 18.04 (CPU, CUDA 10.2, TPU) (Nightly)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda10.2-cudnn7-ubuntu18.04.tar.gz) |
 | [Ubuntu 18.04 (CPU, CUDA 10.1, TPU) (Nightly)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda10.1-cudnn7-ubuntu18.04.tar.gz) |
@@ -110,6 +110,7 @@ To install Swift for TensorFlow, download one of the packages below and follow t
 
 | Download |
 |----------|
+| [May 9, 2020](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2020-05-09-a-osx.pkg) |
 | [May 8, 2020](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2020-05-08-a-osx.pkg) |
 | [May 7, 2020](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2020-05-07-a-osx.pkg) |
 | [May 3, 2020](https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-2020-05-03-a-osx.pkg) |


### PR DESCRIPTION
https://github.com/apple/swift/commit/112f6d30ba69857fea2115e9836a55c89b355f20

---

Notable changes:
* `swift-DEVELOPMENT-SNAPSHOT-2020-05-11-a (2020-05-12) -> tensorflow` merge.

Slight regression: `swift -Xllvm -debug` isn't enabled for macOS toolchains.
```console
$ swift -Xllvm -debug-only=differentiation test.swift
swift (LLVM option parsing): Unknown command line argument '-debug-only=differentiation'.  Try: 'swift (LLVM option parsing) --help'
swift (LLVM option parsing): Did you mean '--debug-pass=differentiation'?
```

We're not yet sure why this is the case, because macOS toolchains are built with `--assertions` and `-DLLVM_ENABLE_ASSERTIONS:BOOL=TRUE`.

This issue isn't reproducible with post-merge Linux toolchains.