### PR TITLE
model training walkthrough minor improvements for clarity

### DIFF
--- a/docs/site/tutorials/model_training_walkthrough.ipynb
+++ b/docs/site/tutorials/model_training_walkthrough.ipynb
@@ -399,29 +399,29 @@
    "source": [
     "/// Initialize an `IrisBatch` dataset from a CSV file.\n",
     "func loadIrisDatasetFromCSV(\n",
-    "        contentsOfCSVFile: String, hasHeader: Bool, featureColumns: [Int], labelColumns: [Int]) -> [IrisBatch] {\n",
+    "        contentsOf: String, hasHeader: Bool, featureColumns: [Int], labelColumns: [Int]) -> [IrisBatch] {\n",
     "        let np = Python.import(\"numpy\")\n",
     "\n",
     "        let featuresNp = np.loadtxt(\n",
-    "            contentsOfCSVFile,\n",
+    "            contentsOf,\n",
     "            delimiter: \",\",\n",
     "            skiprows: hasHeader ? 1 : 0,\n",
     "            usecols: featureColumns,\n",
     "            dtype: Float.numpyScalarTypes.first!)\n",
     "        guard let featuresTensor = Tensor<Float>(numpy: featuresNp) else {\n",
-    "            // This should never happen, because we construct numpy in such a\n",
+    "            // This should never happen, because we construct featuresNp in such a\n",
     "            // way that it should be convertible to tensor.\n",
     "            fatalError(\"np.loadtxt result can't be converted to Tensor\")\n",
     "        }\n",
     "\n",
     "        let labelsNp = np.loadtxt(\n",
-    "            contentsOfCSVFile,\n",
+    "            contentsOf,\n",
     "            delimiter: \",\",\n",
     "            skiprows: hasHeader ? 1 : 0,\n",
     "            usecols: labelColumns,\n",
     "            dtype: Int32.numpyScalarTypes.first!)\n",
     "        guard let labelsTensor = Tensor<Int32>(numpy: labelsNp) else {\n",
-    "            // This should never happen, because we construct numpy in such a\n",
+    "            // This should never happen, because we construct labelsNp in such a\n",
     "            // way that it should be convertible to tensor.\n",
     "            fatalError(\"np.loadtxt result can't be converted to Tensor\")\n",
     "        }\n",
@@ -444,7 +444,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "let trainingDataset: [IrisBatch] = loadIrisDatasetFromCSV(contentsOfCSVFile: trainDataFilename, \n",
+    "let trainingDataset: [IrisBatch] = loadIrisDatasetFromCSV(contentsOf: trainDataFilename, \n",
     "                                                  hasHeader: true, \n",
     "                                                  featureColumns: [0, 1, 2, 3], \n",
     "                                                  labelColumns: [4])\n",
@@ -483,7 +483,9 @@
     "let firstTrainLabels = firstTrainBatch.labels\n",
     "\n",
     "print(\"First batch of features: \\(firstTrainFeatures)\")\n",
-    "print(\"First batch of labels: \\(firstTrainLabels)\")"
+    "print(\"firstTrainFeatures.shape: \\(firstTrainFeatures.shape)\")\n",
+    "print(\"First batch of labels: \\(firstTrainLabels)\")\n",
+    "print(\"firstTrainLabels.shape: \\(firstTrainLabels.shape)\")"
    ]
   },
   {
@@ -1114,7 +1116,7 @@
    "outputs": [],
    "source": [
     "let testDataset = loadIrisDatasetFromCSV(\n",
-    "    contentsOfCSVFile: testDataFilename, hasHeader: true,\n",
+    "    contentsOf: testDataFilename, hasHeader: true,\n",
     "    featureColumns: [0, 1, 2, 3], labelColumns: [4]).inBatches(of: batchSize)"
    ]
   },


### PR DESCRIPTION
contentsOfCSV -> contentsOf. CSV is already in the function name so this
arg name seems needlessly verbose.

Use local variable names in comments about "This should never happen".
Saying "we construct <param name>" was a bit confusing to me, especially
since the param name in this case is also the name of the python module.

Print tensor shapes. I found this helpful to understand the process.