### PR TITLE
Release 2020-08-18 toolchain for macOS.

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -115,7 +115,7 @@ To install Swift for TensorFlow, download one of the packages below and follow t
 
 | Download |
 |----------|
-| [Xcode 12 (August 13, 2020)](https://storage.googleapis.com/swift-tensorflow-artifacts/macos-toolchains/swift-tensorflow-DEVELOPMENT-2020-08-13-a-osx.pkg) |
+| [Xcode 12 (August 18, 2020)](https://storage.googleapis.com/swift-tensorflow-artifacts/macos-toolchains/swift-tensorflow-DEVELOPMENT-2020-08-18-a-osx.pkg) |
 | [Ubuntu 18.04 (CPU, TPU) (Nightly)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-ubuntu18.04.tar.gz) |
 | [Ubuntu 18.04 (CPU, CUDA 10.2, TPU) (Nightly)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda10.2-cudnn7-ubuntu18.04.tar.gz) |
 | [Ubuntu 18.04 (CPU, CUDA 10.1, TPU) (Nightly)](https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda10.1-cudnn7-ubuntu18.04.tar.gz) |
@@ -130,6 +130,7 @@ To install Swift for TensorFlow, download one of the packages below and follow t
 
 | Download |
 |----------|
+| [August 13, 2020](https://storage.googleapis.com/swift-tensorflow-artifacts/macos-toolchains/swift-tensorflow-DEVELOPMENT-2020-08-13-a-osx.pkg) |
 | [August 5, 2020](https://storage.googleapis.com/swift-tensorflow-artifacts/macos-toolchains/swift-tensorflow-DEVELOPMENT-2020-08-05-a-osx.pkg) |
 | [July 29, 2020](https://storage.googleapis.com/swift-tensorflow-artifacts/macos-toolchains/swift-tensorflow-DEVELOPMENT-2020-07-29-a-osx.pkg) |
 | [July 16, 2020](https://storage.googleapis.com/swift-tensorflow-artifacts/macos-toolchains/swift-tensorflow-DEVELOPMENT-2020-07-16-a-osx.pkg) |


### PR DESCRIPTION
https://github.com/apple/swift/commit/d2aece71589bb82189a098b4d384172d907e7128
https://github.com/tensorflow/swift-apis/commit/5d981538fedc2b862ab79f52dd1f25538e519b7c

---

Notable changes: 
* Crash fix related to `Optional` differentiation: https://github.com/apple/swift/commit/fde16b66ee640c6fe2106032490d33ffd829dad0
* Non-active `try_apply` differentiation support: https://github.com/apple/swift/commit/d2aece71589bb82189a098b4d384172d907e7128