### PR TITLE
Add workaround for SR-13949

### DIFF
--- a/docs/site/tutorials/a_swift_tour.ipynb
+++ b/docs/site/tutorials/a_swift_tour.ipynb
@@ -796,10 +796,11 @@
    },
    "outputs": [],
    "source": [
-    "print(numbers.map({ (number: Int) -> Int in\n",
+    "let mappedNumbers = numbers.map({ (number: Int) -> Int in\n",
     "    let result = 3 * number\n",
     "    return result\n",
-    "}))"
+    "})",
+    "print(mappedNumbers)"
    ]
   },
   {
@@ -831,8 +832,8 @@
    },
    "outputs": [],
    "source": [
-    "let mappedNumbers = numbers.map({ number in 3 * number })\n",
-    "print(mappedNumbers)"
+    "let mappedNumbers2 = numbers.map({ number in 3 * number })\n",
+    "print(mappedNumbers2)"
    ]
   },
   {

--- a/docs/site/tutorials/a_swift_tour.ipynb
+++ b/docs/site/tutorials/a_swift_tour.ipynb
@@ -799,7 +799,7 @@
     "let mappedNumbers = numbers.map({ (number: Int) -> Int in\n",
     "    let result = 3 * number\n",
     "    return result\n",
-    "})",
+    "})\n",
     "print(mappedNumbers)"
    ]
   },

--- a/docs/site/tutorials/custom_differentiation.ipynb
+++ b/docs/site/tutorials/custom_differentiation.ipynb
@@ -129,9 +129,10 @@
    "source": [
     "let x: Float = 2.0\n",
     "let y: Float = 3.0\n",
-    "print(gradient(at: x, y) { x, y in\n",
+    "let xyGradient = gradient(at: x, y) { x, y in\n",
     "    sin(sin(sin(x))) + withoutDerivative(at: cos(cos(cos(y))))\n",
-    "})"
+    "}",
+    "print(xyGradient)"
    ]
   },
   {
@@ -176,7 +177,7 @@
    "outputs": [],
    "source": [
     "var x: Float = 30\n",
-    "print(gradient(at: x) { x -> Float in\n",
+    "let xGradient = gradient(at: x) { x -> Float in\n",
     "    // Print the partial derivative with respect to the result of `sin(x)`.\n",
     "    let a = sin(x).withDerivative { print(\"∂+/∂sin = \\($0)\") } \n",
     "    // Force the partial derivative with respect to `x` to be `0.5`.\n",
@@ -185,7 +186,8 @@
     "        dx = 0.5\n",
     "    })\n",
     "    return a + b\n",
-    "})"
+    "}",
+    "print(xGradient)"
    ]
   },
   {

--- a/docs/site/tutorials/custom_differentiation.ipynb
+++ b/docs/site/tutorials/custom_differentiation.ipynb
@@ -131,7 +131,7 @@
     "let y: Float = 3.0\n",
     "let xyGradient = gradient(at: x, y) { x, y in\n",
     "    sin(sin(sin(x))) + withoutDerivative(at: cos(cos(cos(y))))\n",
-    "}",
+    "}\n",
     "print(xyGradient)"
    ]
   },
@@ -186,7 +186,7 @@
     "        dx = 0.5\n",
     "    })\n",
     "    return a + b\n",
-    "}",
+    "}\n",
     "print(xGradient)"
    ]
   },


### PR DESCRIPTION
Adds a workaround for what appears to be a REPL-only upstream bug affecting calls to `print()` ([SR-13949](https://bugs.swift.org/browse/SR-13949)).

This fix resolves the following failures.

a_swift_tour.ipynb:
```
nbclient.exceptions.CellExecutionError: An error occurred while executing the following cell:
------------------
print(numbers.map({ (number: Int) -> Int in
    let result = 3 * number
    return result
}))
------------------

error: <Cell 34>:2:22: error: cannot find 'number' in scope
    let result = 3 * number
                     ^~~~~~

error: <Cell 34>:3:12: error: cannot find 'result' in scope
    return result
           ^~~~~~
```

custom_differentiation.ipynb:
```
nbclient.exceptions.CellExecutionError: An error occurred while executing the following cell:
------------------
var x: Float = 30
print(gradient(at: x) { x -> Float in
    // Print the partial derivative with respect to the result of `sin(x)`.
    let a = sin(x).withDerivative { print("∂+/∂sin = \($0)") } 
    // Force the partial derivative with respect to `x` to be `0.5`.
    let b = log(x.withDerivative { (dx: inout Float) in
        print("∂log/∂x = \(dx), but rewritten to 0.5");
        dx = 0.5
    })
    return a + b
})
------------------

error: <Cell 4>:7:32: error: cannot find 'dx' in scope
        print("∂log/∂x = \(dx), but rewritten to 0.5");

error: <Cell 4>:8:9: error: cannot find 'dx' in scope
        dx = 0.5
        ^~

error: <Cell 4>:10:12: error: cannot find 'a' in scope
    return a + b
           ^

error: <Cell 4>:10:16: error: cannot find 'b' in scope
    return a + b
               ^
```