### PR TITLE
Clean up Python imports in examples

### DIFF
--- a/docs/site/tutorials/model_training_walkthrough.ipynb
+++ b/docs/site/tutorials/model_training_walkthrough.ipynb
@@ -128,11 +128,7 @@
    "outputs": [],
    "source": [
     "import TensorFlow\n",
-    "#if canImport(PythonKit)\n",
-    "    import PythonKit\n",
-    "#else\n",
-    "    import Python\n",
-    "#endif"
+    "import PythonKit"
    ]
   },
   {

--- a/docs/site/tutorials/python_interoperability.ipynb
+++ b/docs/site/tutorials/python_interoperability.ipynb
@@ -78,12 +78,7 @@
    },
    "outputs": [],
    "source": [
-    "// comment so that Colab does not interpret `#if ...` as a comment\n",
-    "#if canImport(PythonKit)\n",
-    "    import PythonKit\n",
-    "#else\n",
-    "    import Python\n",
-    "#endif\n",
+    "import PythonKit\n",
     "print(Python.version)"
    ]
   },

--- a/notebooks/talk_demos/Differentiable_Physics.ipynb
+++ b/notebooks/talk_demos/Differentiable_Physics.ipynb
@@ -531,7 +531,7 @@
         "  return r\n",
         "}\n",
         "\n",
-        "import Python\n",
+        "import PythonKit\n",
         "%include \"EnableIPythonDisplay.swift\"\n",
         "IPythonDisplay.shell.enable_matplotlib(\"inline\")\n",
         "let display = Python.import(\"IPython.core.display\")\n",

--- a/notebooks/talk_demos/Differentiable_Physics_Backup.ipynb
+++ b/notebooks/talk_demos/Differentiable_Physics_Backup.ipynb
@@ -543,7 +543,7 @@
         "  return r\n",
         "}\n",
         "\n",
-        "import Python\n",
+        "import PythonKit\n",
         "%include \"EnableIPythonDisplay.swift\"\n",
         "IPythonDisplay.shell.enable_matplotlib(\"inline\")\n",
         "let display = Python.import(\"IPython.core.display\")\n",


### PR DESCRIPTION
PythonKit is now the standard name for the module which provides Python interoperability, and we've had enough time to transition over. It seems like a good time to simplify the PythonKit imports in our examples.

(Paired with [PR #659 in swift-models](https://github.com/tensorflow/swift-models/pull/659).)