### PR TITLE
Format notebook tutorials with nbfmt

### DIFF
--- a/docs/site/tutorials/a_swift_tour.ipynb
+++ b/docs/site/tutorials/a_swift_tour.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "QdsgF9Mxj0gr"
    },
    "source": [
@@ -13,7 +12,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "pJNp_GAv9LAh"
    },
    "source": [
@@ -33,7 +31,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "673eaebJdE12"
    },
    "source": [
@@ -46,13 +43,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "iNHY9-pzdE13",
-    "outputId": "8319f4a0-0f0c-440a-d547-89c4c30e205d"
+    "id": "iNHY9-pzdE13"
    },
    "outputs": [],
    "source": [
@@ -62,7 +53,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "jdHsgXTYdE17"
    },
    "source": [
@@ -74,7 +64,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "OihtZA6QhEZS"
    },
    "source": [
@@ -87,8 +76,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "p_pjyevTdE18"
    },
    "outputs": [],
@@ -101,7 +88,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "A7S47TpWdE1-"
    },
    "source": [
@@ -114,8 +100,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "RDo7IwtmdE1_"
    },
    "outputs": [],
@@ -129,8 +113,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "9jZ0Hccqhlil"
    },
    "outputs": [],
@@ -142,7 +124,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "N1PqnuLFXR4L"
    },
    "source": [
@@ -153,13 +134,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "rPuJLYsHdE2C",
-    "outputId": "b71227f4-2f81-4fdc-ec72-bb53da731e8c"
+    "id": "rPuJLYsHdE2C"
    },
    "outputs": [],
    "source": [
@@ -172,8 +147,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "QuQ7-JoOhNY9"
    },
    "outputs": [],
@@ -185,7 +158,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "7cwpu6_3YYKX"
    },
    "source": [
@@ -196,13 +168,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "j-W3HyT9ZBOF",
-    "outputId": "fc70e6e3-7ab3-4ec4-94a7-1d3d0ae45e47"
+    "id": "j-W3HyT9ZBOF"
    },
    "outputs": [],
    "source": [
@@ -214,13 +180,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "kd1WEYjwZCXx",
-    "outputId": "ae89a8c0-3e31-4723-e65e-bff549454047"
+    "id": "kd1WEYjwZCXx"
    },
    "outputs": [],
    "source": [
@@ -232,8 +192,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "3avZRAzlguOQ"
    },
    "outputs": [],
@@ -246,7 +204,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "4T6rPJ6tWaKu"
    },
    "source": [
@@ -257,13 +214,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 54
-    },
-    "colab_type": "code",
-    "id": "_5RJZBV1Webt",
-    "outputId": "8723eb4b-431b-4dcb-bc8c-002c7edc8555"
+    "id": "_5RJZBV1Webt"
    },
    "outputs": [],
    "source": [
@@ -281,7 +232,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "AuhL5LMzVr-T"
    },
    "source": [
@@ -292,13 +242,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 187
-    },
-    "colab_type": "code",
-    "id": "BI46PGfQdE2I",
-    "outputId": "c6df9fda-7777-43bc-b807-df9f374c1da5"
+    "id": "BI46PGfQdE2I"
    },
    "outputs": [],
    "source": [
@@ -316,7 +260,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "HpaZFmGhYmW-"
    },
    "source": [
@@ -327,13 +270,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 119
-    },
-    "colab_type": "code",
-    "id": "vVgbHKpaYpPX",
-    "outputId": "7bc9b6b1-4d05-41f1-cf2a-e9d3f9047876"
+    "id": "vVgbHKpaYpPX"
    },
    "outputs": [],
    "source": [
@@ -344,7 +281,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "P_F6ODC6dE2L"
    },
    "source": [
@@ -355,8 +291,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "pZ0hFNzXdE2M"
    },
    "outputs": [],
@@ -368,7 +302,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "r88SNR3mdE2Q"
    },
    "source": [
@@ -379,8 +312,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "LrmOoh8HdE2R"
    },
    "outputs": [],
@@ -392,7 +323,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "IcyJIWOqdE2T"
    },
    "source": [
@@ -405,13 +335,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "QhcmCbQydE2U",
-    "outputId": "7c50964f-0283-4959-a9aa-da02d694031c"
+    "id": "QhcmCbQydE2U"
    },
    "outputs": [],
    "source": [
@@ -430,7 +354,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "VfEX-a-JdE2W"
    },
    "source": [
@@ -443,13 +366,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "fCqYihmIdE2X",
-    "outputId": "8c3a7e14-f483-44ad-fe67-8172c4318732"
+    "id": "fCqYihmIdE2X"
    },
    "outputs": [],
    "source": [
@@ -461,13 +378,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "3GcY1w13hv82",
-    "outputId": "a71724c0-3c5d-42ce-9f07-6f3ccde153f0"
+    "id": "3GcY1w13hv82"
    },
    "outputs": [],
    "source": [
@@ -483,8 +394,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "0dJr-IC8giJL"
    },
    "outputs": [],
@@ -497,7 +406,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "ZZWOeB3ve-jm"
    },
    "source": [
@@ -510,13 +418,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "UqstABf4dE2b",
-    "outputId": "8e3df8c1-50fd-4443-a70f-9adb53cc41c3"
+    "id": "UqstABf4dE2b"
    },
    "outputs": [],
    "source": [
@@ -528,7 +430,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "l_3enGZldE2d"
    },
    "source": [
@@ -539,13 +440,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "AXTHsCcedE2e",
-    "outputId": "b340fbfb-98c0-49ca-eeec-b6c178cc3957"
+    "id": "AXTHsCcedE2e"
    },
    "outputs": [],
    "source": [
@@ -566,8 +461,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "e-FK9XcGga0O"
    },
    "outputs": [],
@@ -579,7 +472,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "AXaHBPiidE2g"
    },
    "source": [
@@ -594,13 +486,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "nJHpFEDPdE2h",
-    "outputId": "9abf7ff9-8830-4ef9-cd41-203a30bdbc23"
+    "id": "nJHpFEDPdE2h"
    },
    "outputs": [],
    "source": [
@@ -624,8 +510,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "UKKf8zkRgWUq"
    },
    "outputs": [],
@@ -638,7 +522,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "or2W6kbyfuXu"
    },
    "source": [
@@ -649,13 +532,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "tt54-NuJdE2m",
-    "outputId": "9cf8b5a5-dc0e-4198-d582-0b49f663bae8"
+    "id": "tt54-NuJdE2m"
    },
    "outputs": [],
    "source": [
@@ -671,13 +548,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "adAijrWkiAGF",
-    "outputId": "1a8e59eb-29e3-4b2a-9095-85e7eebf4a65"
+    "id": "adAijrWkiAGF"
    },
    "outputs": [],
    "source": [
@@ -692,7 +563,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "DqEff6OfdE2q"
    },
    "source": [
@@ -703,13 +573,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "LKkJ4co_dE2r",
-    "outputId": "b2deec61-5688-4029-c72e-d04fe08c13e3"
+    "id": "LKkJ4co_dE2r"
    },
    "outputs": [],
    "source": [
@@ -724,7 +588,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "HKgeaTprdE2t"
    },
    "source": [
@@ -734,7 +597,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "W7H3ptGaiEcB"
    },
    "source": [
@@ -747,13 +609,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "6u_fX5SwdE2t",
-    "outputId": "55a45bef-60de-4419-cd6d-385a0e2dfd4d"
+    "id": "6u_fX5SwdE2t"
    },
    "outputs": [],
    "source": [
@@ -767,8 +623,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "sgYex6gigH87"
    },
    "outputs": [],
@@ -780,7 +634,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "Mo9D_hc0jfkF"
    },
    "source": [
@@ -791,13 +644,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "8Dkx71QUjisV",
-    "outputId": "61839711-9d43-496a-c5bb-229f7060b8d4"
+    "id": "8Dkx71QUjisV"
    },
    "outputs": [],
    "source": [
@@ -810,7 +657,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "71qFe0AWjd9F"
    },
    "source": [
@@ -821,13 +667,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 51
-    },
-    "colab_type": "code",
-    "id": "5cDR7-TydE2w",
-    "outputId": "54c6fb9b-7645-4247-9256-7da826f3e8d1"
+    "id": "5cDR7-TydE2w"
    },
    "outputs": [],
    "source": [
@@ -855,7 +695,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "hHUWHaH-jwmx"
    },
    "source": [
@@ -866,13 +705,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "K094099VdE21",
-    "outputId": "53918e22-3008-4532-b77f-38857f8f6729"
+    "id": "K094099VdE21"
    },
    "outputs": [],
    "source": [
@@ -890,7 +723,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "s8hfkf4HdE24"
    },
    "source": [
@@ -901,13 +733,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "sV33PIdsdE26",
-    "outputId": "27ff3fcd-dfcd-4e45-cbfe-1801f06781ce"
+    "id": "sV33PIdsdE26"
    },
    "outputs": [],
    "source": [
@@ -924,7 +750,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "J6-9e3godE29"
    },
    "source": [
@@ -935,13 +760,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "nOwBtGWLdE2-",
-    "outputId": "f06ff19a-a10b-48ab-9a64-771fda2306dd"
+    "id": "nOwBtGWLdE2-"
    },
    "outputs": [],
    "source": [
@@ -963,7 +782,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "u9uVmoK6dE3B"
    },
    "source": [
@@ -974,13 +792,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 102
-    },
-    "colab_type": "code",
-    "id": "qWTL5QMKdE3C",
-    "outputId": "9bb61550-ce76-4b0a-e0b9-dbd1e4a5957f"
+    "id": "qWTL5QMKdE3C"
    },
    "outputs": [],
    "source": [
@@ -994,8 +806,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "aTZoZCybf2uG"
    },
    "outputs": [],
@@ -1007,7 +817,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "NapuA70Qj8QF"
    },
    "source": [
@@ -1018,13 +827,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "wNcmSyFodE3F",
-    "outputId": "06a606e2-564c-46d5-c243-f8ce6fed8da5"
+    "id": "wNcmSyFodE3F"
    },
    "outputs": [],
    "source": [
@@ -1035,7 +838,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "6MxBFQjRdE3I"
    },
    "source": [
@@ -1046,13 +848,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "6Ecv1ethdE3I",
-    "outputId": "7b28c295-c236-435e-9805-f877e828cf62"
+    "id": "6Ecv1ethdE3I"
    },
    "outputs": [],
    "source": [
@@ -1063,7 +859,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "BfV1d5HpdE3K"
    },
    "source": [
@@ -1076,8 +871,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "SycTCbxadE3L"
    },
    "outputs": [],
@@ -1094,8 +887,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "i-oNcgg4h-wm"
    },
    "outputs": [],
@@ -1107,7 +898,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "NDuIuzgUkAEY"
    },
    "source": [
@@ -1118,8 +908,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "y1_AYUbidE3O"
    },
    "outputs": [],
@@ -1132,7 +920,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "id0q1vIfdE3Q"
    },
    "source": [
@@ -1143,8 +930,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "lboFcMVtdE3Q"
    },
    "outputs": [],
@@ -1166,7 +951,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "h06b-4fKdE3S"
    },
    "source": [
@@ -1183,13 +967,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "VHT1Lpz8dE3S",
-    "outputId": "daa4415a-6cda-4efd-e462-2c52834a19a1"
+    "id": "VHT1Lpz8dE3S"
    },
    "outputs": [],
    "source": [
@@ -1219,8 +997,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "SIoEXii5iDA3"
    },
    "outputs": [],
@@ -1234,7 +1010,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "-jWyfN7KkDqR"
    },
    "source": [
@@ -1245,13 +1020,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 51
-    },
-    "colab_type": "code",
-    "id": "QaqZC56MdE3V",
-    "outputId": "9b3443c9-c6f6-48ea-e328-3390c80738ae"
+    "id": "QaqZC56MdE3V"
    },
    "outputs": [],
    "source": [
@@ -1286,7 +1055,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "CK3s64WhdE3W"
    },
    "source": [
@@ -1307,13 +1075,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 68
-    },
-    "colab_type": "code",
-    "id": "VSPCTz5mdE3a",
-    "outputId": "b1a47683-042e-44b2-e9c0-d220d601d29d"
+    "id": "VSPCTz5mdE3a"
    },
    "outputs": [],
    "source": [
@@ -1343,7 +1105,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "ygWAN55xdE3b"
    },
    "source": [
@@ -1354,13 +1115,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 51
-    },
-    "colab_type": "code",
-    "id": "pmXsLt_gdE3c",
-    "outputId": "a0b7304a-a5ca-415a-dc40-dd2aab51db9f"
+    "id": "pmXsLt_gdE3c"
    },
    "outputs": [],
    "source": [
@@ -1371,7 +1126,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "0yaZFHMRdE3d"
    },
    "source": [
@@ -1384,13 +1138,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 51
-    },
-    "colab_type": "code",
-    "id": "Btg1_6rXdE3e",
-    "outputId": "d6b41207-e8fd-4ec0-b969-5e1505cf4ab6"
+    "id": "Btg1_6rXdE3e"
    },
    "outputs": [],
    "source": [
@@ -1424,8 +1172,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "34Ba8HGwin9n"
    },
    "outputs": [],
@@ -1437,7 +1183,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "0R1w6q3KkIH1"
    },
    "source": [
@@ -1447,7 +1192,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "zgtd86KUp5qa"
    },
    "source": [
@@ -1458,19 +1202,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "7SUCN4Nip-FK"
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "BjzxKC67dE3h"
    },
    "outputs": [],
@@ -1483,7 +1214,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "aViNXJOWdE3k"
    },
    "source": [
@@ -1494,8 +1224,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "i9fKzaQzdE3k"
    },
    "outputs": [],
@@ -1524,8 +1252,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "H-38gQ27isHk"
    },
    "outputs": [],
@@ -1538,7 +1264,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "H1B0m_prdE3m"
    },
    "source": [
@@ -1548,7 +1273,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "fCDHUHBHdE3o"
    },
    "source": [
@@ -1561,13 +1285,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "v7CDdsdydE3o",
-    "outputId": "0b1589dc-64c6-43a5-ea3e-eb822e5cf0c0"
+    "id": "v7CDdsdydE3o"
    },
    "outputs": [],
    "source": [
@@ -1591,8 +1309,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "6KxPZi0ii4Jj"
    },
    "outputs": [],
@@ -1604,7 +1320,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "BCjUxgx0iKDh"
    },
    "source": [
@@ -1614,7 +1329,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "FonxodFmpPXv"
    },
    "source": [
@@ -1625,8 +1339,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "tsTnhpukpTF1"
    },
    "outputs": [],
@@ -1646,8 +1358,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "FM1U4SqwpUp6"
    },
    "outputs": [],
@@ -1660,7 +1370,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "jUBjQqUhdE3p"
    },
    "source": [
@@ -1673,8 +1382,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "vVEIH7WhdE3q"
    },
    "outputs": [],
@@ -1688,7 +1395,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "GSV2yv6SdE3r"
    },
    "source": [
@@ -1699,13 +1405,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "Lgf8If-0dE3r",
-    "outputId": "11282413-31fb-4c49-c493-98d73e93a2df"
+    "id": "Lgf8If-0dE3r"
    },
    "outputs": [],
    "source": [
@@ -1735,8 +1435,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "OvDuEwsYi-ZN"
    },
    "outputs": [],
@@ -1750,7 +1448,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "Is_xfbNXdE3t"
    },
    "source": [
@@ -1763,13 +1460,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "w5Hde1HwdE3u",
-    "outputId": "94273e93-905b-42da-e001-fe9799f66fae"
+    "id": "w5Hde1HwdE3u"
    },
    "outputs": [],
    "source": [
@@ -1788,8 +1479,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "fdY5CdWjjCRI"
    },
    "outputs": [],
@@ -1801,7 +1490,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "EoOPuRjZntCx"
    },
    "source": [
@@ -1812,13 +1500,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "OghTVgiRnvgA",
-    "outputId": "b6f05af2-da76-4211-a929-70a8a53987d2"
+    "id": "OghTVgiRnvgA"
    },
    "outputs": [],
    "source": [
@@ -1830,8 +1512,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "Xad6Z5Nrn34O"
    },
    "outputs": [],
@@ -1843,7 +1523,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "92wBiymPn3HE"
    },
    "source": [
@@ -1853,7 +1532,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "6Z9Y-fWGjxsn"
    },
    "source": [
@@ -1866,8 +1544,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "PiENY4W2kA2t"
    },
    "outputs": [],
@@ -1882,7 +1558,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "Tu7q13kSkCad"
    },
    "source": [
@@ -1893,8 +1568,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "rY7yWs_nkFbM"
    },
    "outputs": [],
@@ -1910,7 +1583,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "uVh7tkr-kPKV"
    },
    "source": [
@@ -1921,13 +1593,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "YejV2PLLkIPA",
-    "outputId": "8dee4ce7-83ae-4a0c-8d5a-09d9bf1f1fb1"
+    "id": "YejV2PLLkIPA"
    },
    "outputs": [],
    "source": [
@@ -1943,8 +1609,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "UJBF1XzdkWjL"
    },
    "outputs": [],
@@ -1957,7 +1621,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "occBM2Cekddc"
    },
    "source": [
@@ -1968,13 +1631,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "eUhzxcUEkjV-",
-    "outputId": "5ca5bd3b-ca0d-4a4c-a1aa-7748a3f894cb"
+    "id": "eUhzxcUEkjV-"
    },
    "outputs": [],
    "source": [
@@ -1994,8 +1651,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "-qpkCM8NnXie"
    },
    "outputs": [],
@@ -2009,7 +1664,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "JOwTXVWbnAup"
    },
    "source": [
@@ -2020,8 +1674,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "2ifK6Lyom-9Q"
    },
    "outputs": [],
@@ -2033,7 +1685,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "SmSiz49knFZY"
    },
    "source": [
@@ -2044,13 +1695,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "tMdhw71anJbP",
-    "outputId": "c4cf15bf-b819-48a5-8cf5-01fe9599a762"
+    "id": "tMdhw71anJbP"
    },
    "outputs": [],
    "source": [
@@ -2073,7 +1718,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "g0wCWqNMiOv-"
    },
    "source": [
@@ -2086,13 +1730,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 102
-    },
-    "colab_type": "code",
-    "id": "sMyq1uQsdE3y",
-    "outputId": "1c328bc0-d437-4717-da44-6831206040b8"
+    "id": "sMyq1uQsdE3y"
    },
    "outputs": [],
    "source": [
@@ -2109,7 +1747,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "If8pw1_7dE3z"
    },
    "source": [
@@ -2120,13 +1757,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "PrhmI6iNdE30",
-    "outputId": "a221fca0-3a7b-4201-dc80-5b793a0261af"
+    "id": "PrhmI6iNdE30"
    },
    "outputs": [],
    "source": [
@@ -2143,7 +1774,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "NXhFj_GCdE31"
    },
    "source": [
@@ -2154,13 +1784,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "EkXn4tmhdE32",
-    "outputId": "45f50fc3-9683-4c54-e8fd-f677bb6b5565"
+    "id": "EkXn4tmhdE32"
    },
    "outputs": [],
    "source": [
@@ -2182,7 +1806,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "6cZJ4EiYq33D"
    },
    "source": [
@@ -2193,16 +1816,14 @@
  "metadata": {
   "colab": {
    "collapsed_sections": [],
-   "name": "A Swift Tour.ipynb",
-   "provenance": [],
-   "version": "0.3.2"
+   "name": "a_swift_tour.ipynb",
+   "toc_visible": true
   },
   "kernelspec": {
    "display_name": "Swift",
-   "language": "swift",
    "name": "swift"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 0
 }

--- a/docs/site/tutorials/custom_differentiation.ipynb
+++ b/docs/site/tutorials/custom_differentiation.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "ZloPIuRHn97X"
    },
    "source": [
@@ -14,8 +13,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
+    "cellView": "form",
     "id": "tNgCmfUvJNoF"
    },
    "outputs": [],
@@ -37,7 +35,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "AlvdCHw5JGyx"
    },
    "source": [
@@ -57,7 +54,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "c_1u7JSBMx3x"
    },
    "source": [
@@ -69,7 +65,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "gHuQo_kCTjFr"
    },
    "source": [
@@ -79,7 +74,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "LP0gMw56TlvH"
    },
    "source": [
@@ -90,13 +84,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 85
-    },
-    "colab_type": "code",
-    "id": "j0a8prgZTlEO",
-    "outputId": "f0f65b8a-30ce-46bb-a6c5-efe3e8956e44"
+    "id": "j0a8prgZTlEO"
    },
    "outputs": [],
    "source": [
@@ -121,7 +109,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "eQPX9r3R5OP-"
    },
    "source": [
@@ -136,13 +123,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 68
-    },
-    "colab_type": "code",
-    "id": "ctRt6vBO5Wle",
-    "outputId": "49580e7d-0bde-4e78-b825-12444bf39767"
+    "id": "ctRt6vBO5Wle"
    },
    "outputs": [],
    "source": [
@@ -156,7 +137,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "EeV3wXQ79WS2"
    },
    "source": [
@@ -170,7 +150,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "AHV0ryTiD6j8"
    },
    "source": [
@@ -180,7 +159,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "9zKSeUjTmbxq"
    },
    "source": [
@@ -193,13 +171,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 68
-    },
-    "colab_type": "code",
-    "id": "eKne7szjD8lr",
-    "outputId": "31bba009-3758-4179-92dc-f080dcba8421"
+    "id": "eKne7szjD8lr"
    },
    "outputs": [],
    "source": [
@@ -219,7 +191,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "vmw0gkqlD9xf"
    },
    "source": [
@@ -229,7 +200,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "JCf_OplsWzhW"
    },
    "source": [
@@ -240,13 +210,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 547
-    },
-    "colab_type": "code",
-    "id": "fnSeAbs9-hf3",
-    "outputId": "80ea60b8-e17c-47d5-9364-c8768c3e377e"
+    "id": "fnSeAbs9-hf3"
    },
    "outputs": [],
    "source": [
@@ -283,7 +247,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "TzLfTj28gEUD"
    },
    "source": [
@@ -299,7 +262,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "5cZe-JbjwMfZ"
    },
    "source": [
@@ -309,7 +271,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "606ob1dn2v77"
    },
    "source": [
@@ -322,8 +283,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "b1uU3tcVwl_1"
    },
    "outputs": [],
@@ -347,7 +306,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "UbeKj7NEF7zz"
    },
    "source": [
@@ -358,13 +316,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 102
-    },
-    "colab_type": "code",
-    "id": "oee8SXital45",
-    "outputId": "f4e7bd68-606a-46d6-96f4-c5294d8e302a"
+    "id": "oee8SXital45"
    },
    "outputs": [],
    "source": [
@@ -389,7 +341,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "7SxWsSUqF9Bh"
    },
    "source": [
@@ -423,7 +374,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "ZP86M5RjP3OG"
    },
    "source": [
@@ -434,8 +384,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "bEm-n5H0QB8s"
    },
    "outputs": [],
@@ -453,7 +401,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "YU6DgqXxP5Nl"
    },
    "source": [
@@ -464,8 +411,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "ao1r_lIPGeOl"
    },
    "outputs": [],
@@ -492,7 +437,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "HqPXwwuTRjmz"
    },
    "source": [
@@ -503,8 +447,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "PGgkNnNNR1th"
    },
    "outputs": [],
@@ -519,7 +461,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "8PP-NZ9XU5_n"
    },
    "source": [
@@ -533,7 +474,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "bCwNPtCfSbGi"
    },
    "source": [
@@ -544,8 +484,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "gsWGwFjOJ3Md"
    },
    "outputs": [],
@@ -566,7 +504,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "dmFxciU6VYdF"
    },
    "source": [
@@ -577,13 +514,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 527
-    },
-    "colab_type": "code",
-    "id": "-x1nYu0uVSPn",
-    "outputId": "fcdc6e19-2ffa-49f3-908f-e5823a485f9d"
+    "id": "-x1nYu0uVSPn"
    },
    "outputs": [],
    "source": [
@@ -612,7 +543,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "gzRaZLa_WX0u"
    },
    "source": [
@@ -623,23 +553,14 @@
  "metadata": {
   "colab": {
    "collapsed_sections": [],
-   "name": "Custom differentiation.ipynb",
-   "provenance": [],
-   "toc_visible": true,
-   "version": "0.3.2"
+   "name": "custom_differentiation.ipynb",
+   "toc_visible": true
   },
   "kernelspec": {
    "display_name": "Swift",
-   "language": "swift",
    "name": "swift"
-  },
-  "language_info": {
-   "file_extension": ".swift",
-   "mimetype": "text/x-swift",
-   "name": "swift",
-   "version": ""
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 0
 }

--- a/docs/site/tutorials/introducing_x10.ipynb
+++ b/docs/site/tutorials/introducing_x10.ipynb
@@ -1,30 +1,8 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "Introducing X10.ipynb",
-      "provenance": [],
-      "collapsed_sections": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Swift",
-      "language": "swift",
-      "name": "swift"
-    },
-    "language_info": {
-      "file_extension": ".swift",
-      "mimetype": "text/x-swift",
-      "name": "swift",
-      "version": ""
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "9TV7IYeqifSv"
       },
       "source": [
@@ -33,25 +11,24 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "colab_type": "code",
-        "id": "kZRlD4utdPuX",
-        "colab": {}
+        "id": "kZRlD4utdPuX"
       },
+      "outputs": [],
       "source": [
         "%install '.package(url: \"https://github.com/tensorflow/swift-models\", .branch(\"tensorflow-0.11\"))' Datasets ImageClassificationModels\n",
         "print(\"\\u{001B}[2J\")"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "colab_type": "code",
-        "id": "tRIJp_4m_Afz",
-        "colab": {}
+        "cellView": "form",
+        "id": "tRIJp_4m_Afz"
       },
+      "outputs": [],
       "source": [
         "// #@title Licensed under the Apache License, Version 2.0 (the \"License\"); { display-mode: \"form\" }\n",
         "// Licensed under the Apache License, Version 2.0 (the \"License\");\n",
@@ -65,14 +42,11 @@
         "// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "// See the License for the specific language governing permissions and\n",
         "// limitations under the License."
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "sI1ZtrdiA4aY"
       },
       "source": [
@@ -92,7 +66,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "8sa42_NblqRE"
       },
       "source": [
@@ -106,7 +79,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "W7MpNcIwIIy8"
       },
       "source": [
@@ -116,7 +88,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "lM9dRji7IIy8"
       },
       "source": [
@@ -127,51 +98,44 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "OHRTNQJo1TxT",
-        "colab_type": "code",
-        "colab": {}
+        "id": "OHRTNQJo1TxT"
       },
+      "outputs": [],
       "source": [
         "import TensorFlow\n",
         "import Foundation"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "colab_type": "code",
-        "id": "FCMWR11NIIy-",
-        "colab": {}
+        "id": "FCMWR11NIIy-"
       },
+      "outputs": [],
       "source": [
         "let eagerTensor1 = Tensor([0.0, 1.0, 2.0])\n",
         "let eagerTensor2 = Tensor([1.5, 2.5, 3.5])\n",
         "let eagerTensorSum = eagerTensor1 + eagerTensor2\n",
         "eagerTensorSum"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "1qad9_yMYf6F",
-        "colab_type": "code",
-        "colab": {}
+        "id": "1qad9_yMYf6F"
       },
+      "outputs": [],
       "source": [
         "eagerTensor1.device"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "HrlMNOinIIy_"
       },
       "source": [
@@ -181,7 +145,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "eoyLeSQVIIy9"
       },
       "source": [
@@ -190,37 +153,32 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "NrRQhQaHaJm9",
-        "colab_type": "code",
-        "colab": {}
+        "id": "NrRQhQaHaJm9"
       },
+      "outputs": [],
       "source": [
         "let x10Tensor1 = Tensor([0.0, 1.0, 2.0], on: Device.defaultXLA)\n",
         "let x10Tensor2 = Tensor([1.5, 2.5, 3.5], on: Device.defaultXLA)\n",
         "let x10TensorSum = x10Tensor1 + x10Tensor2\n",
         "x10TensorSum"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "VbqeudQCaqwv",
-        "colab_type": "code",
-        "colab": {}
+        "id": "VbqeudQCaqwv"
       },
+      "outputs": [],
       "source": [
         "x10Tensor1.device"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "mIbIOW0HIIzA"
       },
       "source": [
@@ -233,22 +191,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "De59VwJ35SvG",
-        "colab_type": "code",
-        "colab": {}
+        "id": "De59VwJ35SvG"
       },
+      "outputs": [],
       "source": [
         "// let tpu1 = Device(kind: .TPU, ordinal: 1, backend: .XLA)\n",
         "// let tpuTensor1 = Tensor([0.0, 1.0, 2.0], on: tpu1)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "rU0WY_sJodio"
       },
       "source": [
@@ -261,25 +216,22 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "colab_type": "code",
-        "id": "kqXILiXhq-iM",
-        "colab": {}
+        "id": "kqXILiXhq-iM"
       },
+      "outputs": [],
       "source": [
         "import Datasets\n",
         "\n",
         "let epochCount = 5\n",
         "let batchSize = 128\n",
         "let dataset = MNIST(batchSize: batchSize)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "1pMewsl0VgnJ"
       },
       "source": [
@@ -288,25 +240,22 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "colab_type": "code",
-        "id": "fEAEyUExXT3I",
-        "colab": {}
+        "id": "fEAEyUExXT3I"
       },
+      "outputs": [],
       "source": [
         "import ImageClassificationModels\n",
         "\n",
         "var eagerModel = LeNet()\n",
         "var eagerOptimizer = SGD(for: eagerModel, learningRate: 0.1)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "cwNDwzS2QgS1",
-        "colab_type": "text"
+        "id": "cwNDwzS2QgS1"
       },
       "source": [
         "Now, we will implement basic progress tracking and reporting.  All intermediate statistics are kept as tensors on the same device where training is run and `scalarized()` is called only during reporting. This will be especially important later when using X10, because it avoids unnecessary materialization of lazy tensors."
@@ -314,11 +263,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "eNzOdly3QY_P",
-        "colab_type": "code",
-        "colab": {}
+        "id": "eNzOdly3QY_P"
       },
+      "outputs": [],
       "source": [
         "struct Statistics {\n",
         "    var correctGuessCount = Tensor<Int32>(0, on: Device.default)\n",
@@ -344,14 +293,11 @@
         "        batches += 1\n",
         "    }\n",
         "}"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "w3lmTRCWT5sS"
       },
       "source": [
@@ -360,11 +306,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "colab_type": "code",
-        "id": "W9bUsiOxVf_v",
-        "colab": {}
+        "id": "W9bUsiOxVf_v"
       },
+      "outputs": [],
       "source": [
         "print(\"Beginning training...\")\n",
         "\n",
@@ -405,15 +351,12 @@
         "        seconds per epoch: \\(String(format: \"%.1f\", Date().timeIntervalSince(start)))\n",
         "        \"\"\")\n",
         "}"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "7ED0HGZW2gWY",
-        "colab_type": "text"
+        "id": "7ED0HGZW2gWY"
       },
       "source": [
         "As you can see, the model trained as we would expect, and its accuracy against the validation set increased each epoch. This is how Swift for TensorFlow models are defined and run using eager execution, now let's see what modifications need to be made to take advantage of X10."
@@ -422,7 +365,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Te7sNNx9c_am"
       },
       "source": [
@@ -433,23 +375,20 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "MaN7fM-lAe7r",
-        "colab_type": "code",
-        "colab": {}
+        "id": "MaN7fM-lAe7r"
       },
+      "outputs": [],
       "source": [
         "let device = Device.defaultXLA\n",
         "device"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "cJfSg0wDAgC7",
-        "colab_type": "text"
+        "id": "cJfSg0wDAgC7"
       },
       "source": [
         "For the datasets, we'll do that at the point in which batches are processed in the training loop, so we can re-use the dataset from the eager execution model.\n",
@@ -459,25 +398,22 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "colab_type": "code",
-        "id": "jpcOByipc75O",
-        "colab": {}
+        "id": "jpcOByipc75O"
       },
+      "outputs": [],
       "source": [
         "var x10Model = LeNet()\n",
         "x10Model.move(to: device)\n",
         "\n",
         "var x10Optimizer = SGD(for: x10Model, learningRate: 0.1)\n",
         "x10Optimizer = SGD(copying: x10Optimizer, to: device)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "hQvza3dUXlr0"
       },
       "source": [
@@ -492,11 +428,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "colab_type": "code",
-        "id": "XrZee8n3Y17_",
-        "colab": {}
+        "id": "XrZee8n3Y17_"
       },
+      "outputs": [],
       "source": [
         "print(\"Beginning training...\")\n",
         "\n",
@@ -543,14 +479,11 @@
         "        seconds per epoch: \\(String(format: \"%.1f\", Date().timeIntervalSince(start)))\n",
         "        \"\"\")\n",
         "}"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Qej_Z6V3mZnG"
       },
       "source": [
@@ -561,5 +494,18 @@
         "As has been stated before, using X10 now makes it not only possible but easy to work with TPUs, unlocking that whole class of accelerators for your Swift for TensorFlow models."
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "collapsed_sections": [],
+      "name": "introducing_x10.ipynb",
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Swift",
+      "name": "swift"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/docs/site/tutorials/model_training_walkthrough.ipynb
+++ b/docs/site/tutorials/model_training_walkthrough.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "QyCcF45zBQ3E"
    },
    "source": [
@@ -14,10 +13,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "CPII1rGR2rF9",
-    "scrolled": true
+    "cellView": "form",
+    "id": "CPII1rGR2rF9"
    },
    "outputs": [],
    "source": [
@@ -38,7 +35,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "zBH72IXMJ3JJ"
    },
    "source": [
@@ -58,7 +54,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "JtEZ1pCPn--z"
    },
    "source": [
@@ -68,7 +63,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "LDrzLFXE8T1l"
    },
    "source": [
@@ -97,7 +91,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "yNr7H-AIoLOR"
    },
    "source": [
@@ -107,7 +100,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "1J3AuPBT9gyR"
    },
    "source": [
@@ -120,10 +112,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "g4Wzg69bnwK2",
-    "scrolled": true
+    "id": "g4Wzg69bnwK2"
    },
    "outputs": [],
    "source": [
@@ -134,7 +123,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "id": "5ms1o2W-DF1g"
+   },
    "outputs": [],
    "source": [
     "// This cell is here to display the plots in a Jupyter Notebook.\n",
@@ -146,7 +137,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "id": "82TJnHsCY02t"
+   },
    "outputs": [],
    "source": [
     "let plt = Python.import(\"matplotlib.pyplot\")"
@@ -155,7 +148,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "id": "-5p_tYTyz43Q"
+   },
    "outputs": [],
    "source": [
     "import Foundation\n",
@@ -171,7 +166,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "Zx7wc0LuuxaJ"
    },
    "source": [
@@ -201,7 +195,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "3Px6KAg0Jowz"
    },
    "source": [
@@ -218,10 +211,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "DKkgac4WO0mP",
-    "scrolled": true
+    "id": "DKkgac4WO0mP"
    },
    "outputs": [],
    "source": [
@@ -232,7 +222,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "qnX1-aLors4S"
    },
    "source": [
@@ -245,14 +234,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 119
-    },
-    "colab_type": "code",
-    "id": "FQvb_JYdrpPm",
-    "outputId": "11f35147-cfde-4aed-8e86-c93b5cfbe1e1",
-    "scrolled": true
+    "id": "FQvb_JYdrpPm"
    },
    "outputs": [],
    "source": [
@@ -266,7 +248,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "kQhzD6P-uBoq"
    },
    "source": [
@@ -285,14 +266,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 51
-    },
-    "colab_type": "code",
-    "id": "9Edhevw7exl6",
-    "outputId": "c78d755c-7832-440d-eda4-3545599a81a2",
-    "scrolled": true
+    "id": "9Edhevw7exl6"
    },
    "outputs": [],
    "source": [
@@ -307,7 +281,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "CCtwLoJhhDNc"
    },
    "source": [
@@ -324,10 +297,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "sVNlJlUOhkoX",
-    "scrolled": true
+    "id": "sVNlJlUOhkoX"
    },
    "outputs": [],
    "source": [
@@ -337,7 +307,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "dqPkQExM2Pwt"
    },
    "source": [
@@ -350,10 +319,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "bBx_C6UWO0mc",
-    "scrolled": true
+    "id": "bBx_C6UWO0mc"
    },
    "outputs": [],
    "source": [
@@ -382,7 +348,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "SO6elT-kwwIK"
+   },
    "source": [
     "Since the datasets we downloaded are in CSV format, let's write a function to load in the data as a list of IrisBatch objects"
    ]
@@ -390,7 +358,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "id": "LwA21wYCguO5"
+   },
    "outputs": [],
    "source": [
     "/// Initialize an `IrisBatch` dataset from a CSV file.\n",
@@ -429,7 +399,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "HbmOmUWneVGM"
+   },
    "source": [
     "We can now use the CSV loading function to load the training dataset and create a `TrainingEpochs` object"
    ]
@@ -437,7 +409,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "id": "zFnMejfFYgSV"
+   },
    "outputs": [],
    "source": [
     "let trainingDataset: [IrisBatch] = loadIrisDatasetFromCSV(contentsOf: trainDataFilename, \n",
@@ -451,7 +425,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "gB_RSn62c-3G"
    },
    "source": [
@@ -462,14 +435,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 578
-    },
-    "colab_type": "code",
-    "id": "iDuG94H-C122",
-    "outputId": "e6a39492-f029-4f18-b1c5-3a0700d82367",
-    "scrolled": true
+    "id": "iDuG94H-C122"
    },
    "outputs": [],
    "source": [
@@ -487,7 +453,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "E63mArnQaAGz"
    },
    "source": [
@@ -500,14 +465,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 300
-    },
-    "colab_type": "code",
-    "id": "me5Wn-9FcyyO",
-    "outputId": "0418e08e-15bf-477c-eba0-e54207d3c928",
-    "scrolled": false
+    "id": "me5Wn-9FcyyO"
    },
    "outputs": [],
    "source": [
@@ -524,7 +482,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "LsaVrtNM3Tx5"
    },
    "source": [
@@ -556,7 +513,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "W23DIMVPQEBt"
    },
    "source": [
@@ -571,10 +527,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "wr5A5WvthvZ0",
-    "scrolled": true
+    "id": "wr5A5WvthvZ0"
    },
    "outputs": [],
    "source": [
@@ -598,7 +551,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "fK0vrIRv_tcc"
    },
    "source": [
@@ -610,7 +562,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "2wFKnhWCpDSS"
    },
    "source": [
@@ -623,14 +574,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 102
-    },
-    "colab_type": "code",
-    "id": "sKjJGIYzO0mr",
-    "outputId": "b67ca0bc-e8c3-4c10-b7f9-decbbc4f4e9b",
-    "scrolled": true
+    "id": "sKjJGIYzO0mr"
    },
    "outputs": [],
    "source": [
@@ -642,7 +586,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "wxyXOhwVr5S3"
    },
    "source": [
@@ -655,14 +598,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 102
-    },
-    "colab_type": "code",
-    "id": "_tRwHZmTNTX2",
-    "outputId": "497f32d3-cd4b-4d00-ab9e-dfd2c20e50ba",
-    "scrolled": true
+    "id": "_tRwHZmTNTX2"
    },
    "outputs": [],
    "source": [
@@ -672,7 +608,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "uRZmchElo481"
    },
    "source": [
@@ -683,14 +618,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 51
-    },
-    "colab_type": "code",
-    "id": "-Jzm_GoErz8B",
-    "outputId": "9b03d08b-7e07-4cd1-c9bc-21babcc30f03",
-    "scrolled": true
+    "id": "-Jzm_GoErz8B"
    },
    "outputs": [],
    "source": [
@@ -701,7 +629,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "Vzq2E5J2QMtw"
    },
    "source": [
@@ -715,7 +642,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "RaKp8aEjKX6B"
    },
    "source": [
@@ -732,14 +658,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "tMAT4DcMPwI-",
-    "outputId": "d1d595c3-264c-48f2-95ee-bd7e51b856ee",
-    "scrolled": true
+    "id": "tMAT4DcMPwI-"
    },
    "outputs": [],
    "source": [
@@ -751,7 +670,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "lOxFimtlKruu"
    },
    "source": [
@@ -776,10 +694,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "8xxi2NNGKwG_",
-    "scrolled": true
+    "id": "8xxi2NNGKwG_"
    },
    "outputs": [],
    "source": [
@@ -789,7 +704,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "pJVRZ0hP52ZB"
    },
    "source": [
@@ -800,14 +714,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "rxRNTFVe56RG",
-    "outputId": "7776b180-08e8-4dc0-8c2c-0bbf88158d24",
-    "scrolled": true
+    "id": "rxRNTFVe56RG"
    },
    "outputs": [],
    "source": [
@@ -821,7 +728,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "5B27cIT0O0nE"
    },
    "source": [
@@ -832,10 +738,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "icyvh-o6O0nF",
-    "scrolled": true
+    "id": "icyvh-o6O0nF"
    },
    "outputs": [],
    "source": [
@@ -845,7 +748,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "nhpgM7UpO0nG"
    },
    "source": [
@@ -856,13 +758,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "aw0OzyojAa39",
-    "outputId": "7516b74d-06a9-4e7a-dc40-dcb6652c39db"
+    "id": "aw0OzyojAa39"
    },
    "outputs": [],
    "source": [
@@ -874,7 +770,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "7Y2VSELvwAvW"
    },
    "source": [
@@ -897,10 +792,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "AIgulGRUhpto",
-    "scrolled": true
+    "id": "AIgulGRUhpto"
    },
    "outputs": [],
    "source": [
@@ -913,14 +805,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 187
-    },
-    "colab_type": "code",
-    "id": "066kVZQFO0nL",
-    "outputId": "39a44aa0-0681-4b71-a9e4-817ce73e3ee3",
-    "scrolled": true
+    "id": "066kVZQFO0nL"
    },
    "outputs": [],
    "source": [
@@ -958,7 +843,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "2FQHVUnm_rjw"
    },
    "source": [
@@ -968,7 +852,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "j3wdbmtLVTyr"
    },
    "source": [
@@ -981,14 +864,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 517
-    },
-    "colab_type": "code",
-    "id": "agjvNd2iUGFn",
-    "outputId": "b4c7ff18-9f9e-4a33-fc1d-e8968560495f",
-    "scrolled": true
+    "id": "agjvNd2iUGFn"
    },
    "outputs": [],
    "source": [
@@ -1009,7 +885,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "axA6WuGVO0nR"
    },
    "source": [
@@ -1019,7 +894,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "Zg8GoMZhLpGH"
    },
    "source": [
@@ -1064,7 +938,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "z-EvK7hGL0d8"
    },
    "source": [
@@ -1079,10 +952,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "SRMWCu30bnxH",
-    "scrolled": true
+    "id": "SRMWCu30bnxH"
    },
    "outputs": [],
    "source": [
@@ -1093,7 +963,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "jEPPL6FUO0nV"
    },
    "source": [
@@ -1104,10 +973,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "w6SCt95HO0nW",
-    "scrolled": true
+    "id": "w6SCt95HO0nW"
    },
    "outputs": [],
    "source": [
@@ -1119,7 +985,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "HFuOKXJdMAdm"
    },
    "source": [
@@ -1132,14 +997,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "Tj4Rs8gwO0nY",
-    "outputId": "1ae72efc-60b4-42ed-e913-79389f02dfe5",
-    "scrolled": true
+    "id": "Tj4Rs8gwO0nY"
    },
    "outputs": [],
    "source": [
@@ -1155,7 +1013,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "HcKEZMtCOeK-"
    },
    "source": [
@@ -1166,14 +1023,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 51
-    },
-    "colab_type": "code",
-    "id": "uNwt2eMeOane",
-    "outputId": "d87dd6fb-55aa-4d18-e73d-9e8bc2783243",
-    "scrolled": true
+    "id": "uNwt2eMeOane"
    },
    "outputs": [],
    "source": [
@@ -1188,7 +1038,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "7Li2r1tYvW7S"
    },
    "source": [
@@ -1207,14 +1056,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 68
-    },
-    "colab_type": "code",
-    "id": "MTYOZr27O0ne",
-    "outputId": "49b62867-b844-4e24-91a4-49f0a37b3f93",
-    "scrolled": true
+    "id": "MTYOZr27O0ne"
    },
    "outputs": [],
    "source": [
@@ -1231,39 +1073,19 @@
     "    print(\"Example \\(i) prediction: \\(classNames[Int(classIdx)]) (\\(softmax(logits)))\")\n",
     "}"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "HwRFrSsul5dS"
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "colab": {
    "collapsed_sections": [],
-   "name": "Swift for TensorFlow: walkthrough",
-   "provenance": [],
-   "toc_visible": true,
-   "version": "0.3.2"
+   "name": "model_training_walkthrough.ipynb",
+   "toc_visible": true
   },
   "kernelspec": {
    "display_name": "Swift",
-   "language": "swift",
    "name": "swift"
-  },
-  "language_info": {
-   "file_extension": ".swift",
-   "mimetype": "text/x-swift",
-   "name": "swift",
-   "version": ""
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 0
 }

--- a/docs/site/tutorials/protocol_oriented_generics.ipynb
+++ b/docs/site/tutorials/protocol_oriented_generics.ipynb
@@ -1,29 +1,8 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "protocol_oriented_generics.ipynb",
-      "provenance": [],
-      "collapsed_sections": []
-    },
-    "kernelspec": {
-      "display_name": "Swift",
-      "language": "swift",
-      "name": "swift"
-    },
-    "language_info": {
-      "file_extension": ".swift",
-      "mimetype": "text/x-swift",
-      "name": "swift",
-      "version": ""
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "ZloPIuRHn97X"
       },
       "source": [
@@ -32,11 +11,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "colab_type": "code",
-        "id": "tNgCmfUvJNoF",
-        "colab": {}
+        "cellView": "form",
+        "id": "tNgCmfUvJNoF"
       },
+      "outputs": [],
       "source": [
         "// #@title Licensed under the Apache License, Version 2.0 (the \"License\"); { display-mode: \"form\" }\n",
         "// Licensed under the Apache License, Version 2.0 (the \"License\");\n",
@@ -50,14 +30,11 @@
         "// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "// See the License for the specific language governing permissions and\n",
         "// limitations under the License."
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "AlvdCHw5JGyx"
       },
       "source": [
@@ -77,7 +54,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "c_1u7JSBMx3x"
       },
       "source": [
@@ -89,7 +65,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "LP0gMw56TlvH"
       },
       "source": [
@@ -105,7 +80,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "5AIIH5Q59b41"
       },
       "source": [
@@ -118,11 +92,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "colab_type": "code",
-        "id": "zCN0Uc0w-gng",
-        "colab": {}
+        "id": "zCN0Uc0w-gng"
       },
+      "outputs": [],
       "source": [
         "enum Color: String {\n",
         "    case red = \"red\"\n",
@@ -168,14 +142,11 @@
         "\n",
         "let invalidColor = Color(color: \"orange\")\n",
         "print(\"is invalidColor nil: \\(invalidColor == nil)\")"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "ueiGy9gCgypk"
       },
       "source": [
@@ -184,11 +155,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "colab_type": "code",
-        "id": "ns4qCE1pg3uJ",
-        "colab": {}
+        "id": "ns4qCE1pg3uJ"
       },
+      "outputs": [],
       "source": [
         "struct FastCar {\n",
         "    // Can have variables and constants as stored properties.\n",
@@ -227,14 +198,11 @@
         "print(car.description())\n",
         "print(\"Horse power in watts: \\(car.watts)\")\n",
         "print(car.titleCaseColorString)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "1Hw8bpQIlaWT"
       },
       "source": [
@@ -243,11 +211,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "colab_type": "code",
-        "id": "C67qzGBVlhdo",
-        "colab": {}
+        "id": "C67qzGBVlhdo"
       },
+      "outputs": [],
       "source": [
         "// Notice we have no problem modifying a constant class with \n",
         "// variable properties.\n",
@@ -277,14 +245,11 @@
         "// print(car.description())\n",
         "// modify(car: &car, toColor: .blue)\n",
         "// print(car.description())\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "0BNxC5RyoKM7"
       },
       "source": [
@@ -295,11 +260,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "colab_type": "code",
-        "id": "3ZSm1uTWoJ0h",
-        "colab": {}
+        "id": "3ZSm1uTWoJ0h"
       },
+      "outputs": [],
       "source": [
         "protocol Car {\n",
         "    var color: Color { get set }\n",
@@ -319,14 +284,11 @@
         "    // # of liters the car is holding, varies b/w models.\n",
         "    var gasLevelLiters: Int { get set }\n",
         "}"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "aV_F6MyLps3h"
       },
       "source": [
@@ -337,11 +299,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "colab_type": "code",
-        "id": "LkGRtwz3psrP",
-        "colab": {}
+        "id": "LkGRtwz3psrP"
       },
+      "outputs": [],
       "source": [
         "struct TeslaModelS: Car, Electric {\n",
         "    var color: Color // Needs to be a var since `Car` has a getter and setter.\n",
@@ -364,14 +326,11 @@
         "}\n",
         "\n",
         "var tesla = TeslaModelS(color: .red, price: 110000, batteryLevel: 100)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "K5KB0IGLrkcm"
       },
       "source": [
@@ -382,11 +341,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "colab_type": "code",
-        "id": "GPLKFUAOrMp-",
-        "colab": {}
+        "id": "GPLKFUAOrMp-"
       },
+      "outputs": [],
       "source": [
         "struct Mustang: Car, Gas{\n",
         "    var color: Color\n",
@@ -409,14 +368,11 @@
         "}\n",
         "\n",
         "var mustang = Mustang(color: .red, price: 30000, gasLevelLiters: 25)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "jrbCRkglsi_d"
       },
       "source": [
@@ -429,11 +385,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "colab_type": "code",
-        "id": "NiHUJxXMtzSg",
-        "colab": {}
+        "id": "NiHUJxXMtzSg"
       },
+      "outputs": [],
       "source": [
         "extension Electric {\n",
         "    mutating func recharge() {\n",
@@ -441,14 +397,11 @@
         "        batteryLevel = 100\n",
         "    }\n",
         "}"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "v8QbTb9NxWqI"
       },
       "source": [
@@ -458,7 +411,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "VIXakqxtvkp_"
       },
       "source": [
@@ -470,7 +422,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "MAo8n3zUR8Q9"
       },
       "source": [
@@ -479,11 +430,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "colab_type": "code",
-        "id": "koP20_C9R7ps",
-        "colab": {}
+        "id": "koP20_C9R7ps"
       },
+      "outputs": [],
       "source": [
         "protocol Default {}\n",
         "\n",
@@ -499,14 +450,11 @@
         "\n",
         "let a: Default = DefaultStruct()\n",
         "a.foo()"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "uSE5IWF_Sdet"
       },
       "source": [
@@ -515,11 +463,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "colab_type": "code",
-        "id": "DJ8jstIWSoUP",
-        "colab": {}
+        "id": "DJ8jstIWSoUP"
       },
+      "outputs": [],
       "source": [
         "protocol Default {\n",
         "    func foo()\n",
@@ -539,14 +487,11 @@
         "\n",
         "let a: Default = DefaultStruct()\n",
         "a.foo()"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "XC1juXPzZV8Q"
       },
       "source": [
@@ -556,7 +501,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "HzB0XC0wwMLD"
       },
       "source": [
@@ -569,11 +513,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "colab_type": "code",
-        "id": "CaIZhcsVyBKz",
-        "colab": {}
+        "id": "CaIZhcsVyBKz"
       },
+      "outputs": [],
       "source": [
         "struct OldElectric: Car, Electric {\n",
         "    var color: Color // Needs to be a var since `Car` has a getter and setter.\n",
@@ -594,14 +538,11 @@
         "        batteryLevel = 90\n",
         "    }\n",
         "}"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "c_Xmw5cDy_rZ"
       },
       "source": [
@@ -617,11 +558,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "colab_type": "code",
-        "id": "-Jfn3P3P1RDt",
-        "colab": {}
+        "id": "-Jfn3P3P1RDt"
       },
+      "outputs": [],
       "source": [
         "extension Collection where Element: Comparable {\n",
         "    // Verify that a `Collection` is sorted.\n",
@@ -667,14 +608,11 @@
         "print([2, 2, 5, 7, 11, 13, 17].binarySearch(5)!)\n",
         "print([\"a\", \"b\", \"c\", \"d\"].binarySearch(\"b\")!)\n",
         "print([1.1, 2.2, 3.3, 4.4, 5.5].binarySearch(3.3)!)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "CIh7qyFVqlaH"
       },
       "source": [
@@ -694,7 +632,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "TmqFx2layKs7"
       },
       "source": [
@@ -710,11 +647,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "colab_type": "code",
-        "id": "HIjkHLGtz268",
-        "colab": {}
+        "id": "HIjkHLGtz268"
       },
+      "outputs": [],
       "source": [
         "typealias ComparableReal = Comparable & FloatingPoint\n",
         "\n",
@@ -743,14 +680,11 @@
         "print(foo3(a: 1, b: 2))\n",
         "print(foo4(a: 1, b: 2))\n",
         "print(foo5(a: 1, b: 2))"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "DMCioS9Dz5Fh"
       },
       "source": [
@@ -763,11 +697,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "colab_type": "code",
-        "id": "oKvieIsw2YJW",
-        "colab": {}
+        "id": "oKvieIsw2YJW"
       },
+      "outputs": [],
       "source": [
         "enum Box {\n",
         "    case small\n",
@@ -791,14 +725,11 @@
         "        return \"(\\(self.name) \\(self.box) \\(self.mass))\"\n",
         "    }\n",
         "}"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "ey519vu04FgG"
       },
       "source": [
@@ -807,11 +738,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "colab_type": "code",
-        "id": "tVRuqx_q4jQ9",
-        "colab": {}
+        "id": "tVRuqx_q4jQ9"
       },
+      "outputs": [],
       "source": [
         "func filtering(_ laptops: [Laptop], by mass: Mass) -> [Laptop] {\n",
         "    return laptops.filter { $0.mass == mass }\n",
@@ -826,14 +757,11 @@
         "\n",
         "let filteredLaptops = filtering(laptops, by: .light)\n",
         "print(filteredLaptops)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Lw_W5zW17UMc"
       },
       "source": [
@@ -844,11 +772,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "colab_type": "code",
-        "id": "2qDVD9Yl8POQ",
-        "colab": {}
+        "id": "2qDVD9Yl8POQ"
       },
+      "outputs": [],
       "source": [
         "// Define a protocol which will act as our comparator.\n",
         "protocol DeviceFilterPredicate {\n",
@@ -887,14 +815,11 @@
         "// Let's test the function out!\n",
         "print(filtering(laptops, by: BoxFilter(box: .large)))\n",
         "print(filtering(laptops, by: MassFilter(mass: .heavy)))"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "yFx_6y0-CRHc"
       },
       "source": [
@@ -905,11 +830,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "colab_type": "code",
-        "id": "EzhE_K-eCvYt",
-        "colab": {}
+        "id": "EzhE_K-eCvYt"
       },
+      "outputs": [],
       "source": [
         "// Define 2 new protocols so we can filter anything in a box and which has mass.\n",
         "protocol Weighable {\n",
@@ -993,14 +918,11 @@
         "\n",
         "print(filtering(products, by: BoxFilter(box: .small)))\n",
         "print(filtering(products, by: MassFilter(mass: .medium)))"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "-UrRDSaFNCRg"
       },
       "source": [
@@ -1010,7 +932,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "6g3pPZIuMvPu"
       },
       "source": [
@@ -1162,7 +1083,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "UVLumcugImNx"
       },
       "source": [
@@ -1175,5 +1095,18 @@
         "* [Generics](https://docs.swift.org/swift-book/LanguageGuide/Generics.html): Swift's own documentation for Swift 5 all about generics."
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "collapsed_sections": [],
+      "name": "protocol_oriented_generics.ipynb",
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Swift",
+      "name": "swift"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/docs/site/tutorials/python_interoperability.ipynb
+++ b/docs/site/tutorials/python_interoperability.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "9TV7IYeqifSv"
    },
    "source": [
@@ -12,10 +11,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
+    "cellView": "form",
     "id": "tRIJp_4m_Afz"
    },
    "outputs": [],
@@ -37,7 +35,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "sI1ZtrdiA4aY"
    },
    "source": [
@@ -57,7 +54,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "8sa42_NblqRE"
    },
    "source": [
@@ -70,10 +66,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "kZRlD4utdPuX"
    },
    "outputs": [],
@@ -85,7 +79,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "W7MpNcIwIIy8"
    },
    "source": [
@@ -95,7 +88,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "lM9dRji7IIy8"
    },
    "source": [
@@ -110,7 +102,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "eoyLeSQVIIy9"
    },
    "source": [
@@ -121,10 +112,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "FCMWR11NIIy-"
    },
    "outputs": [],
@@ -136,7 +125,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "HrlMNOinIIy_"
    },
    "source": [
@@ -146,7 +134,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "mIbIOW0HIIzA"
    },
    "source": [
@@ -156,7 +143,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "rU0WY_sJodio"
    },
    "source": [
@@ -172,10 +158,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "kqXILiXhq-iM"
    },
    "outputs": [],
@@ -198,10 +182,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "fEAEyUExXT3I"
    },
    "outputs": [],
@@ -226,7 +208,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "1pMewsl0VgnJ"
    },
    "source": [
@@ -244,10 +225,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "W9bUsiOxVf_v"
    },
    "outputs": [],
@@ -266,7 +245,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "w3lmTRCWT5sS"
    },
    "source": [
@@ -280,10 +258,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "fQ0HEX89T4mW"
    },
    "outputs": [],
@@ -299,7 +275,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "Te7sNNx9c_am"
    },
    "source": [
@@ -310,10 +285,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "jpcOByipc75O"
    },
    "outputs": [],
@@ -330,7 +303,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "H2wwUL1tY3JX"
    },
    "source": [
@@ -341,10 +313,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "XrZee8n3Y17_"
    },
    "outputs": [],
@@ -358,7 +328,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "hQvza3dUXlr0"
    },
    "source": [
@@ -367,10 +336,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "QD-uQGuaXhrM"
    },
    "outputs": [],
@@ -382,7 +349,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "Qej_Z6V3mZnG"
    },
    "source": [
@@ -400,10 +366,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "hPvKgZBeDQ1p"
    },
    "outputs": [],
@@ -418,10 +382,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "ZuDgZ5cBS3Uk"
    },
    "outputs": [],
@@ -444,7 +406,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "8EQFZZ5iafwh"
    },
    "source": [
@@ -455,10 +416,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "vjQ7Rd3_IXuX"
    },
    "outputs": [],
@@ -471,10 +430,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "jUzsa2cxafQV"
    },
    "outputs": [],
@@ -503,22 +460,14 @@
  "metadata": {
   "colab": {
    "collapsed_sections": [],
-   "name": "Python interoperability.ipynb",
-   "provenance": [],
+   "name": "python_interoperability.ipynb",
    "toc_visible": true
   },
   "kernelspec": {
    "display_name": "Swift",
-   "language": "swift",
    "name": "swift"
-  },
-  "language_info": {
-   "file_extension": ".swift",
-   "mimetype": "text/x-swift",
-   "name": "swift",
-   "version": ""
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 0
 }

--- a/docs/site/tutorials/raw_tensorflow_operators.ipynb
+++ b/docs/site/tutorials/raw_tensorflow_operators.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "XNWJ6JVGkOlf"
    },
    "source": [
@@ -14,8 +13,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
+    "cellView": "form",
     "id": "fSlQ2vFzKGOY"
    },
    "outputs": [],
@@ -37,7 +35,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "yfNdITLmJtX8"
    },
    "source": [
@@ -57,7 +54,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "lONNcRalVUO9"
    },
    "source": [
@@ -69,7 +65,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "CYqNvcHxqg0Y"
    },
    "source": [
@@ -80,8 +75,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "cVRrzjzFqee9"
    },
    "outputs": [],
@@ -92,7 +85,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "5vza91sR09r-"
    },
    "source": [
@@ -105,13 +97,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "kZRlD4utdPuX",
-    "outputId": "6145cbb9-3b0b-42ee-c005-4040bf58eea6"
+    "id": "kZRlD4utdPuX"
    },
    "outputs": [],
    "source": [
@@ -121,7 +107,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "iIgKg-ueVCy_"
    },
    "source": [
@@ -136,13 +121,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "BdH-yZBjTZNx",
-    "outputId": "f3eaa279-a58a-4399-cbdd-a419e71bc88a"
+    "id": "BdH-yZBjTZNx"
    },
    "outputs": [],
    "source": [
@@ -162,7 +141,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "ucD5XZYYyzNe"
    },
    "source": [
@@ -181,13 +159,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 68
-    },
-    "colab_type": "code",
-    "id": "fDXS0h_YumcL",
-    "outputId": "4f3bf631-492d-4e0b-d93e-d9cb3f95bc45"
+    "id": "fDXS0h_YumcL"
    },
    "outputs": [],
    "source": [
@@ -221,7 +193,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "colab_type": "text",
     "id": "l7kae5o1VKnu"
    },
    "source": [
@@ -232,13 +203,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 85
-    },
-    "colab_type": "code",
-    "id": "v92FrXpCSuLT",
-    "outputId": "67cadc53-c983-421a-baa1-c855e08deb85"
+    "id": "v92FrXpCSuLT"
    },
    "outputs": [],
    "source": [
@@ -254,23 +219,14 @@
  "metadata": {
   "colab": {
    "collapsed_sections": [],
-   "name": "Raw TensorFlow operators.ipynb",
-   "provenance": [],
-   "toc_visible": true,
-   "version": "0.3.2"
+   "name": "raw_tensorflow_operators.ipynb",
+   "toc_visible": true
   },
   "kernelspec": {
    "display_name": "Swift",
-   "language": "swift",
    "name": "swift"
-  },
-  "language_info": {
-   "file_extension": ".swift",
-   "mimetype": "text/x-swift",
-   "name": "swift",
-   "version": ""
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
Format notebook tutorials with `nbfmt` from the [TensorFlow docs notebook tools](https://github.com/tensorflow/docs/tree/master/tools/tensorflow_docs/tools). This removes extra metadata for cleaner diffs (if used regularly). It also ensures that all cells have a `metadata.id` field (used by the new translation workflow).

```
python3 -m pip install -U --user git+https://github.com/tensorflow/docs

python3 -m tensorflow_docs.tools.nbfmt docs/site/
```

This PR keeps both 1 and 2 space indention levels for various notebooks, but normally I'd just default to 2 for everything (and example of editor differences that cause diff churn). I can set everything to 2, if desired.

Thanks!