### PR TITLE
Change the macOS package link for the v0.12 RC2

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -124,7 +124,7 @@ the meantime, you may be able to run Ubuntu 18.04 toolchains on Ubuntu 20.04 usi
 
 | Download | Version | Date |
 |----------|---------|------|
-| [Xcode 12](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.12/rc2/swift-tensorflow-RELEASE-0.12-ubuntu18.04.tar.gz) | v0.12-rc2 | November 17, 2020 |
+| [Xcode 12](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.12/rc2/swift-tensorflow-RELEASE-0.12-osx.pkg) | v0.12-rc2 | November 17, 2020 |
 | [Ubuntu 20.04 (CPU Only)](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.12/rc2/swift-tensorflow-RELEASE-0.12-ubuntu20.04.tar.gz) | v0.12-rc2 | November 12, 2020 |
 | [Ubuntu 18.04 (CPU Only)](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.12/rc2/swift-tensorflow-RELEASE-0.12-ubuntu18.04.tar.gz) | v0.12-rc2 | November 12, 2020  |
 | [Ubuntu 18.04 (CUDA 11.0)](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.12/rc2/swift-tensorflow-RELEASE-0.12-cuda11.0-cudnn8-ubuntu18.04.tar.gz) | v0.12-rc2 | November 12, 2020  |


### PR DESCRIPTION
The Ubuntu link accidentally slipped in there, instead of the macOS package.