### PR TITLE
[README] Clean up old source code information.

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,20 +174,20 @@ Document | Last Updated | Status |
 
 ## Source code
 
-Compiler and standard library development happens on the `tensorflow` branch of
-the [apple/swift](https://github.com/apple/swift/tree/tensorflow) repository.
+Compiler and standard library development happens on the `main` branch of the
+[apple/swift](https://github.com/apple/swift/tree/main) repository.
 
 Additional code repositories that make up the core of the project include:
 
- - [Swift fork of LLDB](http://github.com/apple/swift-lldb/tree/tensorflow):
-   debugger and REPL support.
  - [Deep learning library](https://github.com/tensorflow/swift-apis): high-level
    API familiar to Keras users.
 
-> Swift for TensorFlow is **not** intended to remain a long-term fork of the official
-> Swift language. Language additions are designed to fit with the direction of
-> Swift and will go through the [Swift
-> Evolution](https://github.com/apple/swift-evolution) process.
+> Swift for TensorFlow is **no longer** a fork of the official Swift language;
+> development was previously done on the `tensorflow` branch of the
+> [apple/swift](https://github.com/apple/swift/tree/tensorflow) repository.
+> Language additions were designed to fit with the direction of Swift and are
+> going through the [Swift Evolution](https://github.com/apple/swift-evolution)
+> process.
 
 ### Jupyter Notebook support
 


### PR DESCRIPTION
Swift for TensorFlow no longer uses a separate `tensorflow` branch of the Swift compiler.
Resolves https://github.com/tensorflow/swift/issues/542.