### PR TITLE
Add explicit `print()` in tutorial notebooks

### DIFF
--- a/docs/site/tutorials/a_swift_tour.ipynb
+++ b/docs/site/tutorials/a_swift_tour.ipynb
@@ -140,7 +140,7 @@
    "source": [
     "let label = \"The width is \"\n",
     "let width = 94\n",
-    "label + String(width)"
+    "print(label + String(width))"
    ]
   },
   {
@@ -173,7 +173,7 @@
    "outputs": [],
    "source": [
     "let apples = 3\n",
-    "\"I have \\(apples) apples.\""
+    "print(\"I have \\(apples) apples.\")"
    ]
   },
   {
@@ -185,7 +185,7 @@
    "outputs": [],
    "source": [
     "let oranges = 5\n",
-    "\"I have \\(apples + oranges) pieces of fruit.\""
+    "print(\"I have \\(apples + oranges) pieces of fruit.\")"
    ]
   },
   {
@@ -254,7 +254,7 @@
     "    \"Kaylee\": \"Mechanic\",\n",
     "]\n",
     "occupations[\"Jayne\"] = \"Public Relations\"\n",
-    "occupations"
+    "print(occupations)"
    ]
   },
   {
@@ -275,7 +275,7 @@
    "outputs": [],
    "source": [
     "shoppingList.append(\"blue paint\")\n",
-    "shoppingList"
+    "print(shoppingList)"
    ]
   },
   {
@@ -348,7 +348,7 @@
     "        teamScore += 1\n",
     "    }\n",
     "}\n",
-    "teamScore"
+    "print(teamScore)"
    ]
   },
   {
@@ -371,7 +371,7 @@
    "outputs": [],
    "source": [
     "var optionalString: String? = \"Hello\"\n",
-    "optionalString == nil"
+    "print(optionalString == nil)"
    ]
   },
   {
@@ -387,7 +387,7 @@
     "if let name = optionalName {\n",
     "    greeting = \"Hello, \\(name)\"\n",
     "}\n",
-    "greeting"
+    "print(greeting)"
    ]
   },
   {
@@ -424,7 +424,7 @@
    "source": [
     "let nickName: String? = nil\n",
     "let fullName: String = \"John Appleseed\"\n",
-    "\"Hi \\(nickName ?? fullName)\""
+    "print(\"Hi \\(nickName ?? fullName)\")"
    ]
   },
   {
@@ -503,7 +503,7 @@
     "        }\n",
     "    }\n",
     "}\n",
-    "largest"
+    "print(largest)"
    ]
   },
   {
@@ -541,7 +541,7 @@
     "    n = n * 2\n",
     "}\n",
     "\n",
-    "n"
+    "print(n)"
    ]
   },
   {
@@ -557,7 +557,7 @@
     "    m = m * 2\n",
     "} while m < 100\n",
     "\n",
-    "m"
+    "print(m)"
    ]
   },
   {
@@ -582,7 +582,7 @@
     "    total += i\n",
     "}\n",
     "\n",
-    "total"
+    "print(total)"
    ]
   },
   {
@@ -616,7 +616,7 @@
     "func greet(name: String, day: String) -> String {\n",
     "    return \"Hello \\(name), today is \\(day).\"\n",
     "}\n",
-    "greet(name: \"Bob\", day: \"Tuesday\")"
+    "print(greet(name: \"Bob\", day: \"Tuesday\"))"
    ]
   },
   {
@@ -651,7 +651,7 @@
     "func greet(_ person: String, on day: String) -> String {\n",
     "    return \"Hello \\(person), today is \\(day).\"\n",
     "}\n",
-    "greet(\"John\", on: \"Wednesday\")"
+    "print(greet(\"John\", on: \"Wednesday\"))"
    ]
   },
   {
@@ -717,7 +717,7 @@
     "    add()\n",
     "    return y\n",
     "}\n",
-    "returnFifteen()"
+    "print(returnFifteen())"
    ]
   },
   {
@@ -744,7 +744,7 @@
     "    return addOne\n",
     "}\n",
     "var increment = makeIncrementer()\n",
-    "increment(7)"
+    "print(increment(7))"
    ]
   },
   {
@@ -776,7 +776,7 @@
     "    return number < 10\n",
     "}\n",
     "var numbers = [20, 19, 7, 12]\n",
-    "hasAnyMatches(list: numbers, condition: lessThanTen)"
+    "print(hasAnyMatches(list: numbers, condition: lessThanTen))"
    ]
   },
   {
@@ -796,10 +796,10 @@
    },
    "outputs": [],
    "source": [
-    "numbers.map({ (number: Int) -> Int in\n",
+    "print(numbers.map({ (number: Int) -> Int in\n",
     "    let result = 3 * number\n",
     "    return result\n",
-    "})"
+    "}))"
    ]
   },
   {
@@ -989,8 +989,8 @@
     "    }\n",
     "}\n",
     "let test = Square(sideLength: 5.2, name: \"my test square\")\n",
-    "test.area()\n",
-    "test.simpleDescription()"
+    "print(test.area())\n",
+    "print(test.simpleDescription())"
    ]
   },
   {
@@ -1120,7 +1120,7 @@
    "outputs": [],
    "source": [
     "let optionalSquare: Square? = Square(sideLength: 2.5, name: \"optional square\")\n",
-    "optionalSquare?.sideLength"
+    "print(optionalSquare?.sideLength)"
    ]
   },
   {
@@ -1427,8 +1427,8 @@
     "    }\n",
     "}\n",
     "var b = SimpleStructure()\n",
-    "b.adjust()\n",
-    "b.simpleDescription"
+    "print(b.adjust())\n",
+    "print(b.simpleDescription)"
    ]
   },
   {
@@ -1472,7 +1472,7 @@
     "        self += 42\n",
     "    }\n",
     "}\n",
-    "7.simpleDescription"
+    "print(7.simpleDescription)"
    ]
   },
   {
@@ -1505,7 +1505,7 @@
    "outputs": [],
    "source": [
     "let protocolValue: ExampleProtocol = a\n",
-    "protocolValue.simpleDescription"
+    "print(protocolValue.simpleDescription)"
    ]
   },
   {
@@ -1711,8 +1711,8 @@
     "    let result = fridgeContent.contains(food)\n",
     "    return result\n",
     "}\n",
-    "fridgeContains(\"banana\")\n",
-    "fridgeIsOpen"
+    "print(fridgeContains(\"banana\"))\n",
+    "print(fridgeIsOpen)"
    ]
   },
   {
@@ -1741,7 +1741,7 @@
     "    }\n",
     "    return result\n",
     "}\n",
-    "makeArray(repeating: \"knock\", numberOfTimes: 4)"
+    "print(makeArray(repeating: \"knock\", numberOfTimes: 4))"
    ]
   },
   {
@@ -1800,7 +1800,7 @@
     "    }\n",
     "    return false\n",
     "}\n",
-    "anyCommonElements([1, 2, 3], [3])"
+    "print(anyCommonElements([1, 2, 3], [3]))"
    ]
   },
   {

--- a/docs/site/tutorials/custom_differentiation.ipynb
+++ b/docs/site/tutorials/custom_differentiation.ipynb
@@ -129,9 +129,9 @@
    "source": [
     "let x: Float = 2.0\n",
     "let y: Float = 3.0\n",
-    "gradient(at: x, y) { x, y in\n",
+    "print(gradient(at: x, y) { x, y in\n",
     "    sin(sin(sin(x))) + withoutDerivative(at: cos(cos(cos(y))))\n",
-    "}"
+    "})"
    ]
   },
   {
@@ -176,7 +176,7 @@
    "outputs": [],
    "source": [
     "var x: Float = 30\n",
-    "gradient(at: x) { x -> Float in\n",
+    "print(gradient(at: x) { x -> Float in\n",
     "    // Print the partial derivative with respect to the result of `sin(x)`.\n",
     "    let a = sin(x).withDerivative { print(\"∂+/∂sin = \\($0)\") } \n",
     "    // Force the partial derivative with respect to `x` to be `0.5`.\n",
@@ -185,7 +185,7 @@
     "        dx = 0.5\n",
     "    })\n",
     "    return a + b\n",
-    "}"
+    "})"
    ]
   },
   {

--- a/docs/site/tutorials/introducing_x10.ipynb
+++ b/docs/site/tutorials/introducing_x10.ipynb
@@ -119,7 +119,7 @@
         "let eagerTensor1 = Tensor([0.0, 1.0, 2.0])\n",
         "let eagerTensor2 = Tensor([1.5, 2.5, 3.5])\n",
         "let eagerTensorSum = eagerTensor1 + eagerTensor2\n",
-        "eagerTensorSum"
+        "print(eagerTensorSum)"
       ]
     },
     {
@@ -130,7 +130,7 @@
       },
       "outputs": [],
       "source": [
-        "eagerTensor1.device"
+        "print(eagerTensor1.device)"
       ]
     },
     {
@@ -162,7 +162,7 @@
         "let x10Tensor1 = Tensor([0.0, 1.0, 2.0], on: Device.defaultXLA)\n",
         "let x10Tensor2 = Tensor([1.5, 2.5, 3.5], on: Device.defaultXLA)\n",
         "let x10TensorSum = x10Tensor1 + x10Tensor2\n",
-        "x10TensorSum"
+        "print(x10TensorSum)"
       ]
     },
     {
@@ -173,7 +173,7 @@
       },
       "outputs": [],
       "source": [
-        "x10Tensor1.device"
+        "print(x10Tensor1.device)"
       ]
     },
     {
@@ -382,7 +382,7 @@
       "outputs": [],
       "source": [
         "let device = Device.defaultXLA\n",
-        "device"
+        "print(device)"
       ]
     },
     {

--- a/docs/site/tutorials/model_training_walkthrough.ipynb
+++ b/docs/site/tutorials/model_training_walkthrough.ipynb
@@ -131,7 +131,7 @@
     "// This cell is here to display the plots in a Jupyter Notebook.\n",
     "// Do not copy it into another environment.\n",
     "%include \"EnableIPythonDisplay.swift\"\n",
-    "IPythonDisplay.shell.enable_matplotlib(\"inline\")"
+    "print(IPythonDisplay.shell.enable_matplotlib(\"inline\"))"
    ]
   },
   {
@@ -242,7 +242,7 @@
     "for _ in 0..<5 {\n",
     "    print(Python.next(f).strip())\n",
     "}\n",
-    "f.close()"
+    "print(f.close())"
    ]
   },
   {
@@ -580,7 +580,7 @@
    "source": [
     "// Apply the model to a batch of features.\n",
     "let firstTrainPredictions = model(firstTrainFeatures)\n",
-    "firstTrainPredictions[0..<5]"
+    "print(firstTrainPredictions[0..<5])"
    ]
   },
   {
@@ -602,7 +602,7 @@
    },
    "outputs": [],
    "source": [
-    "softmax(firstTrainPredictions[0..<5])"
+    "print(softmax(firstTrainPredictions[0..<5]))"
    ]
   },
   {

--- a/docs/site/tutorials/python_interoperability.ipynb
+++ b/docs/site/tutorials/python_interoperability.ipynb
@@ -425,7 +425,7 @@
     "// This cell is here to display plots inside a Jupyter Notebook.\n",
     "// Do not copy it into another environment.\n",
     "%include \"EnableIPythonDisplay.swift\"\n",
-    "IPythonDisplay.shell.enable_matplotlib(\"inline\")"
+    "print(IPythonDisplay.shell.enable_matplotlib(\"inline\"))"
    ]
   },
   {

--- a/docs/site/tutorials/raw_tensorflow_operators.ipynb
+++ b/docs/site/tutorials/raw_tensorflow_operators.ipynb
@@ -101,7 +101,7 @@
    },
    "outputs": [],
    "source": [
-    "_Raw.mul(Tensor([2.0, 3.0]), Tensor([5.0, 6.0]))"
+    "print(_Raw.mul(Tensor([2.0, 3.0]), Tensor([5.0, 6.0])))"
    ]
   },
   {
@@ -135,7 +135,7 @@
     "\n",
     "let x: Tensor<Double> = [[1.0, 2.0], [3.0, 4.0]]\n",
     "let y: Tensor<Double> = [[8.0, 7.0], [6.0, 5.0]]\n",
-    "x .* y"
+    "print(x .* y)"
    ]
   },
   {
@@ -185,9 +185,9 @@
     "}\n",
     "\n",
     "// Now, we can take the derivative of a function that calls `.*` that we just defined.\n",
-    "gradient(at: x, y) { x, y in\n",
+    "print(gradient(at: x, y) { x, y in\n",
     "    (x .* y).sum()\n",
-    "}"
+    "})"
    ]
   },
   {


### PR DESCRIPTION
Add explicit `print()` in implied cases that throw an error in Colab with the 0.12 release:

```
Use `print()` to show values.
```