### PR TITLE
Fixed readme's TensorFlow Swift API Reference hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Tutorial | Last Updated |
 ### Resources
 
 - [Models and Examples](https://github.com/tensorflow/swift-models)
-- [TensorFlow Swift API Reference](https://www.tensorflow.org/api_docs/swift/Structs/Tensor)
+- [TensorFlow Swift API Reference](https://www.tensorflow.org/swift/api_docs/Structs/Tensor)
 - [Release Notes](RELEASES.md)
 - [Known Issues](KNOWN_ISSUES.md)
 - [Frequently Asked Questions](FAQ.md)


### PR DESCRIPTION
Fixed a small issue in README.md's link to the Tensorflow Swift API reference page which leads to a 404 page. The change consists of swapping `/api_docs/` and `/swift/` in the URL.

Original URL: https://www.tensorflow.org/api_docs/swift/Structs/Tensor
Updated URL: https://www.tensorflow.org/swift/api_docs/Structs/Tensor

Let me know if it's more appropriate to point to the base docs at https://www.tensorflow.org/swift/api_docs rather than the documentation for Tensor.