### PR TITLE
[BitstreamParser] Fix parsing end block directive in block info block

### DIFF
--- a/Sources/SIL/BitcodeParser.swift
+++ b/Sources/SIL/BitcodeParser.swift
@@ -137,6 +137,7 @@ class BitcodeParser {
             let abbrev = try stream.next(bits: abbrLen)
             switch (abbrev) {
             case endBlock:
+                stream.align(toMultipleOf: 32)
                 return
             case unabbrevRecord:
                 let record = try parseUnabbrevRecord()


### PR DESCRIPTION
I was running some experiments with the BitstreamParser and noticed it wasn't aligning the stream when at the end of the BLOCKINFO block.