### PR TITLE
Adding 0.13 release toolchains for Ubuntu

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -11,11 +11,26 @@ To install Swift for TensorFlow, download one of the packages below and follow t
 
 ## Releases
 
+[Release notes for v0.13.0](https://docs.google.com/document/d/1ywzGOGndQI5b-PVu_M2Sy2RuRD9h5FHqCC9zX6LNMHA/edit?usp=sharing)
+
+| Download | Version | Date |
+|----------|---------|------|
+| [Xcode 12.3](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.12/rc2/swift-tensorflow-RELEASE-0.12-osx.pkg) | v0.12 | November 17, 2020 |
+| [Ubuntu 20.04 (CPU Only)](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.13/swift-tensorflow-RELEASE-0.13-ubuntu20.04.tar.gz) | v0.13 | January 21, 2021 |
+| [Ubuntu 18.04 (CPU Only)](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.13/swift-tensorflow-RELEASE-0.13-ubuntu18.04.tar.gz) | v0.13 | January 21, 2021  |
+| [Ubuntu 18.04 (CUDA 11.0)](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.13/swift-tensorflow-RELEASE-0.13-cuda11.0-cudnn8-ubuntu18.04.tar.gz) | v0.13 | January 21, 2021  |
+| [Ubuntu 18.04 (CUDA 10.2)](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.13/swift-tensorflow-RELEASE-0.13-cuda10.2-cudnn7-ubuntu18.04.tar.gz) | v0.13 | January 21, 2021  |
+| [Ubuntu 18.04 (CUDA 10.1)](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.13/swift-tensorflow-RELEASE-0.13-cuda10.1-cudnn7-ubuntu18.04.tar.gz) | v0.13 | January 21, 2021  |
+| [Windows](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.12/rc2/swift-tensorflow-RELEASE-0.12-windows.exe) | v0.12 | November 12, 2020  |
+
+<details>
+  <summary>Older Packages</summary>
+
 [Release notes for v0.12.0](https://docs.google.com/document/d/1lP6euYS7k5zZAt1towGFpaopZ_PCzsMpFjBbA1Leakg)
 
 | Download | Version | Date |
 |----------|---------|------|
-| [Xcode 12.2 Beta 3](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.12/rc2/swift-tensorflow-RELEASE-0.12-osx.pkg) | v0.12 | November 17, 2020 |
+| [Xcode 12.3](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.12/rc2/swift-tensorflow-RELEASE-0.12-osx.pkg) | v0.12 | November 17, 2020 |
 | [Ubuntu 20.04 (CPU Only)](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.12/rc2/swift-tensorflow-RELEASE-0.12-ubuntu20.04.tar.gz) | v0.12 | November 12, 2020 |
 | [Ubuntu 18.04 (CPU Only)](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.12/rc2/swift-tensorflow-RELEASE-0.12-ubuntu18.04.tar.gz) | v0.12 | November 12, 2020  |
 | [Ubuntu 18.04 (CUDA 11.0)](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.12/rc2/swift-tensorflow-RELEASE-0.12-cuda11.0-cudnn8-ubuntu18.04.tar.gz) | v0.12 | November 12, 2020  |
@@ -23,8 +38,6 @@ To install Swift for TensorFlow, download one of the packages below and follow t
 | [Ubuntu 18.04 (CUDA 10.1)](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.12/rc2/swift-tensorflow-RELEASE-0.12-cuda10.1-cudnn7-ubuntu18.04.tar.gz) | v0.12 | November 12, 2020  |
 | [Windows](https://storage.googleapis.com/swift-tensorflow-artifacts/releases/v0.12/rc2/swift-tensorflow-RELEASE-0.12-windows.exe) | v0.12 | November 12, 2020  |
 
-<details>
-  <summary>Older Packages</summary>
 
 [Release notes for v0.11.0](https://docs.google.com/document/d/1aTP88ANmJoxpxHeMIdz7CskqSuDHIg3mVELjm0iBXXQ/edit?usp=sharing)
 


### PR DESCRIPTION
This updates the releases with 0.13 toolchains for Ubuntu, and introduces release notes for this version.