### PR TITLE
Update autodiff sharp edges tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Tutorial | Last Updated |
 [Protocol-Oriented Programming & Generics](https://colab.research.google.com/github/tensorflow/swift/blob/master/docs/site/tutorials/protocol_oriented_generics.ipynb) | August 2019
 [Python Interoperability](https://colab.research.google.com/github/tensorflow/swift/blob/master/docs/site/tutorials/python_interoperability.ipynb) | March 2019
 [Custom Differentiation](https://colab.research.google.com/github/tensorflow/swift/blob/master/docs/site/tutorials/custom_differentiation.ipynb) | March 2019
-[Sharp Edges in Differentiability](https://colab.research.google.com/github/tensorflow/swift/blob/master/docs/site/tutorials/Swift_autodiff_sharp_edges.ipynb) | September 2020
+[Sharp Edges in Differentiability](https://colab.research.google.com/github/tensorflow/swift/blob/master/docs/site/tutorials/Swift_autodiff_sharp_edges.ipynb) | November 2020
 [Model Training Walkthrough](https://colab.research.google.com/github/tensorflow/swift/blob/master/docs/site/tutorials/model_training_walkthrough.ipynb) | March 2019
 [Raw TensorFlow Operators](https://colab.research.google.com/github/tensorflow/swift/blob/master/docs/site/tutorials/raw_tensorflow_operators.ipynb) | December 2019
 [Introducing X10, an XLA-Based Backend](https://colab.research.google.com/github/tensorflow/swift/blob/master/docs/site/tutorials/introducing_x10.ipynb) | May 2020

--- a/docs/site/tutorials/Swift_autodiff_sharp_edges.ipynb
+++ b/docs/site/tutorials/Swift_autodiff_sharp_edges.ipynb
@@ -3,12 +3,12 @@
   "nbformat_minor": 0,
   "metadata": {
     "colab": {
-      "name": "Swift autodiff sharp edges.ipynb",
+      "name": "Swift_autodiff_sharp_edges.ipynb",
       "provenance": []
     },
     "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
+      "name": "swift",
+      "display_name": "Swift"
     }
   },
   "cells": [
@@ -30,43 +30,126 @@
       "source": [
         "##Loops\n",
         "\n",
-        "Loops are differentiable, there's just one detail to know about. When you write the loop, wrap the bit where you specify what you're looping over in `withoutDerivative(at:)`\n",
-        "\n",
-        " ```swift\n",
-        "var a: [Float] = [1,2,3]\n",
-        "```\n",
-        "for example:\n",
-        "```swift\n",
-        "for _ in a.indices\n",
-        "{}\n",
-        "```\n",
-        "becomes\n",
-        "```swift\n",
-        "for _ in withoutDerivative(at: a.indices)\n",
-        "{}\n",
-        "```\n",
-        "\n",
-        "or:\n",
-        "```swift\n",
-        "for _ in 0..<a.count\n",
-        "{}\n",
-        "```\n",
-        "becomes\n",
-        "```swift\n",
-        "for _ in 0..<withoutDerivative(at: a.count)\n",
-        "{}\n",
-        "```\n",
-        "\n",
-        "This is necessary because the `Array.count` member doesn't contribute to the derivative with respect to the array.\n",
-        "Only the actual elements in the array contribute to the derivative.\n",
-        "\n",
-        "If you've got a loop where you manually use an integer as the upper bound, there's no need to use `withoutDerivative(at:)`:\n",
-        "\n",
-        "```swift\n",
-        "let iterations: Int = 10\n",
-        "for _ in 0..<iterations {} //this is fine as-is.\n",
-        "```"
+        "Loops are differentiable, there's just one detail to know about. When you write the loop, wrap the bit where you specify what you're looping over in `withoutDerivative(at:)`\n"
       ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "mvBQ2eCfTDrj"
+      },
+      "source": [
+        "var a: [Float] = [1,2,3]"
+      ],
+      "execution_count": 1,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "to30MPP2TJqi"
+      },
+      "source": [
+        "for example:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "9NRXNazqTMqV"
+      },
+      "source": [
+        "for _ in a.indices \n",
+        "{}"
+      ],
+      "execution_count": 2,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "wPrrZ7qUTUMG"
+      },
+      "source": [
+        "becomes"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "zzwe0d8JTVN7"
+      },
+      "source": [
+        "for _ in withoutDerivative(at: a.indices) \n",
+        "{}"
+      ],
+      "execution_count": 3,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "UITuC4g9TYEp"
+      },
+      "source": [
+        "or:\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "YRbV8eqATcnG"
+      },
+      "source": [
+        "for _ in 0..<a.count \n",
+        "{}"
+      ],
+      "execution_count": 4,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "X5O0DPm6Tfxl"
+      },
+      "source": [
+        "becomes"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "n5c0Dsc3TllX"
+      },
+      "source": [
+        "for _ in 0..<withoutDerivative(at: a.count) \n",
+        "{}"
+      ],
+      "execution_count": 5,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "BJpcKJbTTvTC"
+      },
+      "source": [
+        "This is necessary because the `Array.count` member doesn't contribute to the derivative with respect to the array. Only the actual elements in the array contribute to the derivative.\n",
+        "\n",
+        "If you've got a loop where you manually use an integer as the upper bound, there's no need to use `withoutDerivative(at:)`:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "EDL4ykoZTwcl"
+      },
+      "source": [
+        "let iterations: Int = 10\n",
+        "for _ in 0..<iterations {} //this is fine as-is."
+      ],
+      "execution_count": 6,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -75,11 +158,35 @@
       },
       "source": [
         "##Map and Reduce\n",
-        "`map` and `reduce` have special differentiable versions that work exactly the same as what you're used to:\n",
-        "```swift\n",
-        "_ = a.differentiableMap {$0 + 1}\n",
-        "_ = a.differentiableReduce(0, +)\n",
-        "```"
+        "`map` and `reduce` have special differentiable versions that work exactly like what you're used to:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "vzZl_P6-W_nD",
+        "outputId": "0e058fb9-f6a9-4548-83cb-70475b09f1d4",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "source": [
+        "a = [1,2,3]\n",
+        "let aPlusOne = a.differentiableMap {$0 + 1}\n",
+        "let aSum = a.differentiableReduce(0, +)\n",
+        "print(\"aPlusOne\", aPlusOne)\n",
+        "print(\"aSum\", aSum)"
+      ],
+      "execution_count": 7,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "aPlusOne [2.0, 3.0, 4.0]\r\n",
+            "aSum 6.0\r\n"
+          ],
+          "name": "stdout"
+        }
       ]
     },
     {
@@ -89,14 +196,21 @@
       },
       "source": [
         "##Array subscript sets\n",
-        "Array subscript sets (`array[0] = 0`) aren't differentiable out of the box, but you can paste this extension:\n",
-        "```swift\n",
-        "public extension Array where Element: Differentiable {\n",
+        "Array subscript sets (`array[0] = 0`) aren't differentiable out of the box, but you can paste this extension:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "vj5XDwl0XEGi"
+      },
+      "source": [
+        "extension Array where Element: Differentiable {\n",
         "    @differentiable(where Element: Differentiable)\n",
         "    mutating func updated(at index: Int, with newValue: Element) {\n",
         "        self[index] = newValue\n",
         "    }\n",
-        "    \n",
+        " \n",
         "    @derivative(of: updated)\n",
         "    mutating func vjpUpdated(at index: Int, with newValue: Element)\n",
         "      -> (value: Void, pullback: (inout TangentVector) -> (Element.TangentVector))\n",
@@ -108,73 +222,118 @@
         "            return dElement\n",
         "        })\n",
         "    }\n",
+        "}"
+      ],
+      "execution_count": 8,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "mCkdO-F8XLFo"
+      },
+      "source": [
+        "and then the workaround syntax is like this:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "GxZnhZGdXMm0"
+      },
+      "source": [
+        "var b: [Float] = [1,2,3]"
+      ],
+      "execution_count": 9,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "qC5d-l3nXPxl"
+      },
+      "source": [
+        "instead of this:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "5YNUPyS3XUQ-"
+      },
+      "source": [
+        "b[0] = 17"
+      ],
+      "execution_count": 10,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "G1sCDA9zXWSA"
+      },
+      "source": [
+        "write this:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "ze-zTQP-XbN8"
+      },
+      "source": [
+        "b.updated(at: 0, with: 17)"
+      ],
+      "execution_count": 11,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bjDuPALzfKQC"
+      },
+      "source": [
+        "Let's make sure it works:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "uKTN_ET6fNUc",
+        "outputId": "42c64291-0f91-45df-9b8e-1355a4a04a92",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "source": [
+        "func plusOne(array: [Float]) -> Float{\n",
+        "  var array = array\n",
+        "  array.updated(at: 0, with: array[0] + 1)\n",
+        "  return array[0]\n",
         "}\n",
-        "```\n",
-        "and then the workaround syntax is like this:\n",
-        "```swift\n",
-        "var b: [Float] = [1,2,3]\n",
-        "```\n",
         "\n",
-        "instead of this:\n",
-        "```swift\n",
-        "b[0] = 17\n",
-        "```\n",
-        "write this:\n",
-        "```swift\n",
-        "b.updated(at: 0, with: 17)\n",
-        "```\n",
-        "\n",
-        "here is the link to see progress on making this workaround unnecessary: https://bugs.swift.org/browse/TF-1277 (it talks about Array.subscript._modify, which is what's called behind the scenes when you do an array subscript set)."
+        "let plusOneValAndGrad = valueWithGradient(at: [2], in: plusOne)\n",
+        "print(plusOneValAndGrad)"
+      ],
+      "execution_count": 20,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "(value: 3.0, gradient: [1.0])\r\n"
+          ],
+          "name": "stdout"
+        }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "8-iaCECXd-op"
+        "id": "6-xCTZXNXf5c"
       },
       "source": [
-        "##Boolean `||` and `&&`\n",
-        "Boolean `||` and `&&` aren't differentiable out of the box, but you can use this extension:\n",
-        "```swift\n",
-        "extension Bool{\n",
-        "    public static func and(_ a: Bool, _ b: Bool) -> Bool {\n",
-        "        if a {\n",
-        "            if b {\n",
-        "                return true\n",
-        "            }\n",
-        "        }\n",
-        "        return false\n",
-        "    }\n",
-        "    \n",
-        "    public static func or(_ a: Bool, _ b: Bool) -> Bool {\n",
-        "        if a { return true }\n",
-        "        if b { return true }\n",
-        "        return false\n",
-        "    }\n",
-        "}\n",
-        "```\n",
-        "\n",
-        "\n",
-        "and then the workaround syntax is as follows:\n",
-        "```swift\n",
-        "var condition1 = true\n",
-        "var condition2 = true\n",
-        "```\n",
-        "\n",
-        "\n",
-        "instead of this:\n",
-        "```swift\n",
-        "if condition1 || condition2 {\n",
-        "  //do things\n",
-        "}\n",
-        "```\n",
-        "write this:\n",
-        "```swift\n",
-        "if Bool.or(condition1, condition2) {\n",
-        "  //do things\n",
-        "}\n",
-        "```\n",
-        "(and similarly for `Bool.and`)"
+        "The error you'll get without this workaround is `Differentiation of coroutine calls is not yet supported`.\n",
+        "Here is the link to see progress on making this workaround unnecessary: https://bugs.swift.org/browse/TF-1277 (it talks about Array.subscript._modify, which is what's called behind the scenes when you do an array subscript set)."
       ]
     },
     {
@@ -187,20 +346,74 @@
         "If you're switching between `Float` and `Double`, their constructors aren't already differentiable. Here's a function that will let you go from a `Float` to a `Double` differentiably.\n",
         "\n",
         "(Switch `Float` and `Double` in the below code, and you've got a function that converts from `Double` to `Float`.)\n",
-        "```swift\n",
+        "\n",
+        "You can make similar converters for any other real Numeric types."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "vc0eakpEYE8B"
+      },
+      "source": [
         "@differentiable\n",
-        "public func convertToDouble(_ a: Float) -> Double {\n",
+        "func convertToDouble(_ a: Float) -> Double {\n",
         "    return Double(a)\n",
         "}\n",
-        "\n",
-        "@usableFromInline @derivative(of: convertToDouble)\n",
+        " \n",
+        "@derivative(of: convertToDouble)\n",
         "func convertToDoubleVJP(_ a: Float) -> (value: Double, pullback: (Double) -> Float) {\n",
         "    func pullback(_ v: Double) -> Float{\n",
         "        return Float(v)\n",
         "    }\n",
         "    return (value: Double(a), pullback: pullback)\n",
+        "}"
+      ],
+      "execution_count": 13,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "W9Tup97yfu-x"
+      },
+      "source": [
+        "Here's an example usage:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "pNeh1vHWfyOI",
+        "outputId": "a1ececc1-aa5a-4695-81c6-2183737bd40c",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "source": [
+        "@differentiable\n",
+        "func timesTwo(a: Float) -> Double {\n",
+        "  return convertToDouble(a * 2)\n",
         "}\n",
-        "```"
+        "let input: Float = 3\n",
+        "let valAndGrad = valueWithGradient(at: input, in: timesTwo)\n",
+        "print(\"grad\", valAndGrad.gradient)\n",
+        "print(\"type of input:\", type(of: input))\n",
+        "print(\"type of output:\", type(of: valAndGrad.value))\n",
+        "print(\"type of gradient:\", type(of: valAndGrad.gradient))"
+      ],
+      "execution_count": 14,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "grad 2.0\r\n",
+            "type of input: Float\r\n",
+            "type of output: Double\r\n",
+            "type of gradient: Float\r\n"
+          ],
+          "name": "stdout"
+        }
       ]
     },
     {
@@ -212,8 +425,17 @@
         "##Transcendental and other functions (sin, cos, abs, max)\n",
         "A lot of transcendentals and other common built-in functions have already been made differentiable for `Float` and `Double`. There are fewer for `Double` than `Float`. Some aren't available for either. So here are a few manual derivative definitions to give you the idea of how to make what you need, in case it isn't already provided:\n",
         "\n",
-        "pow (see [link](https://www.wolframalpha.com/input/?i=partial+derivatives+of+f%28x%2Cy%29+%3D+x%5Ey) for derivative explanation)\n",
-        "```swift\n",
+        "pow (see [link](https://www.wolframalpha.com/input/?i=partial+derivatives+of+f%28x%2Cy%29+%3D+x%5Ey) for derivative explanation)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "JPXr_xtwYOV9"
+      },
+      "source": [
+        "import Foundation\n",
+        "\n",
         "@usableFromInline\n",
         "@derivative(of: pow) \n",
         "func powVJP(_ base: Double, _ exponent: Double) -> (value: Double, pullback: (Double) -> (Double, Double)) {\n",
@@ -223,14 +445,28 @@
         "        let exponentDerivative = vector * output * log(base)\n",
         "        return (baseDerivative, exponentDerivative)\n",
         "    }\n",
-        "\n",
+        " \n",
         "    return (value: output, pullback: pullback)\n",
-        "}\n",
-        "```\n",
-        "\n",
-        "\n",
-        "max\n",
-        "```swift\n",
+        "}"
+      ],
+      "execution_count": 15,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "CxwAtO-vYPp0"
+      },
+      "source": [
+        "max"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "P_cqKUe1YWQz"
+      },
+      "source": [
         "@usableFromInline\n",
         "@derivative(of: max)\n",
         "func maxVJP<T: Comparable & Differentiable>(_ x: T, _ y: T) -> (value: T, pullback: (T.TangentVector)\n",
@@ -244,11 +480,26 @@
         "        }\n",
         "    }\n",
         "    return (value: max(x, y), pullback: pullback)\n",
-        "}\n",
-        "```\n",
-        "\n",
-        "abs\n",
-        "```swift\n",
+        "}"
+      ],
+      "execution_count": 16,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "fwwzgOnNYXUR"
+      },
+      "source": [
+        "abs"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "iNCladNcYaio"
+      },
+      "source": [
         "@usableFromInline\n",
         "@derivative(of: abs)\n",
         "func absVJP<T: Comparable & SignedNumeric & Differentiable>(_ x: T)\n",
@@ -263,10 +514,26 @@
         "        }\n",
         "    }\n",
         "    return (value: abs(x), pullback: pullback)\n",
-        "}\n",
-        "```\n",
-        "sqrt (see [link](https://www.wolframalpha.com/input/?i=partial+derivative+of+f%28x%29+%3D+sqrt%28x%29) for derivative explanation)\n",
-        "```swift\n",
+        "}"
+      ],
+      "execution_count": 17,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "OnLo4C7fYeK6"
+      },
+      "source": [
+        "sqrt (see [link](https://www.wolframalpha.com/input/?i=partial+derivative+of+f%28x%29+%3D+sqrt%28x%29) for derivative explanation)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "bIO0M5ONYiRD"
+      },
+      "source": [
         "@usableFromInline\n",
         "@derivative(of: sqrt) \n",
         "func sqrtVJP(_ x: Double) -> (value: Double, pullback: (Double) -> Double) {\n",
@@ -275,9 +542,63 @@
         "        return v / (2 * output)\n",
         "    }\n",
         "    return (value: output, pullback: pullback)\n",
-        "}\n",
-        "```\n",
-        "The compiler error that alerts you to the need for something like this is: `Expression is not differentiable - 1. Cannot differentiate functions that have not been marked '@differentiable' and that are defined in other files`\n"
+        "}"
+      ],
+      "execution_count": 18,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "H45t3grVj2bx"
+      },
+      "source": [
+        "Let's check that these work:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "liU1ZR8_j5VN",
+        "outputId": "5ad8190f-a139-4540-9d40-95d0c2fb6b8d",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "source": [
+        "let powGrad = gradient(at: 2, 2, in: pow)\n",
+        "print(\"pow gradient: \", powGrad, \"which is\", powGrad == (4.0, 2.772588722239781) ? \"correct\" : \"incorrect\")\n",
+        "\n",
+        "let maxGrad = gradient(at: 1, 2, in: max)\n",
+        "print(\"max gradient: \", maxGrad, \"which is\", maxGrad == (0.0, 1.0) ? \"correct\" : \"incorrect\")\n",
+        "\n",
+        "let absGrad = gradient(at: 2, in: abs)\n",
+        "print(\"abs gradient: \", absGrad, \"which is\", absGrad == 1.0 ? \"correct\" : \"incorrect\")\n",
+        "\n",
+        "let sqrtGrad = gradient(at: 4, in: sqrt)\n",
+        "print(\"sqrt gradient: \", sqrtGrad, \"which is\", sqrtGrad == 0.25 ? \"correct\" : \"incorrect\")"
+      ],
+      "execution_count": 19,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "pow gradient:  (4.0, 2.772588722239781) which is correct\r\n",
+            "max gradient:  (0.0, 1.0) which is correct\r\n",
+            "abs gradient:  1.0 which is correct\r\n",
+            "sqrt gradient:  0.25 which is correct\r\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bjXglKrIYpUy"
+      },
+      "source": [
+        "The compiler error that alerts you to the need for something like this is: `Expression is not differentiable. Cannot differentiate functions that have not been marked '@differentiable' and that are defined in other files`"
       ]
     },
     {


### PR DESCRIPTION
Per [issue #560](https://github.com/tensorflow/swift/issues/560)
make notebook executable, and remove deprecated workarounds for || and &&

Also, I haven't seen this tutorial on the tensorflow.org site, not sure how to make that happen.